### PR TITLE
fix(query/influxql): add group spec back to the transpiler

### DIFF
--- a/query/influxql/transpiler.go
+++ b/query/influxql/transpiler.go
@@ -178,12 +178,9 @@ func (t *transpilerState) createIteratorSpec(expr influxql.Expr) (query.Operatio
 		}
 
 		// TODO(jsternberg): Handle group by tags and the windowing function.
-		//group := t.op("group", &functions.GroupOpSpec{
-		//	By: []string{"_measurement"},
-		//}, ref)
-		// TODO(jsternberg): The group spec doesn't seem to be working at the
-		// moment so just ignore this temporarily and fix it in a future commit.
-		group := ref
+		group := t.op("group", &functions.GroupOpSpec{
+			By: []string{"_measurement"},
+		}, ref)
 
 		switch expr.Name {
 		case "mean":

--- a/query/influxql/transpiler_test.go
+++ b/query/influxql/transpiler_test.go
@@ -78,12 +78,12 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
-					//{
-					//	ID: "group0",
-					//	Spec: &functions.GroupOpSpec{
-					//		By: []string{"_measurement"},
-					//	},
-					//},
+					{
+						ID: "group0",
+						Spec: &functions.GroupOpSpec{
+							By: []string{"_measurement"},
+						},
+					},
 					{
 						ID: "mean0",
 						Spec: &functions.MeanOpSpec{
@@ -145,8 +145,8 @@ func TestTranspiler(t *testing.T) {
 				Edges: []query.Edge{
 					{Parent: "from0", Child: "range0"},
 					{Parent: "range0", Child: "filter0"},
-					//{Parent: "filter0", Child: "group0"},
-					{Parent: "filter0", Child: "mean0"},
+					{Parent: "filter0", Child: "group0"},
+					{Parent: "group0", Child: "mean0"},
 					{Parent: "mean0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
@@ -316,12 +316,12 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
-					//{
-					//	ID: "group0",
-					//	Spec: &functions.GroupOpSpec{
-					//		By: []string{"_measurement"},
-					//	},
-					//},
+					{
+						ID: "group0",
+						Spec: &functions.GroupOpSpec{
+							By: []string{"_measurement"},
+						},
+					},
 					{
 						ID: "mean0",
 						Spec: &functions.MeanOpSpec{
@@ -382,12 +382,12 @@ func TestTranspiler(t *testing.T) {
 							},
 						},
 					},
-					//{
-					//	ID: "group1",
-					//	Spec: &functions.GroupOpSpec{
-					//		By: []string{"_measurement"},
-					//	},
-					//},
+					{
+						ID: "group1",
+						Spec: &functions.GroupOpSpec{
+							By: []string{"_measurement"},
+						},
+					},
 					{
 						ID: "max0",
 						Spec: &functions.MaxOpSpec{
@@ -493,12 +493,12 @@ func TestTranspiler(t *testing.T) {
 				Edges: []query.Edge{
 					{Parent: "from0", Child: "range0"},
 					{Parent: "range0", Child: "filter0"},
-					//{Parent: "filter0", Child: "group0"},
-					{Parent: "filter0", Child: "mean0"},
+					{Parent: "filter0", Child: "group0"},
+					{Parent: "group0", Child: "mean0"},
 					{Parent: "from1", Child: "range1"},
 					{Parent: "range1", Child: "filter1"},
-					//{Parent: "filter1", Child: "group1"},
-					{Parent: "filter1", Child: "max0"},
+					{Parent: "filter1", Child: "group1"},
+					{Parent: "group1", Child: "max0"},
 					{Parent: "mean0", Child: "join0"},
 					{Parent: "max0", Child: "join0"},
 					{Parent: "join0", Child: "map0"},

--- a/query/querytest/test_cases/simple_max.ifql
+++ b/query/querytest/test_cases/simple_max.ifql
@@ -1,6 +1,6 @@
 from(db:"test")
   |> range(start:-5m)
-//|> group(by:["_measurement"])
+  |> group(by:["_measurement"])
   |> max(column: "_value")
   |> map(fn: (r) => {time:r._time, _measurement:r._measurement, max:r._value}, mergeKey:false)
   |> yield(name:"0")


### PR DESCRIPTION
The latest version of influxdb has fixed whatever was wrong with the
group function so this works properly again.