### PR TITLE
feat(query/influxql): use yield name to specify the statement id

### DIFF
--- a/query/influxql/README.md
+++ b/query/influxql/README.md
@@ -81,3 +81,12 @@ If there are any variables that are fields and are not the primary field being s
         |> map(fn: (r) => {_value: r.val1})
 
 The created cursor is then used to map the results.
+
+## Yielding Results
+
+Each result is yielded with the statement id as the name.
+
+    > SELECT max(usage_user) FROM telegraf..cpu
+    ... |> yield(name: "0")
+
+Successive commands will increment the name used by yield so that results can be ordered correctly when encoding the result.

--- a/query/influxql/result.go
+++ b/query/influxql/result.go
@@ -29,14 +29,14 @@ func (e *MultiResultEncoder) Encode(w io.Writer, results query.ResultIterator) e
 
 	for results.More() {
 		name, r := results.Next()
+		id, err := strconv.Atoi(name)
+		if err != nil {
+			return fmt.Errorf("unable to parse statement id from result name: %s", err)
+		}
 
 		blocks := r.Blocks()
-		nameInt, err := strconv.Atoi(name)
-		if err != nil {
-			return fmt.Errorf("error converting result name to integer: %s", name)
-		}
-		result := Result{StatementID: nameInt}
 
+		result := Result{StatementID: id}
 		err = blocks.Do(func(b query.Block) error {
 			r := NewRow()
 

--- a/query/influxql/transpiler.go
+++ b/query/influxql/transpiler.go
@@ -157,9 +157,13 @@ func (t *transpilerState) Transpile(ctx context.Context) (*query.Spec, error) {
 	}
 
 	// Map each of the fields in the symbol table to their appropriate column.
-	if _, err := t.mapFields(mapIn, symbolTable); err != nil {
+	mapId, err := t.mapFields(mapIn, symbolTable)
+	if err != nil {
 		return nil, err
 	}
+
+	// Yield the statement to the name zero.
+	t.op("yield", &functions.YieldOpSpec{Name: "0"}, mapId)
 	return t.spec, nil
 }
 

--- a/query/influxql/transpiler_test.go
+++ b/query/influxql/transpiler_test.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/platform/query/ast"
-	"github.com/influxdata/platform/query/functions"
-	"github.com/influxdata/platform/query"
-	"github.com/influxdata/platform/query/execute"
-	"github.com/influxdata/platform/query/semantic"
 	influxqllib "github.com/influxdata/influxql"
+	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/ast"
+	"github.com/influxdata/platform/query/execute"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/influxql"
+	"github.com/influxdata/platform/query/semantic"
 )
 
 var passThroughProperties = []*semantic.Property{}
@@ -113,6 +113,12 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
+					{
+						ID: "yield0",
+						Spec: &functions.YieldOpSpec{
+							Name: "0",
+						},
+					},
 				},
 				Edges: []query.Edge{
 					{Parent: "from0", Child: "range0"},
@@ -120,6 +126,7 @@ func TestTranspiler(t *testing.T) {
 					{Parent: "filter0", Child: "group0"},
 					{Parent: "group0", Child: "mean0"},
 					{Parent: "mean0", Child: "map0"},
+					{Parent: "map0", Child: "yield0"},
 				},
 			},
 		},
@@ -198,11 +205,18 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
+					{
+						ID: "yield0",
+						Spec: &functions.YieldOpSpec{
+							Name: "0",
+						},
+					},
 				},
 				Edges: []query.Edge{
 					{Parent: "from0", Child: "range0"},
 					{Parent: "range0", Child: "filter0"},
 					{Parent: "filter0", Child: "map0"},
+					{Parent: "map0", Child: "yield0"},
 				},
 			},
 		},
@@ -405,6 +419,12 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
+					{
+						ID: "yield0",
+						Spec: &functions.YieldOpSpec{
+							Name: "0",
+						},
+					},
 				},
 				Edges: []query.Edge{
 					{Parent: "from0", Child: "range0"},
@@ -418,6 +438,7 @@ func TestTranspiler(t *testing.T) {
 					{Parent: "mean0", Child: "join0"},
 					{Parent: "max0", Child: "join0"},
 					{Parent: "join0", Child: "map0"},
+					{Parent: "map0", Child: "yield0"},
 				},
 			},
 		},
@@ -592,6 +613,12 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
+					{
+						ID: "yield0",
+						Spec: &functions.YieldOpSpec{
+							Name: "0",
+						},
+					},
 				},
 				Edges: []query.Edge{
 					{Parent: "from0", Child: "range0"},
@@ -601,6 +628,7 @@ func TestTranspiler(t *testing.T) {
 					{Parent: "filter0", Child: "join0"},
 					{Parent: "filter1", Child: "join0"},
 					{Parent: "join0", Child: "map0"},
+					{Parent: "map0", Child: "yield0"},
 				},
 			},
 		},


### PR DESCRIPTION
The transpiler will now yield each statement using the statement id so
the result encoder can properly order the results and encode the
statement id. This behavior is now in the transpiler spec.