### PR TITLE
fix(query/influxql): ensure the join happens deterministically

### DIFF
--- a/query/influxql/join.go
+++ b/query/influxql/join.go
@@ -58,10 +58,10 @@ func Join(t *transpilerState, cursors []cursor, on, except []string) cursor {
 		}
 	}
 
-	// Retrieve the parent tables from the tables map.
+	// Retrieve the parent ids from the cursors.
 	parents := make([]query.OperationID, 0, len(tables))
-	for id := range tables {
-		parents = append(parents, id)
+	for _, cur := range cursors {
+		parents = append(parents, cur.ID())
 	}
 	id := t.op("join", &functions.JoinOpSpec{
 		TableNames: tables,


### PR DESCRIPTION
This ensures the tests are not flaky because the output is
deterministic.

Fixes #116.