### PR TITLE
feat(errors): add error lib

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -6,10 +6,10 @@ import (
 )
 
 // ErrDashboardNotFound is the error for a missing dashboard.
-const ErrDashboardNotFound = Error("dashboard not found")
+const ErrDashboardNotFound = ChronografError("dashboard not found")
 
 // ErrCellNotFound is the error for a missing cell.
-const ErrCellNotFound = Error("cell not found")
+const ErrCellNotFound = ChronografError("cell not found")
 
 // DashboardService represents a service for managing dashboard data.
 type DashboardService interface {

--- a/error.go
+++ b/error.go
@@ -1,9 +1,9 @@
 package platform
 
-// Error is a domain error encountered while processing chronograf requests.
-type Error string
+// ChronografError is a domain error encountered while processing chronograf requests.
+type ChronografError string
 
-// Error returns the string of an error.
-func (e Error) Error() string {
+// ChronografError returns the string of an error.
+func (e ChronografError) Error() string {
 	return string(e)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,151 @@
+package platform
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Some error code constant, ideally we want define common platform codes here
+// projects on use platform's error, should have their own central place like this.
+const (
+	EInternal   = "internal error"
+	ENotFound   = "not found"
+	EConflict   = "conflict" // action cannot be performed
+	EInvalid    = "invalid"  // validation failed
+	EEmptyValue = "empty value"
+)
+
+// Error is the error struct of platform.
+//
+// Errors may have error codes, human-readable messages,
+// and a logical stack trace.
+//
+// The Code targets automated handlers so that recovery can occur.
+// Msg is used by the system operator to help diagnose and fix the problem.
+// Op and Err chain errors together in a logical stack trace to
+// further help operators.
+//
+// To create a simple error,
+//     &Error{
+//         Code:ENotFound,
+//     }
+// To show where the error happens, add Op.
+//     &Error{
+//         Code: ENotFound,
+//         Op: "bolt.FindUserByID"
+//     }
+// To show an error with a unpredictable value, add the value in Msg.
+//     &Error{
+//        Code: EConflict,
+//        Message: fmt.Sprintf("organization with name %s already exist", aName),
+//     }
+// To show an error wrapped with another error.
+//     &Error{
+//         Code:EInternal,
+//         Err: err,
+//     }.
+type Error struct {
+	Code string `json:"code"`          // Code is the machine-readable error code.
+	Msg  string `json:"msg,omitempty"` // Msg is a human-readable message.
+	Op   string `json:"op,omitempty"`  // Op describes the logical code operation during error.
+	Err  error  `json:"err,omitempty"` // Err is a stack of additional errors.
+}
+
+// Error implement the error interface by outputing the Code and Err.
+func (e Error) Error() string {
+	var b strings.Builder
+
+	// Print the current operation in our stack, if any.
+	if e.Op != "" {
+		fmt.Fprintf(&b, "%s: ", e.Op)
+	}
+
+	// If wrapping an error, print its Error() message.
+	// Otherwise print the error code & message.
+	if e.Err != nil {
+		b.WriteString(e.Err.Error())
+	} else {
+		if e.Code != "" {
+			fmt.Fprintf(&b, "<%s>", e.Code)
+			if e.Msg != "" {
+				b.WriteString(" ")
+			}
+		}
+		b.WriteString(e.Msg)
+	}
+	return b.String()
+}
+
+// ErrorCode returns the code of the root error, if available; otherwise returns EINTERNAL.
+func ErrorCode(err error) string {
+	if err == nil {
+		return ""
+	} else if e, ok := err.(*Error); ok && e.Code != "" {
+		return e.Code
+	}
+	return EInternal
+}
+
+// ErrorMessage returns the human-readable message of the error, if available.
+// Otherwise returns a generic error message.
+func ErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	} else if e, ok := err.(*Error); ok && e.Msg != "" {
+		return e.Msg
+	} else if ok && e.Err != nil {
+		return ErrorMessage(e.Err)
+	}
+	return "An internal error has occurred."
+}
+
+// errEncode an JSON encoding helper that is needed to handle the recursive stack of errors.
+type errEncode struct {
+	Code string `json:"code"`          // Code is the machine-readable error code.
+	Msg  string `json:"msg,omitempty"` // Msg is a human-readable message.
+	Op   string `json:"op,omitempty"`  // Op describes the logical code operation during error.
+	Err  string `json:"err,omitempty"` // Err is a stack of additional errors.
+}
+
+// MarshalJSON recursively marshals the stack of Err.
+func (e *Error) MarshalJSON() (result []byte, err error) {
+	ee := errEncode{
+		Code: e.Code,
+		Msg:  e.Msg,
+		Op:   e.Op,
+	}
+	if e.Err != nil {
+		if _, ok := e.Err.(*Error); ok {
+			b, err := e.Err.(*Error).MarshalJSON()
+			if err != nil {
+				return result, err
+			}
+			ee.Err = string(b)
+		} else {
+			ee.Err = e.Err.Error()
+		}
+	}
+	return json.Marshal(ee)
+}
+
+// UnmarshalJSON recursively unmarshals the error stack.
+func (e *Error) UnmarshalJSON(b []byte) (err error) {
+	ee := new(errEncode)
+	err = json.Unmarshal(b, ee)
+	e.Code = ee.Code
+	e.Msg = ee.Msg
+	e.Op = ee.Op
+	if ee.Err != "" {
+		var innerErr error
+		innerResult := new(Error)
+		innerErr = innerResult.UnmarshalJSON([]byte(ee.Err))
+		if innerErr != nil {
+			e.Err = errors.New(ee.Err)
+			return err
+		}
+		e.Err = innerResult
+	}
+	return err
+}

--- a/errors.md
+++ b/errors.md
@@ -1,0 +1,86 @@
+# errors.go
+
+This is inspired from Ben Johnson's blog post [Failure is Your Domain](https://middlemost.com/failure-is-your-domain/)
+
+## The Error struct 
+
+```go
+
+    type Error struct {
+        Code string
+        Msg string
+        Op string
+        Err error
+    }  
+```
+
+    * Code is the machine readable code, for reference purpose. All the codes should be a constant string. For example. `const ENotFound = "source not found"`.
+
+    * Msg is the human readable message for end user. For example, `Your credit card is declined.`
+
+    * Op is the logical Operator, should be a constant defined inside the function. For example: "bolt.UserCreate".
+
+    * Err is the embed error. You may embed either a third party error or and platform.Error.
+
+## Use Case Example
+
+We inplement the following interface
+
+```go
+
+    type OrganizationService interface {
+        FindOrganizationByID(ctx context.Context, id ID) (*Organization, error)
+    }
+
+    func (c *Client)FindOrganizationByID(ctx context.Context, id platform.ID) (*platform.Organization, error) {
+        var o *platform.Organization
+        const op = "bolt.FindOrganizationByID"
+        err := c.db.View(func(tx *bolt.Tx) error {
+            org, err := c.findOrganizationByID(ctx, tx, id)
+            if err != nil {
+                return err
+            }
+            o = org
+            return nil
+        })
+
+        if err != nil {
+            return nil, &platform.Error{
+                Code: platform.ENotFound,
+                Op: op,
+                Err: err,
+            }
+        }
+        return o, nil
+    }
+```
+
+To check the error code
+
+```go
+
+    if platform.ErrorCode(err) == platform.ENotFound {
+        ...
+    }
+```
+
+To serialize the error
+
+```go
+
+    b, err := json.Marshal(err)
+```
+
+To deserialize the error
+
+```go
+
+    e := new(platform.Error)
+    err := json.Unmarshal(b, e)
+```
+
+
+
+
+
+

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,206 @@
+package platform
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+const EFailedToGetStorageHost = "failed to get the storage host"
+
+func TestErrorMsg(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		msg  string
+	}{
+		{
+			name: "simple error",
+			err:  &Error{Code: ENotFound},
+			msg:  "<not found>",
+		},
+		{
+			name: "with op",
+			err: &Error{
+				Code: ENotFound,
+				Op:   "bolt.FindAuthorizationByID",
+			},
+			msg: "bolt.FindAuthorizationByID: <not found>",
+		},
+		{
+			name: "with op and value",
+			err: &Error{
+				Code: ENotFound,
+				Op:   "bolt.FindAuthorizationByID",
+				Msg:  fmt.Sprintf("with ID %d", 323),
+			},
+			msg: "bolt.FindAuthorizationByID: <not found> with ID 323",
+		},
+		{
+			name: "with a third party error",
+			err: &Error{
+				Code: EFailedToGetStorageHost,
+				Op:   "cmd/fluxd.injectDeps",
+				Err:  errors.New("empty value"),
+			},
+			msg: "cmd/fluxd.injectDeps: empty value",
+		},
+		{
+			name: "with a internal error",
+			err: &Error{
+				Code: EFailedToGetStorageHost,
+				Op:   "cmd/fluxd.injectDeps",
+				Err:  &Error{Code: EEmptyValue, Op: "cmd/fluxd.getStrList"},
+			},
+			msg: "cmd/fluxd.injectDeps: cmd/fluxd.getStrList: <empty value>",
+		},
+	}
+	for _, c := range cases {
+		if c.msg != c.err.Error() {
+			t.Fatalf("%s failed, want %s, got %s", c.name, c.msg, c.err.Error())
+		}
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error",
+		},
+		{
+			name: "simple error",
+			err:  &Error{Msg: "simple error"},
+			want: "simple error",
+		},
+		{
+			name: "embeded error",
+			err:  &Error{Err: &Error{Msg: "embeded error"}},
+			want: "embeded error",
+		},
+		{
+			name: "default error",
+			err:  errors.New("s"),
+			want: "An internal error has occurred.",
+		},
+	}
+	for _, c := range cases {
+		if result := ErrorMessage(c.err); c.want != result {
+			t.Fatalf("%s failed, want %s, got %s", c.name, c.want, result)
+		}
+	}
+}
+func TestErrorCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error",
+		},
+		{
+			name: "simple error",
+			err:  &Error{Code: ENotFound},
+			want: ENotFound,
+		},
+		{
+			name: "embeded error",
+			err:  &Error{Code: ENotFound, Err: &Error{Code: EInvalid}},
+			want: ENotFound,
+		},
+		{
+			name: "default error",
+			err:  errors.New("s"),
+			want: EInternal,
+		},
+	}
+	for _, c := range cases {
+		if result := ErrorCode(c.err); c.want != result {
+			t.Fatalf("%s failed, want %s, got %s", c.name, c.want, result)
+		}
+	}
+}
+
+func TestJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *Error
+		json string
+	}{
+		{
+			name: "simple error",
+			err:  &Error{Code: ENotFound},
+		},
+		{
+			name: "with op",
+			err: &Error{
+				Code: ENotFound,
+				Op:   "bolt.FindAuthorizationByID",
+			},
+		},
+		{
+			name: "with op and value",
+			err: &Error{
+				Code: ENotFound,
+				Op:   "bolt.FindAuthorizationByID",
+				Msg:  fmt.Sprintf("with ID %d", 323),
+			},
+		},
+		{
+			name: "with a third party error",
+			err: &Error{
+				Code: EFailedToGetStorageHost,
+				Op:   "cmd/fluxd.injectDeps",
+				Err:  errors.New("empty value"),
+			},
+		},
+		{
+			name: "with a internal error",
+			err: &Error{
+				Code: EFailedToGetStorageHost,
+				Op:   "cmd/fluxd.injectDeps",
+				Err:  &Error{Code: EEmptyValue, Op: "cmd/fluxd.getStrList"},
+			},
+		},
+	}
+	for _, c := range cases {
+		result, err := json.Marshal(c.err)
+		// encode testing
+		if err != nil {
+			t.Fatalf("%s encode failed, want err: %v, should be nil", c.name, err)
+		}
+		// decode testing
+		got := new(Error)
+		err = json.Unmarshal([]byte(result), got)
+		if err != nil {
+			t.Fatalf("%s decode failed, want err: %v, should be nil", c.name, err)
+		}
+		decodeEqual(t, c.err, got, "decode: "+c.name)
+	}
+}
+
+func decodeEqual(t *testing.T, want, result *Error, caseName string) {
+	if want.Code != result.Code {
+		t.Fatalf("%s code failed, want %s, got %s", caseName, want.Code, result.Code)
+	}
+	if want.Op != result.Op {
+		t.Fatalf("%s op failed, want %s, got %s", caseName, want.Op, result.Op)
+	}
+	if want.Msg != result.Msg {
+		t.Fatalf("%s msg failed, want %s, got %s", caseName, want.Msg, result.Msg)
+	}
+	if want.Err != nil {
+		if _, ok := want.Err.(*Error); ok {
+			decodeEqual(t, want.Err.(*Error), result.Err.(*Error), caseName)
+		} else {
+			if want.Err.Error() != result.Err.Error() {
+				t.Fatalf("%s Err failed, want %s, got %s", caseName, want.Err.Error(), result.Err.Error())
+			}
+		}
+	}
+}

--- a/source.go
+++ b/source.go
@@ -3,7 +3,7 @@ package platform
 import "context"
 
 const (
-	ErrSourceNotFound = Error("source not found")
+	ErrSourceNotFound = ChronografError("source not found")
 )
 
 // SourceType is a string for types of sources.

--- a/view.go
+++ b/view.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ErrViewNotFound is the error for a missing View.
-const ErrViewNotFound = Error("View not found")
+const ErrViewNotFound = ChronografError("View not found")
 
 // ViewService represents a service for managing View data.
 type ViewService interface {


### PR DESCRIPTION
https://github.com/influxdata/idpe/issues/488

This is a global errors library. Ideally, we could make all of our generated errors have type and location, 
and wrap all the third party errors with references.

 Due the complexity of our current code base. We decide to separate this project to small PRs. After the library been pushed. We could use this lib for all the new errors, then gradually update our existing code structure.
- [x] Add the library
- [ ] Update the http and idp services, make sure they all return the typed error
- [ ] Update end user services
- [ ] Maybe add https://github.com/kisielk/errcheck to CI 