### PR TITLE
add option statement to semantic graph

### DIFF
--- a/query/interpreter/interpreter.go
+++ b/query/interpreter/interpreter.go
@@ -30,6 +30,10 @@ func (itrp interpreter) eval(program *semantic.Program, scope *Scope) error {
 func (itrp interpreter) doStatement(stmt semantic.Statement, scope *Scope) error {
 	scope.SetReturn(values.InvalidValue)
 	switch s := stmt.(type) {
+	case *semantic.OptionStatement:
+		if err := itrp.doStatement(s.Declaration, scope); err != nil {
+			return err
+		}
 	case *semantic.NativeVariableDeclaration:
 		if err := itrp.doVariableDeclaration(s, scope); err != nil {
 			return err
@@ -584,6 +588,12 @@ func (f function) resolveIdentifiers(n semantic.Node) (semantic.Node, error) {
 			}
 			n.Body[i] = node.(semantic.Statement)
 		}
+	case *semantic.OptionStatement:
+		node, err := f.resolveIdentifiers(n.Declaration)
+		if err != nil {
+			return nil, err
+		}
+		n.Declaration = node.(semantic.VariableDeclaration)
 	case *semantic.ExpressionStatement:
 		node, err := f.resolveIdentifiers(n.Expression)
 		if err != nil {

--- a/query/interpreter/interpreter_test.go
+++ b/query/interpreter/interpreter_test.go
@@ -249,6 +249,17 @@ func TestEval(t *testing.T) {
 			"abba" !~ /^a.*a$/ and fail()
 			`,
 		},
+		{
+			name: "options metadata before query",
+			query: `
+			option task = {
+				name: "foo",
+				repeat: 100,
+			}
+			task.name == "foo" or fail()
+			task.repeat == 100 or fail()
+			`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/query/semantic/graph_test.go
+++ b/query/semantic/graph_test.go
@@ -2,6 +2,7 @@ package semantic_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/platform/query/ast"
@@ -46,6 +47,75 @@ func TestNew(t *testing.T) {
 					},
 					&semantic.ExpressionStatement{
 						Expression: &semantic.IdentifierExpression{Name: "a"},
+					},
+				},
+			},
+		},
+		{
+			name: "options declaration",
+			program: &ast.Program{
+				Body: []ast.Statement{
+					&ast.OptionStatement{
+						Declaration: &ast.VariableDeclarator{
+							ID: &ast.Identifier{Name: "task"},
+							Init: &ast.ObjectExpression{
+								Properties: []*ast.Property{
+									{
+										Key:   &ast.Identifier{Name: "name"},
+										Value: &ast.StringLiteral{Value: "foo"},
+									},
+									{
+										Key:   &ast.Identifier{Name: "every"},
+										Value: &ast.DurationLiteral{Value: 1 * time.Hour},
+									},
+									{
+										Key:   &ast.Identifier{Name: "delay"},
+										Value: &ast.DurationLiteral{Value: 10 * time.Minute},
+									},
+									{
+										Key:   &ast.Identifier{Name: "cron"},
+										Value: &ast.StringLiteral{Value: "0 2 * * *"},
+									},
+									{
+										Key:   &ast.Identifier{Name: "retry"},
+										Value: &ast.IntegerLiteral{Value: 5},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &semantic.Program{
+				Body: []semantic.Statement{
+					&semantic.OptionStatement{
+						Declaration: &semantic.NativeVariableDeclaration{
+							Identifier: &semantic.Identifier{Name: "task"},
+							Init: &semantic.ObjectExpression{
+								Properties: []*semantic.Property{
+									{
+										Key:   &semantic.Identifier{Name: "name"},
+										Value: &semantic.StringLiteral{Value: "foo"},
+									},
+									{
+										Key:   &semantic.Identifier{Name: "every"},
+										Value: &semantic.DurationLiteral{Value: 1 * time.Hour},
+									},
+									{
+										Key:   &semantic.Identifier{Name: "delay"},
+										Value: &semantic.DurationLiteral{Value: 10 * time.Minute},
+									},
+									{
+										Key:   &semantic.Identifier{Name: "cron"},
+										Value: &semantic.StringLiteral{Value: "0 2 * * *"},
+									},
+									{
+										Key:   &semantic.Identifier{Name: "retry"},
+										Value: &semantic.IntegerLiteral{Value: 5},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/query/semantic/json_test.go
+++ b/query/semantic/json_test.go
@@ -42,6 +42,39 @@ func TestJSONMarshal(t *testing.T) {
 			want: `{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"StringLiteral","value":"hello"}}]}`,
 		},
 		{
+			name: "option statement",
+			node: &semantic.OptionStatement{
+				Declaration: &semantic.NativeVariableDeclaration{
+					Identifier: &semantic.Identifier{Name: "task"},
+					Init: &semantic.ObjectExpression{
+						Properties: []*semantic.Property{
+							{
+								Key:   &semantic.Identifier{Name: "name"},
+								Value: &semantic.StringLiteral{Value: "foo"},
+							},
+							{
+								Key:   &semantic.Identifier{Name: "every"},
+								Value: &semantic.DurationLiteral{Value: 1 * time.Hour},
+							},
+							{
+								Key:   &semantic.Identifier{Name: "delay"},
+								Value: &semantic.DurationLiteral{Value: 10 * time.Minute},
+							},
+							{
+								Key:   &semantic.Identifier{Name: "cron"},
+								Value: &semantic.StringLiteral{Value: "0 2 * * *"},
+							},
+							{
+								Key:   &semantic.Identifier{Name: "retry"},
+								Value: &semantic.IntegerLiteral{Value: 5},
+							},
+						},
+					},
+				},
+			},
+			want: `{"type":"OptionStatement","declaration":{"type":"NativeVariableDeclaration","identifier":{"type":"Identifier","name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","value":"1h0m0s"}},{"type":"Property","key":{"type":"Identifier","name":"delay"},"value":{"type":"DurationLiteral","value":"10m0s"}},{"type":"Property","key":{"type":"Identifier","name":"cron"},"value":{"type":"StringLiteral","value":"0 2 * * *"}},{"type":"Property","key":{"type":"Identifier","name":"retry"},"value":{"type":"IntegerLiteral","value":"5"}}]}}}`,
+		},
+		{
 			name: "expression statement",
 			node: &semantic.ExpressionStatement{
 				Expression: &semantic.StringLiteral{Value: "hello"},

--- a/query/semantic/walk.go
+++ b/query/semantic/walk.go
@@ -26,6 +26,11 @@ func walk(v Visitor, n Node) {
 				walk(w, s)
 			}
 		}
+	case *OptionStatement:
+		w := v.Visit(n)
+		if w != nil {
+			walk(w, n.Declaration)
+		}
 	case *ExpressionStatement:
 		w := v.Visit(n)
 		if w != nil {


### PR DESCRIPTION
This commit adds the option statement as a recognized node in
the semantic graph of a Flux query.

Flux interpreter must visit an option statement node

interpreter parses option statement