### PR TITLE
fix(Makefile): Touch Gopkg.lock after dep ensure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ bin/goreleaser: ./vendor/github.com/goreleaser/goreleaser/main.go
 
 Gopkg.lock: Gopkg.toml
 	dep ensure -v
+	touch Gopkg.lock
 
 vendor/github.com/mna/pigeon/main.go: Gopkg.lock
 	dep ensure -v -vendor-only


### PR DESCRIPTION
Running "dep ensure" no longer always writes out the Gopkg.lock file.
As such if somehow Gopkg.toml has a newer modified time than Gopkg.lock
the make command would always run "dep ensure" and all other build
steps.

This change makes it explicit that after a dep ensure run that
Gopkg.lock is newer than Gopkg.toml.