### PR TITLE
fix(query/control): use Lock to avoid data race

### DIFF
--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -134,8 +134,8 @@ func (c *Controller) enqueueQuery(q *Query) error {
 }
 
 func (c *Controller) nextID() QueryID {
-	c.queriesMu.RLock()
-	defer c.queriesMu.RUnlock()
+	c.queriesMu.Lock()
+	defer c.queriesMu.Unlock()
 	ok := true
 	for ok {
 		c.lastID++


### PR DESCRIPTION
The previous code used RLock even though it was modifying a field. I
observed a data race locally due to concurrent access on that field.