### PR TITLE
fix(http): keep the http response body open until the result has been read

### DIFF
--- a/http/query_service.go
+++ b/http/query_service.go
@@ -156,7 +156,6 @@ func (s *QueryService) Query(ctx context.Context, orgID platform.ID, query *ifql
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	return s.processResponse(resp)
 }
 
@@ -182,7 +181,6 @@ func (s *QueryService) QueryWithCompile(ctx context.Context, orgID platform.ID, 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	return s.processResponse(resp)
 }
 

--- a/query/csv/result_test.go
+++ b/query/csv/result_test.go
@@ -506,7 +506,7 @@ func TestResultDecoder(t *testing.T) {
 
 func TestResultEncoder(t *testing.T) {
 	testCases := []TestCase{
-	// Add tests cases specific to encoding here
+		// Add tests cases specific to encoding here
 	}
 	testCases = append(testCases, symetricalTestCases...)
 	for _, tc := range testCases {

--- a/query/influxql/result.go
+++ b/query/influxql/result.go
@@ -139,7 +139,7 @@ func (e *MultiResultEncoder) Encode(w io.Writer, results query.ResultIterator) e
 		resp.Results = append(resp.Results, result)
 	}
 
-	if err := results.Err(); err != nil {
+	if err := results.Err(); err != nil && resp.Err == "" {
 		resp.error(err)
 	}
 

--- a/query/query.go
+++ b/query/query.go
@@ -198,6 +198,7 @@ func (r *SliceResultIterator) Next() Result {
 }
 
 func (r *SliceResultIterator) Cancel() {
+	r.results = nil
 }
 
 func (r *SliceResultIterator) Err() error {

--- a/query/result.go
+++ b/query/result.go
@@ -124,7 +124,7 @@ type ResultEncoder interface {
 // MultiResultDecoder can decode multiple results from a reader.
 type MultiResultDecoder interface {
 	// Decode decodes multiple results from r.
-	Decode(r io.Reader) (ResultIterator, error)
+	Decode(r io.ReadCloser) (ResultIterator, error)
 }
 
 // MultiResultEncoder can encode multiple results into a writer.


### PR DESCRIPTION
This modifies the `MultiResultDecoder` interface to accept an
`io.ReadCloser` so the `ResultIterator` can close the `io.Reader`
instead of doing it through a defer call. It then makes it so the
`Cancel()` method will close the reader or the reader will be
automatically closed when `More()` returns false.