### PR TITLE
feat(query/influxql): expose default database and retention policy for transpiler

### DIFF
--- a/query/influxql/config.go
+++ b/query/influxql/config.go
@@ -1,0 +1,7 @@
+package influxql
+
+// Config modifies the behavior of the Transpiler.
+type Config struct {
+	DefaultDatabase        string
+	DefaultRetentionPolicy string
+}

--- a/query/transpiler.go
+++ b/query/transpiler.go
@@ -8,6 +8,7 @@ import (
 
 // Transpiler can convert a query from a source lanague into a query spec.
 type Transpiler interface {
+	// Transpile will perform the transpilation.
 	Transpile(ctx context.Context, txt string) (*Spec, error)
 }
 


### PR DESCRIPTION
The influxql transpiler can now be configured with a default database
and retention policy.