### PR TITLE
add user owners to ownable objects

### DIFF
--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -310,3 +310,47 @@ func (c *Client) deleteOrganizationsBuckets(ctx context.Context, tx *bolt.Tx, id
 	}
 	return nil
 }
+
+func (c *Client) AddOrganizationOwner(ctx context.Context, id platform.ID, owner *platform.Owner) error {
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		err := c.addOwner(ctx, tx, id, owner)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	return err
+}
+
+func (c *Client) addOwner(ctx context.Context, tx *bolt.Tx, id platform.ID, owner *platform.Owner) error {
+	o, err := c.findOrganizationByID(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+
+	found := false
+}
+
+func (c *Client) GetOrganizationOwners(ctx context.Context, id platform.ID) (*[]platform.Owner, error) {
+	var o *platform.Organization
+
+	err := c.db.View(func(tx *bolt.Tx) error {
+		org, err := c.findOrganizationByID(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		o = org
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &o.Owners, nil
+}
+
+func (c *Client) RemoveOrganizationOwner(ctx context.Context, orgID platform.ID, ownerID platform.ID) error {
+
+}

--- a/bucket.go
+++ b/bucket.go
@@ -12,6 +12,7 @@ type Bucket struct {
 	Organization    string        `json:"organization,omitempty"`
 	Name            string        `json:"name"`
 	RetentionPeriod time.Duration `json:"retentionPeriod"`
+	Owners          []ID          `json:"owners"`
 }
 
 // BucketService represents a service for managing bucket data.
@@ -42,6 +43,7 @@ type BucketService interface {
 type BucketUpdate struct {
 	Name            *string        `json:"name,omitempty"`
 	RetentionPeriod *time.Duration `json:"retentionPeriod,omitempty"`
+	Owners          *[]ID          `json:"owners"`
 }
 
 // BucketFilter represents a set of filter that restrict the returned results.

--- a/bucket.go
+++ b/bucket.go
@@ -38,7 +38,7 @@ type BucketService interface {
 	DeleteBucket(ctx context.Context, id ID) error
 
 	// AddBucketOwner adds a new owner to a bucket.
-	AddBucketOwner(ctx context.Context, bucketID ID, owner Owner) error
+	AddBucketOwner(ctx context.Context, bucketID ID, owner *Owner) error
 
 	GetBucketOwners(ctx context.Context, bucketID ID) (*[]Owner, error)
 

--- a/bucket.go
+++ b/bucket.go
@@ -3,8 +3,6 @@ package platform
 import (
 	"context"
 	"time"
-
-	"github.com/influxdata/platform"
 )
 
 // Bucket is a bucket. 🎉
@@ -40,7 +38,7 @@ type BucketService interface {
 	DeleteBucket(ctx context.Context, id ID) error
 
 	// AddBucketOwner adds a new owner to a bucket.
-	AddBucketOwner(ctx context.Context, bucketID ID, owner platform.Owner) error
+	AddBucketOwner(ctx context.Context, bucketID ID, owner Owner) error
 
 	GetBucketOwners(ctx context.Context, bucketID ID) (*[]Owner, error)
 

--- a/bucket.go
+++ b/bucket.go
@@ -3,6 +3,8 @@ package platform
 import (
 	"context"
 	"time"
+
+	"github.com/influxdata/platform"
 )
 
 // Bucket is a bucket. 🎉
@@ -38,7 +40,9 @@ type BucketService interface {
 	DeleteBucket(ctx context.Context, id ID) error
 
 	// AddBucketOwner adds a new owner to a bucket.
-	AddBucketOwner(ctx context.Context, bucketID ID, ownerID ID) error
+	AddBucketOwner(ctx context.Context, bucketID ID, owner platform.Owner) error
+
+	GetBucketOwners(ctx context.Context, bucketID ID) (*[]Owner, error)
 
 	// RemoveBucketOwner removes an owner from a bucket.
 	RemoveBucketOwner(ctx context.Context, bucketID ID, ownerID ID) error

--- a/bucket.go
+++ b/bucket.go
@@ -12,7 +12,7 @@ type Bucket struct {
 	Organization    string        `json:"organization,omitempty"`
 	Name            string        `json:"name"`
 	RetentionPeriod time.Duration `json:"retentionPeriod"`
-	Owners          []ID          `json:"owners"`
+	Owners          []Owner       `json:"owners"`
 }
 
 // BucketService represents a service for managing bucket data.

--- a/bucket.go
+++ b/bucket.go
@@ -36,6 +36,12 @@ type BucketService interface {
 
 	// DeleteBucket removes a bucket by ID.
 	DeleteBucket(ctx context.Context, id ID) error
+
+	// AddBucketOwner adds a new owner to a bucket.
+	AddBucketOwner(ctx context.Context, bucketID ID, ownerID ID) error
+
+	// RemoveBucketOwner removes an owner from a bucket.
+	RemoveBucketOwner(ctx context.Context, bucketID ID, ownerID ID) error
 }
 
 // BucketUpdate represents updates to a bucket.
@@ -43,7 +49,6 @@ type BucketService interface {
 type BucketUpdate struct {
 	Name            *string        `json:"name,omitempty"`
 	RetentionPeriod *time.Duration `json:"retentionPeriod,omitempty"`
-	Owners          *[]ID          `json:"owners"`
 }
 
 // BucketFilter represents a set of filter that restrict the returned results.

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -242,6 +242,21 @@ func (s *StaticOrganizationService) DeleteOrganization(ctx context.Context, id p
 	panic("not implemented")
 }
 
+// AddOrganizationOwner adds an owner to an organization.
+func (s *StaticOrganizationService) AddOrganizationOwner(ctx context.Context, orgID platform.ID, owner *platform.Owner) error {
+	panic("not implemented")
+}
+
+// GetOrganizationOwners lists owners for an organization.
+func (s *StaticOrganizationService) GetOrganizationOwners(ctx context.Context, orgID platform.ID) (*[]platform.Owner, error) {
+	panic("not implemented")
+}
+
+// RemoveOrganizationOwner removes an owner from a bucket.
+func (s *StaticOrganizationService) RemoveOrganizationOwner(ctx context.Context, orgID platform.ID, ownerID platform.ID) error {
+	panic("not implemented")
+}
+
 // StaticBucketService connects to Influx via HTTP using tokens to manage buckets
 type StaticBucketService struct {
 	Name string
@@ -292,5 +307,20 @@ func (s *StaticBucketService) UpdateBucket(ctx context.Context, id platform.ID, 
 
 // DeleteBucket removes a bucket by ID.
 func (s *StaticBucketService) DeleteBucket(ctx context.Context, id platform.ID) error {
+	panic("not implemented")
+}
+
+// AddBucketOwner adds an owner to a bucket.
+func (s *StaticBucketService) AddBucketOwner(ctx context.Context, bucketID platform.ID, owner *platform.Owner) error {
+	panic("not implemented")
+}
+
+// GetBucketOwners lists all owners for a bucket.
+func (s *StaticBucketService) GetBucketOwners(ctx context.Context, bucketID platform.ID) (*[]platform.Owner, error) {
+	panic("not implemented")
+}
+
+// RemoveBucketOwner removes an owner from a bucket.
+func (s *StaticBucketService) RemoveBucketOwner(ctx context.Context, bucketID platform.ID, ownerID platform.ID) error {
 	panic("not implemented")
 }

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -575,7 +575,7 @@ func bucketOwnersDeleteF(cmd *cobra.Command, args []string) {
 
 func init() {
 	bucketOwnersDeleteCmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "remove",
 		Short: "Delete bucket owner",
 		Run:   bucketOwnersDeleteF,
 	}

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -338,12 +338,23 @@ func init() {
 
 // List Owners
 type BucketOwnersListFlags struct {
+	name string
+	id   string
 }
 
 var bucketOwnersListFlags BucketOwnersListFlags
 
 func bucketOwnersListF(cmd *cobra.Comannd, args []string) {
+	s := &http.BucketService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
 
+	if bucketOwnersListFlags.id == "" && bucketOwnersListFlags.name == "" {
+		fmt.Println("must specify either id or name")
+		cmd.Usage()
+		os.Exit(1)
+	}
 }
 
 func init() {
@@ -354,6 +365,7 @@ func init() {
 	}
 
 	bucketOwnersListCmd.Flags().StringVarP(&bucketOwnersListFlags.id, "id", "i", "", "bucket id")
+	bucketOwnersListCmd.Flags().StringVarP(&bucketOwnersListFLags.name, "name", "n", "", "bucket name")
 
 	bucketOwnersCmd.AddCommand(bucketOwnersListCmd)
 }

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -324,3 +324,80 @@ func init() {
 
 	bucketCmd.AddCommand(bucketDeleteCmd)
 }
+
+// Owner management
+var bucketOwnersCmd = &cobra.Command{
+	Use:   "owners",
+	Short: "bucket ownership commands",
+	Run:   bucketF,
+}
+
+func init() {
+	bucketCmd.AddCommand(bucketOwnersCmd)
+}
+
+// List Owners
+type BucketOwnersListFlags struct {
+}
+
+var bucketOwnersListFlags BucketOwnersListFlags
+
+func bucketOwnersListF(cmd *cobra.Comannd, args []string) {
+
+}
+
+func init() {
+	bucketOwnersListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List bucket owners",
+		Run:   bucketOwnersListF,
+	}
+
+	bucketOwnersListCmd.Flags().StringVarP(&bucketOwnersListFlags.id, "id", "i", "", "bucket id")
+
+	bucketOwnersCmd.AddCommand(bucketOwnersListCmd)
+}
+
+// Add Owner
+type BucketOwnersAddFlags struct {
+}
+
+var bucketOwnersAddFlags BucketOwnersAddFlags
+
+func bucketOwnersAddF(cmd *cobra.Comannd, args []string) {
+
+}
+
+func init() {
+	bucketOwnersAddCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add bucket owner",
+		Run:   bucketOwnersAddF,
+	}
+
+	bucketOwnersAddCmd.Flags().StringVarP(&bucketOwnersAddFlags.id, "id", "i", "", "bucket id")
+
+	bucketOwnersCmd.AddCommand(bucketOwnersAddCmd)
+}
+
+// Delete Owner
+type BucketOwnersDeleteFlags struct {
+}
+
+var bucketOwnersDeleteFlags BucketOwnersDeleteFlags
+
+func bucketOwnersDeleteF(cmd *cobra.Comannd, args []string) {
+
+}
+
+func init() {
+	bucketOwnersDeleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete bucket owner",
+		Run:   bucketOwnersDeleteF,
+	}
+
+	bucketOwnersDeleteCmd.Flags().StringVarP(&bucketOwnersDeleteFlags.id, "id", "i", "", "bucket id")
+
+	bucketOwnersCmd.AddCommand(bucketOwnersDeleteCmd)
+}

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -56,6 +56,12 @@ func bucketCreateF(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if bucketFindFlags.orgID != "" && bucketFindFlags.org != "" {
+		fmt.Println("must specify at exactly one of org and org-id")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
 	s := &http.BucketService{
 		Addr:  flags.host,
 		Token: flags.token,
@@ -128,6 +134,18 @@ func init() {
 }
 
 func bucketFindF(cmd *cobra.Command, args []string) {
+	if bucketFindFlags.orgID == "" && bucketFindFlags.org == "" {
+		fmt.Println("must specify at exactly one of org and org-id")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	if bucketFindFlags.orgID != "" && bucketFindFlags.org != "" {
+		fmt.Println("must specify at exactly one of org and org-id")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
 	s := &http.BucketService{
 		Addr:  flags.host,
 		Token: flags.token,
@@ -145,12 +163,6 @@ func bucketFindF(cmd *cobra.Command, args []string) {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-	}
-
-	if bucketFindFlags.orgID == "" && bucketFindFlags.org == "" {
-		fmt.Println("must specify at exactly one of org and org-id")
-		cmd.Usage()
-		os.Exit(1)
 	}
 
 	if bucketFindFlags.orgID != "" {

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -502,35 +502,35 @@ func init() {
 	bucketOwnersCmd.AddCommand(bucketOwnersAddCmd)
 }
 
-// Delete Owner
-type BucketOwnersDeleteFlags struct {
+// Remove Owner
+type BucketOwnersRemoveFlags struct {
 	name    string
 	id      string
 	ownerId string
 }
 
-var bucketOwnersDeleteFlags BucketOwnersDeleteFlags
+var BucketOwnersRemoveFlags BucketOwnersRemoveFlags
 
-func bucketOwnersDeleteF(cmd *cobra.Command, args []string) {
+func BucketOwnersRemoveF(cmd *cobra.Command, args []string) {
 	s := &http.BucketService{
 		Addr:  flags.host,
 		Token: flags.token,
 	}
 
-	if bucketOwnersDeleteFlags.id == "" && bucketOwnersDeleteFlags.name == "" {
+	if BucketOwnersRemoveFlags.id == "" && BucketOwnersRemoveFlags.name == "" {
 		fmt.Println("must specify exactly one of id and name")
 		cmd.Usage()
 		os.Exit(1)
 	}
 
 	filter := platform.BucketFilter{}
-	if bucketOwnersDeleteFlags.name != "" {
-		filter.Name = &bucketOwnersDeleteFlags.name
+	if BucketOwnersRemoveFlags.name != "" {
+		filter.Name = &BucketOwnersRemoveFlags.name
 	}
 
-	if bucketOwnersDeleteFlags.id != "" {
+	if BucketOwnersRemoveFlags.id != "" {
 		filter.ID = &platform.ID{}
-		err := filter.ID.DecodeFromString(bucketOwnersDeleteFlags.id)
+		err := filter.ID.DecodeFromString(BucketOwnersRemoveFlags.id)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -547,7 +547,7 @@ func bucketOwnersDeleteF(cmd *cobra.Command, args []string) {
 	owners := bucket.Owners
 
 	for i, owner := range owners {
-		if owner.String() == bucketOwnersDeleteFlags.ownerId {
+		if owner.String() == BucketOwnersRemoveFlags.ownerId {
 			updatedOwners := append(owners[:i], owners[i+1:]...)
 			upd.Owners = &updatedOwners
 			_, err = s.UpdateBucket(context.Background(), bucket.ID, upd)
@@ -574,16 +574,16 @@ func bucketOwnersDeleteF(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	bucketOwnersDeleteCmd := &cobra.Command{
+	BucketOwnersRemoveCmd := &cobra.Command{
 		Use:   "remove",
-		Short: "Delete bucket owner",
-		Run:   bucketOwnersDeleteF,
+		Short: "Remove bucket owner",
+		Run:   BucketOwnersRemoveF,
 	}
 
-	bucketOwnersDeleteCmd.Flags().StringVarP(&bucketOwnersDeleteFlags.id, "id", "i", "", "bucket id")
-	bucketOwnersDeleteCmd.Flags().StringVarP(&bucketOwnersDeleteFlags.name, "name", "n", "", "bucket name")
-	bucketOwnersDeleteCmd.Flags().StringVarP(&bucketOwnersDeleteFlags.ownerId, "owner", "o", "", "owner id")
-	bucketOwnersDeleteCmd.MarkFlagRequired("owner")
+	BucketOwnersRemoveCmd.Flags().StringVarP(&BucketOwnersRemoveFlags.id, "id", "i", "", "bucket id")
+	BucketOwnersRemoveCmd.Flags().StringVarP(&BucketOwnersRemoveFlags.name, "name", "n", "", "bucket name")
+	BucketOwnersRemoveCmd.Flags().StringVarP(&BucketOwnersRemoveFlags.ownerId, "owner", "o", "", "owner id")
+	BucketOwnersRemoveCmd.MarkFlagRequired("owner")
 
-	bucketOwnersCmd.AddCommand(bucketOwnersDeleteCmd)
+	bucketOwnersCmd.AddCommand(BucketOwnersRemoveCmd)
 }

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -56,8 +56,8 @@ func bucketCreateF(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if bucketFindFlags.orgID != "" && bucketFindFlags.org != "" {
-		fmt.Println("must specify at exactly one of org and org-id")
+	if bucketCreateFlags.org != "" && bucketCreateFlags.orgID != "" {
+		fmt.Println("must specify exactly one of org and org-id")
 		cmd.Usage()
 		os.Exit(1)
 	}
@@ -135,13 +135,13 @@ func init() {
 
 func bucketFindF(cmd *cobra.Command, args []string) {
 	if bucketFindFlags.orgID == "" && bucketFindFlags.org == "" {
-		fmt.Println("must specify at exactly one of org and org-id")
+		fmt.Println("must specify exactly one of org and org-id")
 		cmd.Usage()
 		os.Exit(1)
 	}
 
 	if bucketFindFlags.orgID != "" && bucketFindFlags.org != "" {
-		fmt.Println("must specify at exactly one of org and org-id")
+		fmt.Println("must specify exactly one of org and org-id")
 		cmd.Usage()
 		os.Exit(1)
 	}
@@ -357,15 +357,21 @@ type BucketOwnersListFlags struct {
 var bucketOwnersListFlags BucketOwnersListFlags
 
 func bucketOwnersListF(cmd *cobra.Command, args []string) {
-	s := &http.BucketService{
-		Addr:  flags.host,
-		Token: flags.token,
-	}
-
 	if bucketOwnersListFlags.id == "" && bucketOwnersListFlags.name == "" {
 		fmt.Println("must specify exactly one of id and name")
 		cmd.Usage()
 		os.Exit(1)
+	}
+
+	if bucketOwnersListFlags.id != "" && bucketOwnersListFlags.name != "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	s := &http.BucketService{
+		Addr:  flags.host,
+		Token: flags.token,
 	}
 
 	filter := platform.BucketFilter{}
@@ -426,15 +432,21 @@ type BucketOwnersAddFlags struct {
 var bucketOwnersAddFlags BucketOwnersAddFlags
 
 func bucketOwnersAddF(cmd *cobra.Command, args []string) {
-	s := &http.BucketService{
-		Addr:  flags.host,
-		Token: flags.token,
-	}
-
 	if bucketOwnersAddFlags.id == "" && bucketOwnersAddFlags.name == "" {
 		fmt.Println("must specify exactly one of id and name")
 		cmd.Usage()
 		os.Exit(1)
+	}
+
+	if bucketOwnersAddFlags.id != "" && bucketOwnersAddFlags.name != "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	s := &http.BucketService{
+		Addr:  flags.host,
+		Token: flags.token,
 	}
 
 	filter := platform.BucketFilter{}
@@ -521,28 +533,34 @@ type BucketOwnersRemoveFlags struct {
 	ownerId string
 }
 
-var BucketOwnersRemoveFlags BucketOwnersRemoveFlags
+var bucketOwnersRemoveFlags BucketOwnersRemoveFlags
 
 func BucketOwnersRemoveF(cmd *cobra.Command, args []string) {
-	s := &http.BucketService{
-		Addr:  flags.host,
-		Token: flags.token,
-	}
-
-	if BucketOwnersRemoveFlags.id == "" && BucketOwnersRemoveFlags.name == "" {
+	if bucketOwnersRemoveFlags.id == "" && bucketOwnersRemoveFlags.name == "" {
 		fmt.Println("must specify exactly one of id and name")
 		cmd.Usage()
 		os.Exit(1)
 	}
 
-	filter := platform.BucketFilter{}
-	if BucketOwnersRemoveFlags.name != "" {
-		filter.Name = &BucketOwnersRemoveFlags.name
+	if bucketOwnersRemoveFlags.id != "" && bucketOwnersRemoveFlags.name != "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
 	}
 
-	if BucketOwnersRemoveFlags.id != "" {
+	s := &http.BucketService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	filter := platform.BucketFilter{}
+	if bucketOwnersRemoveFlags.name != "" {
+		filter.Name = &bucketOwnersRemoveFlags.name
+	}
+
+	if bucketOwnersRemoveFlags.id != "" {
 		filter.ID = &platform.ID{}
-		err := filter.ID.DecodeFromString(BucketOwnersRemoveFlags.id)
+		err := filter.ID.DecodeFromString(bucketOwnersRemoveFlags.id)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -559,7 +577,7 @@ func BucketOwnersRemoveF(cmd *cobra.Command, args []string) {
 	owners := bucket.Owners
 
 	for i, owner := range owners {
-		if owner.String() == BucketOwnersRemoveFlags.ownerId {
+		if owner.String() == bucketOwnersRemoveFlags.ownerId {
 			updatedOwners := append(owners[:i], owners[i+1:]...)
 			upd.Owners = &updatedOwners
 			_, err = s.UpdateBucket(context.Background(), bucket.ID, upd)
@@ -592,9 +610,9 @@ func init() {
 		Run:   BucketOwnersRemoveF,
 	}
 
-	BucketOwnersRemoveCmd.Flags().StringVarP(&BucketOwnersRemoveFlags.id, "id", "i", "", "bucket id")
-	BucketOwnersRemoveCmd.Flags().StringVarP(&BucketOwnersRemoveFlags.name, "name", "n", "", "bucket name")
-	BucketOwnersRemoveCmd.Flags().StringVarP(&BucketOwnersRemoveFlags.ownerId, "owner", "o", "", "owner id")
+	BucketOwnersRemoveCmd.Flags().StringVarP(&bucketOwnersRemoveFlags.id, "id", "i", "", "bucket id")
+	BucketOwnersRemoveCmd.Flags().StringVarP(&bucketOwnersRemoveFlags.name, "name", "n", "", "bucket name")
+	BucketOwnersRemoveCmd.Flags().StringVarP(&bucketOwnersRemoveFlags.ownerId, "owner", "o", "", "owner id")
 	BucketOwnersRemoveCmd.MarkFlagRequired("owner")
 
 	bucketOwnersCmd.AddCommand(BucketOwnersRemoveCmd)

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -50,7 +50,7 @@ func init() {
 }
 
 func bucketCreateF(cmd *cobra.Command, args []string) {
-	if bucketCreateFlags.org != "" && bucketCreateFlags.orgID != "" {
+	if bucketCreateFlags.org == "" && bucketCreateFlags.orgID == "" {
 		fmt.Println("must specify exactly one of org or org-id")
 		cmd.Usage()
 		os.Exit(1)
@@ -147,7 +147,7 @@ func bucketFindF(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if bucketFindFlags.orgID != "" && bucketFindFlags.org != "" {
+	if bucketFindFlags.orgID == "" && bucketFindFlags.org == "" {
 		fmt.Println("must specify at exactly one of org and org-id")
 		cmd.Usage()
 		os.Exit(1)

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -448,15 +448,15 @@ func bucketOwnersAddF(cmd *cobra.Command, args []string) {
 	var upd platform.BucketUpdate
 	owners := bucket.Owners
 
-	updateRequired := false
+	ownerExists := false
 	for _, owner := range owners {
-		if owner.String() == bucketOwnersAddFlags.ownerId {
-			updateRequired = true
+		if owner.String() != bucketOwnersAddFlags.ownerId {
+			ownerExists = true
 			break
 		}
 	}
 
-	if updateRequired {
+	if !ownerExists {
 		id := &platform.ID{}
 		err := id.DecodeFromString(bucketOwnersAddFlags.ownerId)
 		if err != nil {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -24,6 +24,7 @@ func init() {
 	influxCmd.AddCommand(replCmd)
 	influxCmd.AddCommand(queryCmd)
 	influxCmd.AddCommand(organizationCmd)
+	influxCmd.AddCommand(taskCmd)
 	influxCmd.AddCommand(userCmd)
 }
 

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -423,35 +423,35 @@ func init() {
 	organizationOwnersCmd.AddCommand(organizationOwnersAddCmd)
 }
 
-// Delete Owner
-type OrganizationOwnersDeleteFlags struct {
+// Remove Owner
+type OrganizationOwnersRemoveFlags struct {
 	name    string
 	id      string
 	ownerId string
 }
 
-var organizationOwnersDeleteFlags OrganizationOwnersDeleteFlags
+var organizationOwnersRemoveFlags OrganizationOwnersRemoveFlags
 
-func organizationOwnersDeleteF(cmd *cobra.Command, args []string) {
+func organizationOwnersRemoveF(cmd *cobra.Command, args []string) {
 	s := &http.OrganizationService{
 		Addr:  flags.host,
 		Token: flags.token,
 	}
 
-	if organizationOwnersDeleteFlags.id == "" && organizationOwnersDeleteFlags.name == "" {
+	if organizationOwnersRemoveFlags.id == "" && organizationOwnersRemoveFlags.name == "" {
 		fmt.Println("must specify exactly one of id and name")
 		cmd.Usage()
 		os.Exit(1)
 	}
 
 	filter := platform.OrganizationFilter{}
-	if organizationOwnersDeleteFlags.name != "" {
-		filter.Name = &organizationOwnersDeleteFlags.name
+	if organizationOwnersRemoveFlags.name != "" {
+		filter.Name = &organizationOwnersRemoveFlags.name
 	}
 
-	if organizationOwnersDeleteFlags.id != "" {
+	if organizationOwnersRemoveFlags.id != "" {
 		filter.ID = &platform.ID{}
-		err := filter.ID.DecodeFromString(organizationOwnersDeleteFlags.id)
+		err := filter.ID.DecodeFromString(organizationOwnersRemoveFlags.id)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -468,7 +468,7 @@ func organizationOwnersDeleteF(cmd *cobra.Command, args []string) {
 	owners := organization.Owners
 
 	for i, owner := range owners {
-		if owner.String() == organizationOwnersDeleteFlags.ownerId {
+		if owner.String() == organizationOwnersRemoveFlags.ownerId {
 			updatedOwners := append(owners[:i], owners[i+1:]...)
 			upd.Owners = &updatedOwners
 			_, err = s.UpdateOrganization(context.Background(), organization.ID, upd)
@@ -495,16 +495,16 @@ func organizationOwnersDeleteF(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	organizationOwnersDeleteCmd := &cobra.Command{
+	organizationOwnersRemoveCmd := &cobra.Command{
 		Use:   "remove",
-		Short: "Delete organization owner",
-		Run:   organizationOwnersDeleteF,
+		Short: "Remove organization owner",
+		Run:   organizationOwnersRemoveF,
 	}
 
-	organizationOwnersDeleteCmd.Flags().StringVarP(&organizationOwnersDeleteFlags.id, "id", "i", "", "organization id")
-	organizationOwnersDeleteCmd.Flags().StringVarP(&organizationOwnersDeleteFlags.name, "name", "n", "", "organization name")
-	organizationOwnersDeleteCmd.Flags().StringVarP(&organizationOwnersDeleteFlags.ownerId, "owner", "o", "", "owner id")
-	organizationOwnersDeleteCmd.MarkFlagRequired("owner")
+	organizationOwnersRemoveCmd.Flags().StringVarP(&organizationOwnersRemoveFlags.id, "id", "i", "", "organization id")
+	organizationOwnersRemoveCmd.Flags().StringVarP(&organizationOwnersRemoveFlags.name, "name", "n", "", "organization name")
+	organizationOwnersRemoveCmd.Flags().StringVarP(&organizationOwnersRemoveFlags.ownerId, "owner", "o", "", "owner id")
+	organizationOwnersRemoveCmd.MarkFlagRequired("owner")
 
-	organizationOwnersCmd.AddCommand(organizationOwnersDeleteCmd)
+	organizationOwnersCmd.AddCommand(organizationOwnersRemoveCmd)
 }

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -245,3 +245,266 @@ func init() {
 
 	organizationCmd.AddCommand(organizationDeleteCmd)
 }
+
+// Owner management
+var organizationOwnersCmd = &cobra.Command{
+	Use:   "owners",
+	Short: "organization ownership commands",
+	Run:   organizationF,
+}
+
+func init() {
+	organizationCmd.AddCommand(organizationOwnersCmd)
+}
+
+// List Owners
+type OrganizationOwnersListFlags struct {
+	name string
+	id   string
+}
+
+var organizationOwnersListFlags OrganizationOwnersListFlags
+
+func organizationOwnersListF(cmd *cobra.Command, args []string) {
+	s := &http.OrganizationService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	if organizationOwnersListFlags.id == "" && organizationOwnersListFlags.name == "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	filter := platform.OrganizationFilter{}
+	if organizationOwnersListFlags.name != "" {
+		filter.Name = &organizationOwnersListFlags.name
+	}
+
+	if organizationOwnersListFlags.id != "" {
+		filter.ID = &platform.ID{}
+		err := filter.ID.DecodeFromString(organizationOwnersListFlags.id)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	organization, err := s.FindOrganization(context.Background(), filter)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	owners := organization.Owners
+
+	// TODO: look up each user and output their name
+	w := internal.NewTabWriter(os.Stdout)
+	w.WriteHeaders(
+		"ID",
+	)
+	for _, id := range owners {
+		w.Write(map[string]interface{}{
+			"ID": id.String(),
+		})
+	}
+	w.Flush()
+}
+
+func init() {
+	organizationOwnersListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List organization owners",
+		Run:   organizationOwnersListF,
+	}
+
+	organizationOwnersListCmd.Flags().StringVarP(&organizationOwnersListFlags.id, "id", "i", "", "organization id")
+	organizationOwnersListCmd.Flags().StringVarP(&organizationOwnersListFlags.name, "name", "n", "", "organization name")
+
+	organizationOwnersCmd.AddCommand(organizationOwnersListCmd)
+}
+
+// Add Owner
+type OrganizationOwnersAddFlags struct {
+	name    string
+	id      string
+	ownerId string
+}
+
+var organizationOwnersAddFlags OrganizationOwnersAddFlags
+
+func organizationOwnersAddF(cmd *cobra.Command, args []string) {
+	s := &http.OrganizationService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	if organizationOwnersAddFlags.id == "" && organizationOwnersAddFlags.name == "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	filter := platform.OrganizationFilter{}
+	if organizationOwnersAddFlags.name != "" {
+		filter.Name = &organizationOwnersListFlags.name
+	}
+
+	if organizationOwnersAddFlags.id != "" {
+		filter.ID = &platform.ID{}
+		err := filter.ID.DecodeFromString(organizationOwnersAddFlags.id)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	organization, err := s.FindOrganization(context.Background(), filter)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var upd platform.OrganizationUpdate
+	owners := organization.Owners
+
+	updateRequired := false
+	for _, owner := range owners {
+		if owner.String() == organizationOwnersAddFlags.ownerId {
+			updateRequired = true
+			break
+		}
+	}
+
+	if updateRequired {
+		id := &platform.ID{}
+		err := id.DecodeFromString(organizationOwnersAddFlags.ownerId)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		owners = append(owners, *id)
+		upd.Owners = &owners
+
+		_, err = s.UpdateOrganization(context.Background(), organization.ID, upd)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	// TODO: look up each user and output their name
+	w := internal.NewTabWriter(os.Stdout)
+	w.WriteHeaders(
+		"ID",
+	)
+	for _, id := range owners {
+		w.Write(map[string]interface{}{
+			"ID": id.String(),
+		})
+	}
+	w.Flush()
+}
+
+func init() {
+	organizationOwnersAddCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add organization owner",
+		Run:   organizationOwnersAddF,
+	}
+
+	organizationOwnersAddCmd.Flags().StringVarP(&organizationOwnersAddFlags.id, "id", "i", "", "organization id")
+	organizationOwnersAddCmd.Flags().StringVarP(&organizationOwnersAddFlags.name, "name", "n", "", "organization name")
+	organizationOwnersAddCmd.Flags().StringVarP(&organizationOwnersAddFlags.ownerId, "owner", "o", "", "owner id")
+	organizationOwnersAddCmd.MarkFlagRequired("owner")
+
+	organizationOwnersCmd.AddCommand(organizationOwnersAddCmd)
+}
+
+// Delete Owner
+type OrganizationOwnersDeleteFlags struct {
+	name    string
+	id      string
+	ownerId string
+}
+
+var organizationOwnersDeleteFlags OrganizationOwnersDeleteFlags
+
+func organizationOwnersDeleteF(cmd *cobra.Command, args []string) {
+	s := &http.OrganizationService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	if organizationOwnersDeleteFlags.id == "" && organizationOwnersDeleteFlags.name == "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	filter := platform.OrganizationFilter{}
+	if organizationOwnersDeleteFlags.name != "" {
+		filter.Name = &organizationOwnersDeleteFlags.name
+	}
+
+	if organizationOwnersDeleteFlags.id != "" {
+		filter.ID = &platform.ID{}
+		err := filter.ID.DecodeFromString(organizationOwnersDeleteFlags.id)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	organization, err := s.FindOrganization(context.Background(), filter)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var upd platform.OrganizationUpdate
+	owners := organization.Owners
+
+	for i, owner := range owners {
+		if owner.String() == organizationOwnersDeleteFlags.ownerId {
+			updatedOwners := append(owners[:i], owners[i+1:]...)
+			upd.Owners = &updatedOwners
+			_, err = s.UpdateOrganization(context.Background(), organization.ID, upd)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			// TODO: look up each user and output their name
+			w := internal.NewTabWriter(os.Stdout)
+			w.WriteHeaders(
+				"ID",
+			)
+			for _, id := range updatedOwners {
+				w.Write(map[string]interface{}{
+					"ID": id.String(),
+				})
+			}
+			w.Flush()
+
+			break
+		}
+	}
+}
+
+func init() {
+	organizationOwnersDeleteCmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Delete organization owner",
+		Run:   organizationOwnersDeleteF,
+	}
+
+	organizationOwnersDeleteCmd.Flags().StringVarP(&organizationOwnersDeleteFlags.id, "id", "i", "", "organization id")
+	organizationOwnersDeleteCmd.Flags().StringVarP(&organizationOwnersDeleteFlags.name, "name", "n", "", "organization name")
+	organizationOwnersDeleteCmd.Flags().StringVarP(&organizationOwnersDeleteFlags.ownerId, "owner", "o", "", "owner id")
+	organizationOwnersDeleteCmd.MarkFlagRequired("owner")
+
+	organizationOwnersCmd.AddCommand(organizationOwnersDeleteCmd)
+}

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -369,15 +369,15 @@ func organizationOwnersAddF(cmd *cobra.Command, args []string) {
 	var upd platform.OrganizationUpdate
 	owners := organization.Owners
 
-	updateRequired := false
+	ownerExists := false
 	for _, owner := range owners {
-		if owner.String() == organizationOwnersAddFlags.ownerId {
-			updateRequired = true
+		if owner.String() != organizationOwnersAddFlags.ownerId {
+			ownerExists = true
 			break
 		}
 	}
 
-	if updateRequired {
+	if ownerExists {
 		id := &platform.ID{}
 		err := id.DecodeFromString(organizationOwnersAddFlags.ownerId)
 		if err != nil {

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -59,6 +59,59 @@ func taskCreateF(cmd *cobra.Command, args []string) {
 	}
 }
 
+// Find Command
+// TODO: add filter by owner
+type TaskFindFlags struct {
+	id    string
+	orgID string
+}
+
+var taskFindFlags TaskFindFlags
+
+func init() {
+	taskFindCmd := &cobra.Command{
+		Use:   "find",
+		Short: "Find tasks",
+		Run:   taskFindF,
+	}
+
+	taskFindCmd.Flags().StringVarP(&taskFindFlags.id, "id", "i", "", "task ID")
+	taskFindCmd.Flags().StringVarP(&taskFindFlags.orgID, "org-id", "", "", "task organization ID")
+
+	taskCmd.AddCommand(taskFindCmd)
+}
+
+func taskFindF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+}
+
+// Update Command
+type TaskUpdateFlags struct {
+	flux string
+}
+
+func taskUpdateF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+}
+
+// Delete command
+type TaskDeleteFlags struct {
+	id string
+}
+
+func taskDeleteF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+}
+
 // Owner management
 var taskOwnersCmd = &cobra.Command{
 	Use:   "owners",
@@ -250,10 +303,6 @@ func taskOwnersDeleteF(cmd *cobra.Command, args []string) {
 	}
 
 	filter := platform.TaskFilter{}
-	if taskOwnersDeleteFlags.name != "" {
-		filter.Name = &taskOwnersDeleteFlags.name
-	}
-
 	if taskOwnersDeleteFlags.id != "" {
 		filter.ID = &platform.ID{}
 		err := filter.ID.DecodeFromString(taskOwnersDeleteFlags.id)

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -37,7 +37,7 @@ func init() {
 	}
 
 	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.name, "name", "n", "", "task name")
-	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.flux, "flux", "f", "", "ifql to execute")
+	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.flux, "flux", "f", "", "flux to create")
 
 	taskCmd.AddCommand(taskCreateCmd)
 }
@@ -117,14 +117,14 @@ func taskFindF(cmd *cobra.Command, args []string) {
 		"ID",
 		"Name",
 		"Flux",
-		"Retention",
+		"Status",
 	)
 	for _, task := range tasks {
 		w.Write(map[string]interface{}{
-			"ID":        task.ID.String(),
-			"Name":      task.Name,
-			"Flux":      task.Flux,
-			"Retention": task.Status,
+			"ID":     task.ID.String(),
+			"Name":   task.Name,
+			"Flux":   task.Flux,
+			"Status": task.Status,
 		})
 	}
 	w.Flush()
@@ -179,13 +179,13 @@ func taskUpdateF(cmd *cobra.Command, args []string) {
 		"ID",
 		"Name",
 		"Flux",
-		"Retention",
+		"Status",
 	)
 	w.Write(map[string]interface{}{
-		"ID":        task.ID.String(),
-		"Name":      task.Name,
-		"Flux":      task.Flux,
-		"Retention": task.Status,
+		"ID":     task.ID.String(),
+		"Name":   task.Name,
+		"Flux":   task.Flux,
+		"Status": task.Status,
 	})
 	w.Flush()
 }
@@ -239,15 +239,15 @@ func taskDeleteF(cmd *cobra.Command, args []string) {
 		"ID",
 		"Name",
 		"Flux",
-		"Retention",
+		"Status",
 		"Deleted",
 	)
 	w.Write(map[string]interface{}{
-		"ID":        task.ID.String(),
-		"Name":      task.Name,
-		"Flux":      task.Flux,
-		"Retention": task.Status,
-		"Deleted":   true,
+		"ID":      task.ID.String(),
+		"Name":    task.Name,
+		"Flux":    task.Flux,
+		"Status":  task.Status,
+		"Deleted": true,
 	})
 	w.Flush()
 }
@@ -421,31 +421,31 @@ func init() {
 	taskOwnersCmd.AddCommand(taskOwnersAddCmd)
 }
 
-// Delete Owner
-type TaskOwnersDeleteFlags struct {
+// Remove Owner
+type TaskOwnersRemoveFlags struct {
 	name    string
 	id      string
 	ownerId string
 }
 
-var taskOwnersDeleteFlags TaskOwnersDeleteFlags
+var taskOwnersRemoveFlags TaskOwnersRemoveFlags
 
-func taskOwnersDeleteF(cmd *cobra.Command, args []string) {
+func taskOwnersRemoveF(cmd *cobra.Command, args []string) {
 	s := &http.TaskService{
 		Addr:  flags.host,
 		Token: flags.token,
 	}
 
-	if taskOwnersDeleteFlags.id == "" && taskOwnersDeleteFlags.name == "" {
+	if taskOwnersRemoveFlags.id == "" && taskOwnersRemoveFlags.name == "" {
 		fmt.Println("must specify exactly one of id and name")
 		cmd.Usage()
 		os.Exit(1)
 	}
 
 	filter := platform.TaskFilter{}
-	if taskOwnersDeleteFlags.id != "" {
+	if taskOwnersRemoveFlags.id != "" {
 		filter.ID = &platform.ID{}
-		err := filter.ID.DecodeFromString(taskOwnersDeleteFlags.id)
+		err := filter.ID.DecodeFromString(taskOwnersRemoveFlags.id)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -462,7 +462,7 @@ func taskOwnersDeleteF(cmd *cobra.Command, args []string) {
 	owners := task.Owners
 
 	for i, owner := range owners {
-		if owner.String() == taskOwnersDeleteFlags.ownerId {
+		if owner.String() == taskOwnersRemoveFlags.ownerId {
 			updatedOwners := append(owners[:i], owners[i+1:]...)
 			upd.Owners = &updatedOwners
 			_, err = s.UpdateTask(context.Background(), task.ID, upd)
@@ -489,16 +489,16 @@ func taskOwnersDeleteF(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	taskOwnersDeleteCmd := &cobra.Command{
+	taskOwnersRemoveCmd := &cobra.Command{
 		Use:   "remove",
-		Short: "Delete task owner",
-		Run:   taskOwnersDeleteF,
+		Short: "Remove task owner",
+		Run:   taskOwnersRemoveF,
 	}
 
-	taskOwnersDeleteCmd.Flags().StringVarP(&taskOwnersDeleteFlags.id, "id", "i", "", "task id")
-	taskOwnersDeleteCmd.Flags().StringVarP(&taskOwnersDeleteFlags.name, "name", "n", "", "task name")
-	taskOwnersDeleteCmd.Flags().StringVarP(&taskOwnersDeleteFlags.ownerId, "owner", "o", "", "owner id")
-	taskOwnersDeleteCmd.MarkFlagRequired("owner")
+	taskOwnersRemoveCmd.Flags().StringVarP(&taskOwnersRemoveFlags.id, "id", "i", "", "task id")
+	taskOwnersRemoveCmd.Flags().StringVarP(&taskOwnersRemoveFlags.name, "name", "n", "", "task name")
+	taskOwnersRemoveCmd.Flags().StringVarP(&taskOwnersRemoveFlags.ownerId, "owner", "o", "", "owner id")
+	taskOwnersRemoveCmd.MarkFlagRequired("owner")
 
-	taskOwnersCmd.AddCommand(taskOwnersDeleteCmd)
+	taskOwnersCmd.AddCommand(taskOwnersRemoveCmd)
 }

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -367,15 +367,15 @@ func taskOwnersAddF(cmd *cobra.Command, args []string) {
 	var upd platform.TaskUpdate
 	owners := task.Owners
 
-	updateRequired := false
+	ownerExists := false
 	for _, owner := range owners {
-		if owner.String() == taskOwnersAddFlags.ownerId {
-			updateRequired = true
+		if owner.String() != taskOwnersAddFlags.ownerId {
+			ownerExists = true
 			break
 		}
 	}
 
-	if updateRequired {
+	if ownerExists {
 		id := &platform.ID{}
 		err := id.DecodeFromString(taskOwnersAddFlags.ownerId)
 		if err != nil {

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/cmd/influx/internal"
+	"github.com/influxdata/platform/http"
+	"github.com/spf13/cobra"
+)
+
+var taskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "task related commands",
+	Run:   taskF,
+}
+
+func taskF(cmd *cobra.Command, args []string) {
+	cmd.Usage()
+}
+
+// Create Command
+type TaskCreateFlags struct {
+	name string
+	flux string
+}
+
+var taskCreateFlags TaskCreateFlags
+
+func init() {
+	taskCreateCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create task",
+		Run:   taskCreateF,
+	}
+
+	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.name, "name", "n", "", "task name")
+	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.flux, "flux", "f", "", "ifql to execute")
+
+	taskCmd.AddCommand(taskCreateCmd)
+}
+
+func taskCreateF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	t := &platform.Task{
+		Name: taskCreateFlags.name,
+		Flux: taskCreateFlags.flux,
+	}
+
+	if err := s.CreateTask(context.Background(), t); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// Owner management
+var taskOwnersCmd = &cobra.Command{
+	Use:   "owners",
+	Short: "task ownership commands",
+	Run:   taskF,
+}
+
+func init() {
+	taskCmd.AddCommand(taskOwnersCmd)
+}
+
+// List Owners
+type TaskOwnersListFlags struct {
+	name string
+	id   string
+}
+
+var taskOwnersListFlags TaskOwnersListFlags
+
+func taskOwnersListF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	if taskOwnersListFlags.id == "" && taskOwnersListFlags.name == "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	filter := platform.TaskFilter{}
+	if taskOwnersListFlags.id != "" {
+		filter.ID = &platform.ID{}
+		err := filter.ID.DecodeFromString(taskOwnersListFlags.id)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	task, err := s.FindTask(context.Background(), filter)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	owners := task.Owners
+
+	// TODO: look up each user and output their name
+	w := internal.NewTabWriter(os.Stdout)
+	w.WriteHeaders(
+		"ID",
+	)
+	for _, id := range owners {
+		w.Write(map[string]interface{}{
+			"ID": id.String(),
+		})
+	}
+	w.Flush()
+}
+
+func init() {
+	taskOwnersListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List task owners",
+		Run:   taskOwnersListF,
+	}
+
+	taskOwnersListCmd.Flags().StringVarP(&taskOwnersListFlags.id, "id", "i", "", "task id")
+	taskOwnersListCmd.Flags().StringVarP(&taskOwnersListFlags.name, "name", "n", "", "task name")
+
+	taskOwnersCmd.AddCommand(taskOwnersListCmd)
+}
+
+// Add Owner
+type TaskOwnersAddFlags struct {
+	name    string
+	id      string
+	ownerId string
+}
+
+var taskOwnersAddFlags TaskOwnersAddFlags
+
+func taskOwnersAddF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	if taskOwnersAddFlags.id == "" && taskOwnersAddFlags.name == "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	filter := platform.TaskFilter{}
+	if taskOwnersAddFlags.id != "" {
+		filter.ID = &platform.ID{}
+		err := filter.ID.DecodeFromString(taskOwnersAddFlags.id)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	task, err := s.FindTask(context.Background(), filter)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var upd platform.TaskUpdate
+	owners := task.Owners
+
+	updateRequired := false
+	for _, owner := range owners {
+		if owner.String() == taskOwnersAddFlags.ownerId {
+			updateRequired = true
+			break
+		}
+	}
+
+	if updateRequired {
+		id := &platform.ID{}
+		err := id.DecodeFromString(taskOwnersAddFlags.ownerId)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		owners = append(owners, *id)
+		upd.Owners = &owners
+
+		_, err = s.UpdateTask(context.Background(), task.ID, upd)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	// TODO: look up each user and output their name
+	w := internal.NewTabWriter(os.Stdout)
+	w.WriteHeaders(
+		"ID",
+	)
+	for _, id := range owners {
+		w.Write(map[string]interface{}{
+			"ID": id.String(),
+		})
+	}
+	w.Flush()
+}
+
+func init() {
+	taskOwnersAddCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add task owner",
+		Run:   taskOwnersAddF,
+	}
+
+	taskOwnersAddCmd.Flags().StringVarP(&taskOwnersAddFlags.id, "id", "i", "", "task id")
+	taskOwnersAddCmd.Flags().StringVarP(&taskOwnersAddFlags.name, "name", "n", "", "task name")
+	taskOwnersAddCmd.Flags().StringVarP(&taskOwnersAddFlags.ownerId, "owner", "o", "", "owner id")
+	taskOwnersAddCmd.MarkFlagRequired("owner")
+
+	taskOwnersCmd.AddCommand(taskOwnersAddCmd)
+}
+
+// Delete Owner
+type TaskOwnersDeleteFlags struct {
+	name    string
+	id      string
+	ownerId string
+}
+
+var taskOwnersDeleteFlags TaskOwnersDeleteFlags
+
+func taskOwnersDeleteF(cmd *cobra.Command, args []string) {
+	s := &http.TaskService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}
+
+	if taskOwnersDeleteFlags.id == "" && taskOwnersDeleteFlags.name == "" {
+		fmt.Println("must specify exactly one of id and name")
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	filter := platform.TaskFilter{}
+	if taskOwnersDeleteFlags.name != "" {
+		filter.Name = &taskOwnersDeleteFlags.name
+	}
+
+	if taskOwnersDeleteFlags.id != "" {
+		filter.ID = &platform.ID{}
+		err := filter.ID.DecodeFromString(taskOwnersDeleteFlags.id)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	task, err := s.FindTask(context.Background(), filter)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var upd platform.TaskUpdate
+	owners := task.Owners
+
+	for i, owner := range owners {
+		if owner.String() == taskOwnersDeleteFlags.ownerId {
+			updatedOwners := append(owners[:i], owners[i+1:]...)
+			upd.Owners = &updatedOwners
+			_, err = s.UpdateTask(context.Background(), task.ID, upd)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			// TODO: look up each user and output their name
+			w := internal.NewTabWriter(os.Stdout)
+			w.WriteHeaders(
+				"ID",
+			)
+			for _, id := range updatedOwners {
+				w.Write(map[string]interface{}{
+					"ID": id.String(),
+				})
+			}
+			w.Flush()
+
+			break
+		}
+	}
+}
+
+func init() {
+	taskOwnersDeleteCmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Delete task owner",
+		Run:   taskOwnersDeleteF,
+	}
+
+	taskOwnersDeleteCmd.Flags().StringVarP(&taskOwnersDeleteFlags.id, "id", "i", "", "task id")
+	taskOwnersDeleteCmd.Flags().StringVarP(&taskOwnersDeleteFlags.name, "name", "n", "", "task name")
+	taskOwnersDeleteCmd.Flags().StringVarP(&taskOwnersDeleteFlags.ownerId, "owner", "o", "", "owner id")
+	taskOwnersDeleteCmd.MarkFlagRequired("owner")
+
+	taskOwnersCmd.AddCommand(taskOwnersDeleteCmd)
+}

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -270,18 +270,18 @@ func (h *BucketHandler) handleGetOwners(w http.ResponseWriter, r *http.Request) 
 
 	req, err := decodeGetOwnersRequest(ctx, r)
 	if err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 
 	owners, err := h.BucketService.GetBucketOwners(ctx, req.BucketID)
 	if err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, owners); err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 }
@@ -313,17 +313,17 @@ func (h *BucketHandler) handlePostOwner(w http.ResponseWriter, r *http.Request) 
 
 	req, err := decodePostOwnerRequest(ctx, r)
 	if err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 
 	if err := h.BucketService.AddBucketOwner(ctx, req.BucketID, req.Owner); err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, req.Owner); err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 }
@@ -361,12 +361,12 @@ func (h *BucketHandler) handleDeleteOwner(w http.ResponseWriter, r *http.Request
 
 	req, err := decodeDeleteOwnerRequest(ctx, r)
 	if err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 
 	if err := h.BucketService.RemoveBucketOwner(ctx, req.BucketID, req.OwnerID); err != nil {
-		kerrors.EncodeHTTP(ctx, err, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 
@@ -611,7 +611,7 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id platform.ID) error 
 	return CheckError(resp)
 }
 
-func (s *BucketService) AddBucketOwner(ctx context.Context, bucketID platform.ID, owner platform.owner) error {
+func (s *BucketService) AddBucketOwner(ctx context.Context, bucketID platform.ID, owner platform.Owner) error {
 	u, err := newURL(s.Addr, bucketOwnerPath(bucketID))
 	if err != nil {
 		return err
@@ -671,7 +671,7 @@ func (s *BucketService) GetBucketOwners(ctx context.Context, bucketID platform.I
 		return nil, err
 	}
 
-	var owners []*platform.Owner
+	var owners *[]platform.Owner
 	if err := json.NewDecoder(resp.Body).Decode(&owners); err != nil {
 		return nil, err
 	}

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -611,7 +611,7 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id platform.ID) error 
 	return CheckError(resp)
 }
 
-func (s *BucketService) AddBucketOwner(ctx context.Context, bucketID platform.ID, owner platform.Owner) error {
+func (s *BucketService) AddBucketOwner(ctx context.Context, bucketID platform.ID, owner *platform.Owner) error {
 	u, err := newURL(s.Addr, bucketOwnerPath(bucketID))
 	if err != nil {
 		return err

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -464,6 +464,14 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id platform.ID) error 
 	return CheckError(resp)
 }
 
+func (s *BucketService) AddBucketOwner(ctx context.Context, bucketID platform.ID, ownerID platform.ID) error {
+
+}
+
+func (s *BucketService) RemoveBucketOwner(ctx context.Context, bucketID platform.ID, ownerID platform.ID) error {
+
+}
+
 func bucketIDPath(id platform.ID) string {
 	return path.Join(bucketPath, id.String())
 }

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -13,6 +13,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+const bucketPath = "/v1/buckets"
+
 // BucketHandler represents an HTTP API handler for buckets.
 type BucketHandler struct {
 	*httprouter.Router
@@ -258,10 +260,6 @@ func decodePatchBucketRequest(ctx context.Context, r *http.Request) (*patchBucke
 		BucketID: i,
 	}, nil
 }
-
-const (
-	bucketPath = "/v1/buckets"
-)
 
 // BucketService connects to Influx via HTTP using tokens to manage buckets
 type BucketService struct {

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -421,6 +421,18 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, id platfor
 	return CheckError(resp)
 }
 
+func (s *OrganizationService) GetOrganizationOwners(ctx context.Context, orgId platform.ID) (*[]platform.Owner, error) {
+	return &[]platform.Owner{}, nil
+}
+
+func (s *OrganizationService) AddOrganizationOwner(ctx context.Context, orgId platform.ID, owner *platform.Owner) error {
+	return nil
+}
+
+func (s *OrganizationService) RemoveOrganizationOwner(ctx context.Context, orgId platform.ID, ownerId platform.ID) error {
+	return nil
+}
+
 func organizationIDPath(id platform.ID) string {
 	return path.Join(organizationPath, id.String())
 }

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -671,6 +671,90 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  '/tasks/{taskId}/owners':
+    get:
+      tags:
+        - Tasks
+      summary: Get list of task owners
+      parameters:
+        - in: path
+          name: taskId
+          schema:
+            type: string
+          required: true
+          description: ID of task
+      responses:
+        '200':
+          description: list of task owners
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Owners"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags:
+        - Tasks
+      summary: Add an owner to a task
+      requestBody:
+        description: owner to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+      parameters:
+        - in: path
+          name: taskId
+          schema:
+            type: string
+          required: true
+          description: ID of task
+      responses:
+        '200':
+          description: list of task owners
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Owners"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/tasks/{taskId}/owners/{ownerId}':
+    delete:
+      tags:
+        - Tasks
+      summary: Remove a task owner
+      description: Removes a user from the list of owners for a task
+      parameters:
+        - in: path
+          name: taskId
+          schema:
+            type: string
+          required: true
+          description: ID of task
+        - in: path
+          name: ownerId
+          schema:
+            type: string
+          required: true
+          description: ID of owner to remove
+      responses:
+        '204':
+          description: owner removed
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   '/tasks/{taskId}/runs':
     get:
       tags:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -429,6 +429,89 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  '/buckets/{bucketId}/owners':
+    get:
+      tags:
+        - Buckets
+      summary: Get list of bucket owners
+      parameters:
+        - in: path
+          name: bucketId
+          schema:
+            type: string
+          required: true
+          description: ID of bucket
+      responses:
+        '200':
+          description: list of bucket owners
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Owners"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags:
+        - Buckets
+      summary: Add an owner to a bucket
+      requestBody:
+        description: owner to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+      parameters:
+        - in: path
+          name: bucketId
+          schema:
+            type: string
+          required: true
+          description: ID of bucket
+      responses:
+        '201':
+          description: owner added
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Owners"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/buckets/{bucketId}/owners/{ownerId}':
+    delete:
+      tags:
+        - Buckets
+      summary: Remove a bucket owner
+      parameters:
+        - in: path
+          name: bucketId
+          schema:
+            type: string
+          required: true
+          description: ID of bucket
+        - in: path
+          name: ownerId
+          schema:
+            type: string
+          required: true
+          description: ID of owner to remove
+      responses:
+        '204':
+          description: owner removed
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /orgs:
     get:
       tags:
@@ -684,8 +767,8 @@ paths:
           required: true
           description: ID of task
       responses:
-        '200':
-          description: list of task owners
+        '201':
+          description: owner added
           content:
             application/json:
               schema:

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -657,6 +657,18 @@ func (s *TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 	return CheckError(resp)
 }
 
+func (s *TaskService) GetTaskOwners(ctx context.Context, taskId platform.ID) (*[]platform.Owner, error) {
+	return &[]platform.Owner{}, nil
+}
+
+func (s *TaskService) AddTaskOwner(ctx context.Context, taskId platform.ID, owner *platform.Owner) error {
+	return nil
+}
+
+func (s *TaskService) RemoveTaskOwner(ctx context.Context, taskId platform.ID, ownerId platform.ID) error {
+	return nil
+}
+
 func taskIDPath(id platform.ID) string {
 	return path.Join(taskPath, id.String())
 }

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"path"
 	"strconv"
@@ -503,6 +504,19 @@ func (s *TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfo
 	defer resp.Body.Close()
 
 	return &task, nil
+}
+
+func (s *TaskService) FindTask(ctx context.Context, filter platform.TaskFilter) (*platform.Task, error) {
+	tasks, n, err := s.FindTasks(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if n == 0 {
+		return nil, errors.New("found no matching tasks")
+	}
+
+	return tasks[0], nil
 }
 
 func (s *TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -35,8 +35,6 @@ func NewTaskHandler() *TaskHandler {
 	h.HandlerFunc("PATCH", "/v1/tasks/:tid", h.handleUpdateTask)
 	h.HandlerFunc("DELETE", "/v1/tasks/:tid", h.handleDeleteTask)
 
-	h.HandlerFunc("GET")
-
 	h.HandlerFunc("GET", "/v1/tasks/:tid/logs", h.handleGetLogs)
 	h.HandlerFunc("GET", "/v1/tasks/:tid/runs/:rid/logs", h.handleGetLogs)
 

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -35,6 +35,8 @@ func NewTaskHandler() *TaskHandler {
 	h.HandlerFunc("PATCH", "/v1/tasks/:tid", h.handleUpdateTask)
 	h.HandlerFunc("DELETE", "/v1/tasks/:tid", h.handleDeleteTask)
 
+	h.HandlerFunc("GET")
+
 	h.HandlerFunc("GET", "/v1/tasks/:tid/logs", h.handleGetLogs)
 	h.HandlerFunc("GET", "/v1/tasks/:tid/runs/:rid/logs", h.handleGetLogs)
 

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -485,7 +485,7 @@ func (s *TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfo
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", s.Token)
+	req.Header.Set("Authorization", "Token "+s.Token)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -539,7 +539,7 @@ func (s *TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter)
 	}
 
 	req.URL.RawQuery = query.Encode()
-	req.Header.Set("Authorization", s.Token)
+	req.Header.Set("Authorization", "Token "+s.Token)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -577,7 +577,7 @@ func (s *TaskService) CreateTask(ctx context.Context, task *platform.Task) error
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", s.Token)
+	req.Header.Set("Authorization", "Token "+s.Token)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 
@@ -615,7 +615,7 @@ func (s *TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platfo
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", s.Token)
+	req.Header.Set("Authorization", "Token "+s.Token)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 
@@ -647,7 +647,7 @@ func (s *TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", s.Token)
+	req.Header.Set("Authorization", "Token "+s.Token)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(req)

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -462,3 +462,10 @@ func decodeRetryRunRequest(ctx context.Context, r *http.Request) (*retryRunReque
 		RunID: i,
 	}, nil
 }
+
+// TaskService connects to Influx via HTTP using tokens to manage tasks
+type TaskService struct {
+	Addr               string
+	Token              string
+	InsecureSkipVerify bool
+}

--- a/organization.go
+++ b/organization.go
@@ -32,7 +32,9 @@ type OrganizationService interface {
 	DeleteOrganization(ctx context.Context, id ID) error
 
 	// AddOrganizationOwner adds a new owner to a bucket.
-	AddOrganizationOwner(ctx context.Context, orgID ID, ownerID ID) error
+	AddOrganizationOwner(ctx context.Context, orgID ID, owner *Owner) error
+
+	GetOrganizationOwners(ctx context.Context, orgID ID) (*[]Owner, error)
 
 	// RemoveOrganizationOwner removes an owner from a bucket.
 	RemoveOrganizationOwner(ctx context.Context, orgID ID, ownerID ID) error

--- a/organization.go
+++ b/organization.go
@@ -4,8 +4,9 @@ import "context"
 
 // Organization is a organization. 🎉
 type Organization struct {
-	ID   ID     `json:"id"`
-	Name string `json:"name"`
+	ID     ID     `json:"id"`
+	Name   string `json:"name"`
+	Owners []ID   `json:"owners"`
 }
 
 // OrganizationService represents a service for managing organization data.
@@ -34,7 +35,8 @@ type OrganizationService interface {
 // OrganizationUpdate represents updates to a organization.
 // Only fields which are set are updated.
 type OrganizationUpdate struct {
-	Name *string
+	Name   *string
+	Owners *[]ID
 }
 
 // OrganizationFilter represents a set of filter that restrict the returned results.

--- a/organization.go
+++ b/organization.go
@@ -4,9 +4,9 @@ import "context"
 
 // Organization is a organization. 🎉
 type Organization struct {
-	ID     ID     `json:"id"`
-	Name   string `json:"name"`
-	Owners []ID   `json:"owners"`
+	ID     ID      `json:"id"`
+	Name   string  `json:"name"`
+	Owners []Owner `json:"owners"`
 }
 
 // OrganizationService represents a service for managing organization data.

--- a/organization.go
+++ b/organization.go
@@ -30,13 +30,18 @@ type OrganizationService interface {
 
 	// Removes a organization by ID.
 	DeleteOrganization(ctx context.Context, id ID) error
+
+	// AddOrganizationOwner adds a new owner to a bucket.
+	AddOrganizationOwner(ctx context.Context, orgID ID, ownerID ID) error
+
+	// RemoveOrganizationOwner removes an owner from a bucket.
+	RemoveOrganizationOwner(ctx context.Context, orgID ID, ownerID ID) error
 }
 
 // OrganizationUpdate represents updates to a organization.
 // Only fields which are set are updated.
 type OrganizationUpdate struct {
-	Name   *string
-	Owners *[]ID
+	Name *string
 }
 
 // OrganizationFilter represents a set of filter that restrict the returned results.

--- a/owner.go
+++ b/owner.go
@@ -1,0 +1,5 @@
+package platform
+
+type Owner struct {
+  ID ID
+}

--- a/task.go
+++ b/task.go
@@ -34,6 +34,9 @@ type TaskService interface {
 	// Returns a single task
 	FindTaskByID(ctx context.Context, id ID) (*Task, error)
 
+	// FindTask returns the first task that matches a filter.
+	FindTask(ctx context.Context, filter TaskFilter) (*Task, error)
+
 	// Returns a list of tasks that match a filter (limit 100) and the total count
 	// of matching tasks.
 	FindTasks(ctx context.Context, filter TaskFilter) ([]*Task, int, error)

--- a/task.go
+++ b/task.go
@@ -51,7 +51,7 @@ type TaskService interface {
 	DeleteTask(ctx context.Context, id ID) error
 
 	// AddTaskOwner adds a new owner to a task.
-	AddTaskOwner(ctx context.Context, taskID ID, ownerID ID) error
+	AddTaskOwner(ctx context.Context, taskID ID, owner *Owner) error
 
 	// RemoveTaskOwner removes an owner from a task.
 	RemoveTaskOwner(ctx context.Context, taskID ID, ownerID ID) error

--- a/task.go
+++ b/task.go
@@ -50,6 +50,12 @@ type TaskService interface {
 	// Removes a task by ID and purges all associated data and scheduled runs
 	DeleteTask(ctx context.Context, id ID) error
 
+	// AddTaskOwner adds a new owner to a task.
+	AddTaskOwner(ctx context.Context, taskID ID, ownerID ID) error
+
+	// RemoveTaskOwner removes an owner from a task.
+	RemoveTaskOwner(ctx context.Context, taskID ID, ownerID ID) error
+
 	// Returns logs for a run.
 	FindLogs(ctx context.Context, filter LogFilter) ([]*Log, int, error)
 
@@ -65,8 +71,7 @@ type TaskService interface {
 
 // TaskUpdate represents updates to a task
 type TaskUpdate struct {
-	Flux   *string `json:"flux"`
-	Owners *[]ID   `json:"owners"`
+	Flux *string `json:"flux"`
 }
 
 // TaskFilter represents a set of filters that restrict the returned results

--- a/task.go
+++ b/task.go
@@ -4,16 +4,16 @@ import "context"
 
 // Task is a task. 🎊
 type Task struct {
-	ID           ID     `json:"id,omitempty"`
-	Organization ID     `json:"organizationId"`
-	Name         string `json:"name"`
-	Status       string `json:"status"`
-	Owner        User   `json:"owner"`
-	Flux         string `json:"flux"`
-	Every        string `json:"every,omitempty"`
-	Cron         string `json:"cron,omitempty"`
-	Last         Run    `json:"last,omitempty"`
-	Owners       []ID   `json:"owners"`
+	ID           ID      `json:"id,omitempty"`
+	Organization ID      `json:"organizationId"`
+	Name         string  `json:"name"`
+	Status       string  `json:"status"`
+	Owner        User    `json:"owner"`
+	Flux         string  `json:"flux"`
+	Every        string  `json:"every,omitempty"`
+	Cron         string  `json:"cron,omitempty"`
+	Last         Run     `json:"last,omitempty"`
+	Owners       []Owner `json:"owners"`
 }
 
 // Run is a record created when a run of a task is queued.

--- a/task.go
+++ b/task.go
@@ -13,6 +13,7 @@ type Task struct {
 	Every        string `json:"every,omitempty"`
 	Cron         string `json:"cron,omitempty"`
 	Last         Run    `json:"last,omitempty"`
+	Owners       []ID   `json:"owners"`
 }
 
 // Run is a record created when a run of a task is queued.
@@ -61,11 +62,13 @@ type TaskService interface {
 
 // TaskUpdate represents updates to a task
 type TaskUpdate struct {
-	Flux *string `json:"flux"`
+	Flux   *string `json:"flux"`
+	Owners *[]ID   `json:"owners"`
 }
 
 // TaskFilter represents a set of filters that restrict the returned results
 type TaskFilter struct {
+	ID           *ID
 	After        *ID
 	Organization *ID
 	User         *ID


### PR DESCRIPTION
This implements bucket owners as a simple slice of IDs.

Almost all of the work here is on the `cmd` interface:

`bucket owners list --id=123`
`bucket owners list --name=mybucket`
`bucket owners add --name=mybucket --owner=456`
`bucket owners remove --name=mybucket --owner=456`