### PR TITLE
feat(cmd/transpilerd): update transpilerd to use http server package

### DIFF
--- a/cmd/transpilerd/main.go
+++ b/cmd/transpilerd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	nethttp "net/http"
 	"os"
 	"strings"
 
@@ -61,7 +60,9 @@ func transpileF(cmd *cobra.Command, args []string) {
 	handler.Handler = transpileHandler
 
 	log.Printf("Starting transpilerd on %s\n", flags.bindAddr)
-	log.Fatal(nethttp.ListenAndServe(flags.bindAddr, handler))
+	if err := http.ListenAndServe(flags.bindAddr, handler, nil); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func main() {


### PR DESCRIPTION
The http package now contains a server that handles signals and proper
shutdown procedure. It has now been updated to use it.

The http package has also added a `ListenAndServe` convenience function
that is similar to the `net/http` one, but also takes in a logger and
will automatically use the most common signals when running an http
server.