### PR TITLE
[WIP] add authorization for users service

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -59,9 +59,9 @@ type resource string
 
 const (
 	// UserResource represents the user resource actions can apply to.
-	UserResource = resource("user")
+	UserResource resource = "user"
 	// OrganizationResource represents the org resource actions can apply to.
-	OrganizationResource = resource("org")
+	OrganizationResource resource = "org"
 )
 
 // BucketResource constructs a bucket resource.
@@ -80,19 +80,29 @@ func (p Permission) String() string {
 }
 
 var (
-	// CreateUser is a permission for creating users.
+	// CreateUserPermission is a permission for creating users.
 	CreateUserPermission = Permission{
 		Action:   CreateAction,
 		Resource: UserResource,
 	}
-	// DeleteUser is a permission for deleting users.
+	// WriteUserPermission is a permission for writing users.
+	WriteUserPermission = Permission{
+		Action:   WriteAction,
+		Resource: UserResource,
+	}
+	// DeleteUserPermission is a permission for deleting users.
 	DeleteUserPermission = Permission{
 		Action:   DeleteAction,
 		Resource: UserResource,
 	}
+	// ReadUserPermission is a permission for reading users.
+	ReadUserPermission = Permission{
+		Action:   ReadAction,
+		Resource: UserResource,
+	}
 )
 
-// ReadBucket constructs a permission for reading a bucket.
+// ReadBucketPermission constructs a permission for reading a bucket.
 func ReadBucketPermission(id ID) Permission {
 	return Permission{
 		Action:   ReadAction,
@@ -100,7 +110,7 @@ func ReadBucketPermission(id ID) Permission {
 	}
 }
 
-// WriteBucket constructs a permission for writing to a bucket.
+// WriteBucketPermission constructs a permission for writing to a bucket.
 func WriteBucketPermission(id ID) Permission {
 	return Permission{
 		Action:   WriteAction,

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -29,7 +29,7 @@ func NewUserHandler() *UserHandler {
 
 	h.HandlerFunc("POST", "/v1/users", withAuth(h.handlePostUser, platform.CreateUserPermission))
 	h.HandlerFunc("GET", "/v1/users", withAuth(h.handleGetUsers, platform.ReadUserPermission))
-	h.HandlerFunc("GET", "/v1/users/:id", withAuth(h.handleGetUsers, platform.ReadUserPermission))
+	h.HandlerFunc("GET", "/v1/users/:id", withAuth(h.handleGetUser, platform.ReadUserPermission))
 	h.HandlerFunc("PATCH", "/v1/users/:id", withAuth(h.handlePatchUser, platform.WriteUserPermission))
 	h.HandlerFunc("DELETE", "/v1/users/:id", withAuth(h.handleDeleteUser, platform.DeleteUserPermission))
 	return h


### PR DESCRIPTION
Adds permission checks to HTTP users service.

This isn't ready to merge yet. The other two pieces of the puzzle are:
* scoping permissions by organization (a user should not be able to read or write to users outside of their organization)
* In `http/platform_handler.go` we take the token from our auth header and set that to context, but authorizations for said token are never set to the context. Should this be done in each individual http service?