### PR TITLE
Prevent X-Influx-Error headers to exceed a certain size

### DIFF
--- a/kit/errors/http.go
+++ b/kit/errors/http.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 )
 
+const errorHeaderMaxLength = 64
+
 // TODO: move to http directory
 
 // EncodeHTTP encodes err with the appropriate status code and format,
@@ -17,9 +19,14 @@ func EncodeHTTP(ctx context.Context, err error, w http.ResponseWriter) {
 	}
 	e, ok := err.(*Error)
 	if !ok {
+		errStr := err.Error()
+		if len(errStr) > errorHeaderMaxLength {
+			errStr = err.Error()[0:errorHeaderMaxLength]
+		}
+
 		e = &Error{
 			Reference: InternalError,
-			Err:       err.Error(),
+			Err:       errStr,
 		}
 	}
 	e.SetCode()

--- a/kit/errors/http_test.go
+++ b/kit/errors/http_test.go
@@ -1,0 +1,46 @@
+package errors
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEncodeHTTP(t *testing.T) {
+	ctx := context.TODO()
+
+	w := httptest.NewRecorder()
+
+	EncodeHTTP(ctx, nil, w)
+
+	if w.Code != 200 {
+		t.Errorf("expected status code 200, got: %d", w.Code)
+	}
+}
+
+func TestEncodeHTTPWithError(t *testing.T) {
+	ctx := context.TODO()
+	err := fmt.Errorf("there's an error here, be aware")
+
+	w := httptest.NewRecorder()
+
+	EncodeHTTP(ctx, err, w)
+
+	if w.Code != 500 {
+		t.Errorf("expected status code 500, got: %d", w.Code)
+	}
+
+	errHeader := w.Header().Get("X-Influx-Error")
+	if errHeader != err.Error() {
+		t.Errorf("expected X-Influx-Error: %s, got: %s", err.Error(), errHeader)
+	}
+
+	err = fmt.Errorf("there's a very long error here, it will be truncated so that we don't break webserver's pagesize")
+	expected := "there's a very long error here, it will be truncated so that we "
+	EncodeHTTP(ctx, err, w)
+	errHeader = w.Header().Get("X-Influx-Error")
+	if errHeader != expected {
+		t.Errorf("Expected a truncated X-Influx-Error header content: %s, got: %s", expected, errHeader)
+	}
+}


### PR DESCRIPTION
The `errors` package is giving back to the client the full error passed by the caller to `EncodeHTTP`.
This PR makes `EncodeHTTP` more defensive against its consumers in order to disallow error strings greater than 64 bytes.

## Why this is needed

There's not a standard in [RFC2616](https://tools.ietf.org/html/rfc2616#section-4.2) regarding the length of http headers sent back by the server, however since this implementation detail is always related to the page size of the current system (On linux see `man getpagesize`) most webservers apply restrictions on the size of the sum of the request line and all the headers, like how [nginx does](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) 

Said that, even if technically there's no limit in Go, boundaries, like proxies or webservers seeing the request might not let the request pass and give a 413 error instead.

Signed-off-by: Lorenzo Fontana <lo@linux.com>