### PR TITLE
feat(http): add a /ping endpoint to the transpiler

### DIFF
--- a/http/transpiler_handler.go
+++ b/http/transpiler_handler.go
@@ -28,8 +28,16 @@ func NewTranspilerQueryHandler(orgID platform.ID) *TranspilerQueryHandler {
 		Logger: zap.NewNop(),
 	}
 
+	h.HandlerFunc("GET", "/ping", h.servePing)
 	h.HandlerFunc("POST", "/query", h.handlePostQuery)
 	return h
+}
+
+// servePing returns a simple response to let the client know the server is running.
+// This handler is only available for 1.x compatibility and is not part of the 2.0 platform.
+func (h *TranspilerQueryHandler) servePing(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handlePostInfluxQL handles query requests mirroring the 1.x influxdb API.


### PR DESCRIPTION
This will match the /ping endpoint from the influxdb 1.x httpd service.
This endpoint is used by many of the clients that use the query service
and it will also be helpful for testing that the transpiler service is
up and working.

In the future, we will add the appropriate health endpoint that is
standard for 2.0. But, for the best compatibility, we have to return
something viable for 1.x clients.

Fixes #123.