### PR TITLE
feat(http): add swagger definitions for influxql query

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -134,10 +134,10 @@ paths:
           description: bucket is the query and write destination store
         - in: query
           name: precision
-          description: preciscion rounds the timestamp to the nearest unit
+          description: precision rounds the timestamp to the nearest unit
           schema:
             type: string
-            description: acceptable epochs define the time units returned in the query
+            description: precision define the time units returned in the query
             enum: [
               "n",
               "u",

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -103,6 +103,138 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /query:
+   servers:
+      - url: /
+   get:
+    tags:
+      - Query
+    summary: Executes InfluxQL to retrieve time-series data
+    parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+          description: URL-encoded InfluxQL query to execute
+        - in: query
+          name: db
+          schema:
+            type: string
+          description: the database has been renamed to bucket.
+        - in: query
+          name: rp
+          schema:
+            type: string
+          description: optional retention policy to query (> 1.6.0)
+        - in: query
+          name: bucket
+          schema:
+            type: string
+          description: bucket is the query and write destination store
+        - in: query
+          name: precision
+          description: preciscion rounds the timestamp to the nearest unit
+          schema:
+            type: string
+            description: acceptable epochs define the time units returned in the query
+            enum: [
+              "n",
+              "u",
+              "ms",
+              "s",
+              "m",
+              "h"
+            ]
+        - in: query
+          name: epoch
+          description: override default RFC3339 time format with unix epoch at a precision; epoch rounds the timestamp to the nearest unit
+          schema:
+            type: string
+            description: acceptable epochs define the time units returned in the query
+            enum: [
+              "n",
+              "u",
+              "ms",
+              "s",
+              "m",
+              "h"
+            ]
+        - in: query
+          name: chunked
+          description: return results in streamed batches rather than as a single response
+          schema:
+            type: boolean
+        - in: query
+          name: chunk_size
+          description: responses will be chunked by series or by every chunk_size points, whichever occurs first.
+          schema:
+            type: integer
+            default: 10000
+        - in: query
+          name: pretty
+          description: format JSON response onto multiple lines and tab indention.
+          schema:
+            type: boolean
+        - in: header
+          name: Content-Encoding
+          description: optional gzip encoding of query results
+          schema:
+            type: string
+            enum:
+             - gzip
+        - in: header
+          name: X-Request-Id
+          description: specifies correlating requests across services
+          schema:
+            type: string
+            format: uuid
+    responses:
+      '200':
+        description: query executed successfully
+        headers:
+          X-Request-Id:
+            description: request correlation id
+            schema:
+              type: string
+              format: uuid
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InfluxQLResults"
+      '400':
+        description: error during query execution
+        headers:
+          X-InfluxDB-Error:
+            description: Error message describing error resason
+            schema:
+              type: string
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InfluxqlQueryError"
+      '403':
+        description: Not authorized to execute query
+        headers:
+          WWW-Authenticate:
+            description: WWW-Authenticate response header defines the authentication method that should be used to gain access to a resource.
+            schema:
+              type: string
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InfluxqlQueryError"
+      default:
+        description: unexpected error
+        headers:
+          X-InfluxDB-Error:
+            description: Error message describing error resason
+            schema:
+              type: string
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InfluxqlQueryError"
   /buckets:
     get:
       tags:
@@ -887,3 +1019,72 @@ components:
           readOnly: true
           type: string
       required: [code, message]
+    InfluxQLResults:
+      properties:
+        error:
+          description: error during processing of the message
+          type: string
+        results:
+          type: array
+          description: result for each query
+          items:
+            type: object
+            properties:
+              error:
+                type: string
+                description: error during processing of the message
+              partial:
+                type: boolean
+                description: If a max row limit has been placed in the configuration file and the number of returned values is larger, this will be set to true and values truncated.
+              statement_id:
+                type: integer
+                description: statement's position in the query.
+              series:
+                description: The collection of data in InfluxDB’s data structure that share a measurement, tag set, and retention policy.
+                type: array
+                items:
+                  type: object
+                  description: values for a unique series
+                  properties:
+                    name:
+                      description: The part of InfluxDB’s structure that describes the data stored in the associated fields. Measurements are strings.
+                      type: string
+                    tags:
+                      description: The key-value pairs in InfluxDB’s data structure that records metadata.
+                      type: object
+                    columns:
+                      description: list of columns describing the content of a single value array
+                      type: array
+                      items:
+                        type: string
+                    values:
+                      description: array of arrays of the values return from the query
+                      type: array
+                      items:
+                        type: array
+                        description: single row of results in the order of the columns field.
+                        items:
+                          oneOf:
+                            - type: string
+                            - type: number
+                            - type: integer
+                    partial:
+                      type: boolean
+              messages:
+                type: array
+                description: represents a user-facing message to be included with the result.
+                items:
+                  type: object
+                  properties:
+                    level:
+                      type: string
+                    text:
+                      type: string
+    InfluxqlQueryError:
+      properties:
+        error:
+          description: message describing why the query was rejected
+          readOnly: true
+          type: string
+      required:
+        - error


### PR DESCRIPTION
This is documentation for the 1.0 compatibility query path.