### PR TITLE
chore(query/builtin): Add package to formalize query builtin initialization

### DIFF
--- a/cmd/ifqld/main.go
+++ b/cmd/ifqld/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/http"
 	"github.com/influxdata/platform/query"
+	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/query/control"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/functions"

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/http"
 	"github.com/influxdata/platform/query"
-	"github.com/influxdata/platform/query/control"
+	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/functions/storage"
@@ -119,20 +117,4 @@ func orgID(org string) (ifqlid.ID, error) {
 	var oid ifqlid.ID
 	err := oid.DecodeFromString(org)
 	return oid, err
-}
-
-func getIFQLREPL(storageHosts storage.Reader, buckets platform.BucketService, org ifqlid.ID, verbose bool) (*repl.REPL, error) {
-	conf := control.Config{
-		ExecutorDependencies: make(execute.Dependencies),
-		ConcurrencyQuota:     runtime.NumCPU() * 2,
-		MemoryBytesQuota:     math.MaxInt64,
-		Verbose:              verbose,
-	}
-
-	if err := injectDeps(conf.ExecutorDependencies, storageHosts, buckets); err != nil {
-		return nil, err
-	}
-
-	c := control.New(conf)
-	return repl.New(c, org), nil
 }

--- a/query/builtin/builtin.go
+++ b/query/builtin/builtin.go
@@ -1,0 +1,21 @@
+// This package ensures all packages related to built-ins are imported and initialized.
+// It provides helper functions for constructing various types that depend on the built-ins.
+package query
+
+import (
+	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/complete"
+	_ "github.com/influxdata/platform/query/functions" // Import the built-in functions
+	"github.com/influxdata/platform/query/interpreter"
+)
+
+func init() {
+	query.FinalizeBuiltIns()
+}
+
+// DefaultCompleter creates a completer with builtin scope and declarations
+func DefaultCompleter() complete.Completer {
+	scope, declarations := query.BuiltIns()
+	interpScope := interpreter.NewScopeWithValues(scope)
+	return complete.NewCompleter(interpScope, declarations)
+}

--- a/query/compile.go
+++ b/query/compile.go
@@ -111,29 +111,16 @@ func RegisterBuiltInValue(name string, v values.Value) {
 	builtinScope[name] = v
 }
 
-// FinalizeRegistration must be called to complete registration.
+// FinalizeBuiltIns must be called to complete registration.
 // Future calls to RegisterFunction, RegisterBuiltIn or RegisterBuiltInValue will panic.
-func FinalizeRegistration() {
+func FinalizeBuiltIns() {
 	if finalized {
 		panic("already finalized")
 	}
 	finalized = true
-	//for name, script := range builtins {
-	//	astProg, err := parser.NewAST(script)
-	//	if err != nil {
-	//		panic(errors.Wrapf(err, "failed to parse builtin %q", name))
-	//	}
-	//	semProg, err := semantic.New(astProg, builtinDeclarations)
-	//	if err != nil {
-	//		panic(errors.Wrapf(err, "failed to create semantic graph for builtin %q", name))
-	//	}
-
-	//	if err := interpreter.Eval(semProg, builtinScope); err != nil {
-	//		panic(errors.Wrapf(err, "failed to evaluate builtin %q", name))
-	//	}
-	//}
-	//// free builtins list
-	//builtins = nil
+	// Call BuiltIns to validate all built-in values are valid.
+	// A panic will occur if any value is invalid.
+	_, _ = BuiltIns()
 }
 
 var TableObjectType = semantic.NewObjectType(map[string]semantic.Type{
@@ -267,6 +254,9 @@ func DefaultFunctionSignature() semantic.FunctionSignature {
 }
 
 func BuiltIns() (map[string]values.Value, semantic.DeclarationScope) {
+	if !finalized {
+		panic("builtins not finalized")
+	}
 	qd := new(queryDomain)
 	return builtIns(qd)
 }

--- a/query/complete/complete.go
+++ b/query/complete/complete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/interpreter"
 	"github.com/influxdata/platform/query/semantic"
 )
@@ -95,11 +94,4 @@ func (c Completer) FunctionSuggestion(name string) (FunctionSuggestion, error) {
 
 func isFunction(d semantic.VariableDeclaration) bool {
 	return d.InitType().Kind() == semantic.Function
-}
-
-// DefaultCompleter create a completer with builtin scope and declarations
-func DefaultCompleter() Completer {
-	scope, declarations := query.BuiltIns()
-	interpScope := interpreter.NewScopeWithValues(scope)
-	return NewCompleter(interpScope, declarations)
 }

--- a/query/execute/executor_test.go
+++ b/query/execute/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/ast"
+	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/execute/executetest"
 	"github.com/influxdata/platform/query/functions"

--- a/query/functions/data_test.go
+++ b/query/functions/data_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gonum/stat/distuv"
 	"github.com/influxdata/platform/query"
+	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/execute/executetest"
 	"github.com/influxdata/platform/query/values"
@@ -18,10 +19,6 @@ const (
 
 	seed = 42
 )
-
-func init() {
-	query.FinalizeRegistration()
-}
 
 // NormalData is a slice of N random values that are normaly distributed with mean Mu and standard deviation Sigma.
 var NormalData []float64

--- a/query/querytest/prepcsvtests/prepcsvtests.go
+++ b/query/querytest/prepcsvtests/prepcsvtests.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/influxdata/platform/query"
+	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/query/querytest"
 
 	"golang.org/x/text/unicode/norm"
@@ -24,10 +25,6 @@ func normalizeString(s string) []byte {
 
 func printUsage() {
 	fmt.Println("usage: prepcsvtests /path/to/testfiles [testname]")
-}
-
-func init() {
-	query.FinalizeRegistration()
 }
 
 func main() {

--- a/query/querytest/query_test.go
+++ b/query/querytest/query_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/platform/query"
+	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/query/influxql"
 
 	"github.com/andreyvit/diff"


### PR DESCRIPTION

Now all packages wishing to consume query package can and must import
query/builtin in order to properly initialize all builtin values.