### PR TITLE
feat(query): add organization lookup to storage dependencies

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -144,9 +144,16 @@ func injectDeps(deps execute.Dependencies) error {
 	}
 	bucketSvc := StaticBucketService{Name: bucketName[0]}
 
+	orgName, err := getStrList("ORGANIZATION_NAME")
+	if err != nil {
+		return errors.Wrap(err, "failed to get organization name")
+	}
+	orgSvc := StaticOrganizationService{Name: orgName[0]}
+
 	return functions.InjectFromDependencies(deps, storage.Dependencies{
-		Reader:       sr,
-		BucketLookup: query.FromBucketService(&bucketSvc),
+		Reader:             sr,
+		BucketLookup:       query.FromBucketService(&bucketSvc),
+		OrganizationLookup: query.FromOrganizationService(&orgSvc),
 	})
 }
 

--- a/cmd/influx/repl.go
+++ b/cmd/influx/repl.go
@@ -70,7 +70,13 @@ func replF(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	r, err := getFluxREPL(hosts, buckets, org, replFlags.Verbose)
+	orgs, err := orgService(flags.host, flags.token)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	r, err := getFluxREPL(hosts, buckets, orgs, org, replFlags.Verbose)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -79,7 +85,7 @@ func replF(cmd *cobra.Command, args []string) {
 	r.Run()
 }
 
-func getFluxREPL(storageHosts storage.Reader, buckets platform.BucketService, org qid.ID, verbose bool) (*repl.REPL, error) {
+func getFluxREPL(storageHosts storage.Reader, buckets platform.BucketService, orgs platform.OrganizationService, org qid.ID, verbose bool) (*repl.REPL, error) {
 	conf := control.Config{
 		ExecutorDependencies: make(execute.Dependencies),
 		ConcurrencyQuota:     runtime.NumCPU() * 2,
@@ -87,7 +93,7 @@ func getFluxREPL(storageHosts storage.Reader, buckets platform.BucketService, or
 		Verbose:              verbose,
 	}
 
-	if err := injectDeps(conf.ExecutorDependencies, storageHosts, buckets); err != nil {
+	if err := injectDeps(conf.ExecutorDependencies, storageHosts, buckets, orgs); err != nil {
 		return nil, err
 	}
 

--- a/query/dependency.go
+++ b/query/dependency.go
@@ -32,3 +32,26 @@ func (b *BucketLookup) Lookup(orgID id.ID, name string) (id.ID, bool) {
 	}
 	return id.ID(bucket.ID), true
 }
+
+// FromOrganizationService wraps a platform.OrganizationService in the OrganizationLookup interface.
+func FromOrganizationService(srv platform.OrganizationService) *OrganizationLookup {
+	return &OrganizationLookup{OrganizationService: srv}
+}
+
+// OrganizationLookup converts organization name lookups into platform.OrganizationService calls.
+type OrganizationLookup struct {
+	OrganizationService platform.OrganizationService
+}
+
+// Lookup returns the organization ID and its existence given an organization name.
+func (o *OrganizationLookup) Lookup(ctx context.Context, name string) (platform.ID, bool) {
+	org, err := o.OrganizationService.FindOrganization(
+		ctx,
+		platform.OrganizationFilter{Name: &name},
+	)
+
+	if err != nil {
+		return nil, false
+	}
+	return org.ID, true
+}

--- a/query/functions/storage/storage.go
+++ b/query/functions/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/id"
@@ -21,14 +22,25 @@ type BucketLookup interface {
 	Lookup(orgID id.ID, name string) (id.ID, bool)
 }
 
+type OrganizationLookup interface {
+	Lookup(ctx context.Context, name string) (platform.ID, bool)
+}
+
 type Dependencies struct {
-	Reader       Reader
-	BucketLookup BucketLookup
+	Reader             Reader
+	BucketLookup       BucketLookup
+	OrganizationLookup OrganizationLookup
 }
 
 func (d Dependencies) Validate() error {
 	if d.Reader == nil {
 		return errors.New("missing reader dependency")
+	}
+	if d.BucketLookup == nil {
+		return errors.New("missing bucket lookup dependency")
+	}
+	if d.OrganizationLookup == nil {
+		return errors.New("missing organization lookup dependency")
 	}
 	return nil
 }


### PR DESCRIPTION
This is needed for the `to` function to write to buckets in another
organization.