### PR TITLE
feat(http): add a utility function for reading http errors

### DIFF
--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -249,8 +249,8 @@ func (s *AuthorizationService) FindAuthorizationByID(ctx context.Context, id pla
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, err
 	}
 
 	var b platform.Authorization
@@ -303,8 +303,8 @@ func (s *AuthorizationService) FindAuthorizations(ctx context.Context, filter pl
 		return nil, 0, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, 0, err
 	}
 
 	var bs []*platform.Authorization
@@ -347,9 +347,9 @@ func (s *AuthorizationService) CreateAuthorization(ctx context.Context, a *platf
 		return err
 	}
 
-	// TODO: this should really check the error from the headers
-	if resp.StatusCode != http.StatusCreated {
-		return errors.New(resp.Header.Get("X-Influx-Error"))
+	// TODO(jsternberg): Should this check for a 201 explicitly?
+	if err := CheckError(resp); err != nil {
+		return err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(a); err != nil {
@@ -377,13 +377,7 @@ func (s *AuthorizationService) DeleteAuthorization(ctx context.Context, id platf
 	if err != nil {
 		return err
 	}
-
-	switch resp.StatusCode {
-	case http.StatusNoContent, http.StatusAccepted:
-		return nil
-	}
-
-	return errors.New(resp.Header.Get("X-Influx-Error"))
+	return CheckError(resp)
 }
 
 func authorizationIDPath(id platform.ID) string {

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -289,8 +289,8 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*pl
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, err
 	}
 
 	var b platform.Bucket
@@ -352,8 +352,8 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketF
 		return nil, 0, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, 0, err
 	}
 
 	var bs []*platform.Bucket
@@ -392,8 +392,9 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) er
 		return err
 	}
 
-	if resp.StatusCode != http.StatusCreated {
-		return errors.New(resp.Header.Get("X-Influx-Error"))
+	// TODO(jsternberg): Should this check for a 201 explicitly?
+	if err := CheckError(resp); err != nil {
+		return err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(b); err != nil {
@@ -431,8 +432,8 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd pl
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, err
 	}
 
 	var b platform.Bucket
@@ -462,13 +463,7 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id platform.ID) error 
 	if err != nil {
 		return err
 	}
-
-	switch resp.StatusCode {
-	case http.StatusNoContent, http.StatusAccepted:
-		return nil
-	}
-
-	return errors.New(resp.Header.Get("X-Influx-Error"))
+	return CheckError(resp)
 }
 
 func bucketIDPath(id platform.ID) string {

--- a/http/errors.go
+++ b/http/errors.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+
+	kerrors "github.com/influxdata/platform/kit/errors"
+	"github.com/pkg/errors"
+)
+
+// CheckError reads the http.Response and returns an error if one exists.
+// It will automatically recognize the errors returned by Influx services
+// and decode the error into an internal error type. If the error cannot
+// be determined in that way, it will create a generic error message.
+//
+// If there is no error, then this returns nil.
+func CheckError(resp *http.Response) error {
+	switch resp.StatusCode / 100 {
+	case 4, 5:
+		// We will attempt to parse this error outside of this block.
+	case 2:
+		return nil
+	default:
+		// TODO(jsternberg): Figure out what to do here?
+		return kerrors.InternalErrorf("unexpected status code: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	// Attempt to read the X-Influx-Error header with the message.
+	if errMsg := resp.Header.Get("X-Influx-Error"); errMsg != "" {
+		// Parse the reference number as an integer. If we cannot parse it,
+		// return the error message by itself.
+		ref, err := strconv.Atoi(resp.Header.Get("X-Influx-Reference"))
+		if err != nil {
+			// We cannot parse the reference number so just use internal.
+			ref = kerrors.InternalError
+		}
+		return &kerrors.Error{
+			Reference: ref,
+			Code:      resp.StatusCode,
+			Err:       errMsg,
+		}
+	}
+
+	// There is no influx error so we need to report that we have some kind
+	// of error from somewhere.
+	// TODO(jsternberg): Try to make this more advance by reading the response
+	// and either decoding a possible json message or just reading the text itself.
+	// This might be good enough though.
+	msg := "unknown server error"
+	if resp.StatusCode/100 == 4 {
+		msg = "client error"
+	}
+	return errors.Wrap(errors.New(resp.Status), msg)
+}

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -306,8 +306,8 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter plat
 		return nil, 0, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, 0, err
 	}
 
 	var os []*platform.Organization
@@ -346,9 +346,9 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, o *platfor
 		return err
 	}
 
-	// TODO: this should really check the error from the headers
-	if resp.StatusCode != http.StatusCreated {
-		return errors.New(resp.Header.Get("X-Influx-Error"))
+	// TODO(jsternberg): Should this check for a 201 explicitly?
+	if err := CheckError(resp); err != nil {
+		return err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(o); err != nil {
@@ -384,8 +384,8 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, id platfor
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, err
 	}
 
 	var o platform.Organization
@@ -414,13 +414,7 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, id platfor
 	if err != nil {
 		return err
 	}
-
-	switch resp.StatusCode {
-	case http.StatusNoContent, http.StatusAccepted:
-		return nil
-	}
-
-	return errors.New(resp.Header.Get("X-Influx-Error"))
+	return CheckError(resp)
 }
 
 func organizationIDPath(id platform.ID) string {

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -273,8 +273,8 @@ func (s *UserService) FindUserByID(ctx context.Context, id platform.ID) (*platfo
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, err
 	}
 
 	var b platform.User
@@ -330,8 +330,8 @@ func (s *UserService) FindUsers(ctx context.Context, filter platform.UserFilter,
 		return nil, 0, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, 0, err
 	}
 
 	var bs []*platform.User
@@ -373,8 +373,9 @@ func (s *UserService) CreateUser(ctx context.Context, u *platform.User) error {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusCreated {
-		return errors.New(resp.Header.Get("X-Influx-Error"))
+	// TODO(jsternberg): Should this check for a 201 explicitly?
+	if err := CheckError(resp); err != nil {
+		return err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(u); err != nil {
@@ -412,8 +413,8 @@ func (s *UserService) UpdateUser(ctx context.Context, id platform.ID, upd platfo
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(resp.Header.Get("X-Influx-Error"))
+	if err := CheckError(resp); err != nil {
+		return nil, err
 	}
 
 	var u platform.User
@@ -443,12 +444,7 @@ func (s *UserService) DeleteUser(ctx context.Context, id platform.ID) error {
 	if err != nil {
 		return err
 	}
-
-	if resp.StatusCode != http.StatusAccepted {
-		return errors.New(resp.Header.Get("X-Influx-Error"))
-	}
-
-	return nil
+	return CheckError(resp)
 }
 
 func userIDPath(id platform.ID) string {

--- a/kit/errors/http.go
+++ b/kit/errors/http.go
@@ -24,7 +24,7 @@ func EncodeHTTP(ctx context.Context, err error, w http.ResponseWriter) {
 	}
 	e.SetCode()
 
-	w.Header().Set("X-Influx-Error", e.Error())
+	w.Header().Set("X-Influx-Error", e.Err)
 	w.Header().Set("X-Influx-Reference", fmt.Sprintf("%d", e.Reference))
 	w.WriteHeader(e.Code)
 }


### PR DESCRIPTION
This also modifies the http error encoder to not include the reference
code in the `X-Influx-Error` message so it only includes the text.