### PR TITLE
Linking to Flux from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ This project is using [`dep`](https://golang.github.io/dep/docs/introduction.htm
 
 Use `dep ensure -vendor-only` when you only need to populate the `vendor` directory to run `go build` successfully,
 or run `dep ensure` to both populate the `vendor` directory and update `Gopkg.lock` with any newer constraints.
+
+## Introducing Flux 
+
+We recently announced Flux, the MIT-licensed data scripting language (and rename for IFQL). The source for Flux is [in this repository under `query`](query#flux---influx-data-language). Learn more about Flux from [CTO Paul Dix's presentation](https://speakerdeck.com/pauldix/flux-number-fluxlang-a-new-time-series-data-scripting-language).


### PR DESCRIPTION
Making it easier for interested parties to find Flux. Also linking to the best resource so far, which is @pauldix's presentation.

A couple other suggestions for discoverability (independent from the PR): 

- Once you have a blog/page on the website, link users there instead of directly to Paul's slides (always nice to land on the company page)
- you might want to setup another pointer repository at github.com/influxdata/flux for visibility. I couldn't find Flux without real sleuthing before realizing it was in here. Side note: you could end up migrating there as the project grows. In the meantime, you can turn off Issues on the repo and point people into here

Either way, I hope this helps. Congratulations on the release! 🎉 