### PR TITLE
fix(query): Add Empty to blocks

### DIFF
--- a/query/csv/result_test.go
+++ b/query/csv/result_test.go
@@ -65,9 +65,7 @@ var symetricalTestCases = []TestCase{
 		}}},
 	},
 	{
-		name: "single empty table",
-		// The encoder cannot encode a empty tables, it needs to know ahead of time if it is empty
-		skip:          true,
+		name:          "single empty table",
 		encoderConfig: csv.DefaultEncoderConfig(),
 		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #partition,false,false,true,true,false,true,true,false
@@ -312,9 +310,7 @@ var symetricalTestCases = []TestCase{
 		}},
 	},
 	{
-		name: "multiple tables with one empty",
-		// The encoder cannot encode a empty tables, it needs to know ahead of time if it is empty
-		skip:          true,
+		name:          "multiple tables with one empty",
 		encoderConfig: csv.DefaultEncoderConfig(),
 		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #partition,false,false,true,true,false,true,true,false
@@ -327,7 +323,7 @@ var symetricalTestCases = []TestCase{
 
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #partition,false,false,true,true,false,true,true,false
-#default,_result,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+#default,_result,2,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
 ,result,table,_start,_stop,_time,_measurement,host,_value
 `),
 		result: &executetest.Result{Blks: []*executetest.Block{

--- a/query/docs/SPEC.md
+++ b/query/docs/SPEC.md
@@ -1480,7 +1480,7 @@ The possible data types are:
 | Datatype     | IFQL type | Description                                                                          |
 | --------     | --------- | -----------                                                                          |
 | boolean      | bool      | a truth value, one of "true" or "false"                                              |
-| unsignedlong | uint      | an unsigned 64-bit integer                                                           |
+| unsignedLong | uint      | an unsigned 64-bit integer                                                           |
 | long         | int       | a signed 64-bit integer                                                              |
 | double       | float     | a IEEE-754 64-bit floating-point number                                              |
 | string       | string    | a UTF-8 encoded string                                                               |

--- a/query/execute/block.go
+++ b/query/execute/block.go
@@ -776,6 +776,9 @@ func (b *ColListBlock) Key() query.PartitionKey {
 func (b *ColListBlock) Cols() []query.ColMeta {
 	return b.colMeta
 }
+func (b *ColListBlock) Empty() bool {
+	return b.nrows == 0
+}
 func (b *ColListBlock) NRows() int {
 	return b.nrows
 }

--- a/query/execute/executetest/block.go
+++ b/query/execute/executetest/block.go
@@ -48,6 +48,10 @@ func (b *Block) Normalize() {
 	}
 }
 
+func (b *Block) Empty() bool {
+	return len(b.Data) == 0
+}
+
 func (b *Block) RefCount(n int) {}
 
 func (b *Block) Cols() []query.ColMeta {

--- a/query/result.go
+++ b/query/result.go
@@ -27,6 +27,9 @@ type Block interface {
 	// RefCount modifies the reference count on the block by n.
 	// When the RefCount goes to zero, the block is freed.
 	RefCount(n int)
+
+	// Empty returns whether the block contains no records.
+	Empty() bool
 }
 
 type ColMeta struct {


### PR DESCRIPTION
Using Empty the csv encoder can now correctly encode empty blocks.