### PR TITLE
refactor(cmd/influxqld): rename transpilerd to influxqld

### DIFF
--- a/cmd/influxqld/README.md
+++ b/cmd/influxqld/README.md
@@ -1,10 +1,10 @@
-# Transpilerd
+# InfluxQLD
 
-Transpilerd is daemon that can execute queries from various source languages by transpiling the query and tranforming the result.
+InfluxQLD is a daemon that can execute queries from InfluxQL using the 2.0 query engine.
 
 # Exposed Metrics
 
-The `transpilerd` process exposes a Prometheus endpoint on port `8098` by default.
+The `influxqld` process exposes an InfluxQL endpoint on port `8098` by default.
 
 The following metrics are exposed:
 


### PR DESCRIPTION
This clarifies the transpiler to only function for influxql and to only
implement the 1.x interface for that specific language. This simplifies
the handler and will allow us to prevent non-1.x things from being
included. It also clearly delineates the responsibility of influxqld as
a compatibility layer rather than a new tool.