### PR TITLE
Retrieve and set optional query paramaters from global scope

### DIFF
--- a/query/compile.go
+++ b/query/compile.go
@@ -61,7 +61,7 @@ func Compile(ctx context.Context, q string, opts ...Option) (*Spec, error) {
 		return nil, err
 	}
 
-	if err := interpreter.Eval(semProg, interpScope); err != nil {
+	if _, err := interpreter.Eval(semProg, interpScope, nil); err != nil {
 		return nil, err
 	}
 	spec := qd.ToSpec()
@@ -284,11 +284,13 @@ func builtIns(qd *queryDomain) (map[string]values.Value, semantic.DeclarationSco
 			panic(errors.Wrapf(err, "failed to create semantic graph for builtin %q", name))
 		}
 
-		if err := interpreter.Eval(semProg, interpScope); err != nil {
+		if err := interpreter.EvalBuiltIn(semProg, interpScope); err != nil {
 			panic(errors.Wrapf(err, "failed to evaluate builtin %q", name))
 		}
 	}
-	return scope, decls
+	// TODO(Josh): I think we only need the values in
+	// the top-level scope, but not totally sure about this.
+	return interpScope.GetValues(), decls
 }
 
 type Administration struct {

--- a/query/repl/repl.go
+++ b/query/repl/repl.go
@@ -48,7 +48,7 @@ func addBuiltIn(script string, scope *interpreter.Scope, declarations semantic.D
 		return errors.Wrap(err, "failed to create semantic graph for builtin")
 	}
 
-	if err := interpreter.Eval(semProg, scope); err != nil {
+	if _, err := interpreter.Eval(semProg, scope, nil); err != nil {
 		return errors.Wrap(err, "failed to evaluate builtin")
 	}
 	return nil
@@ -170,7 +170,7 @@ func (r *REPL) executeLine(t string, expectYield bool) (values.Value, error) {
 		return nil, err
 	}
 
-	if err := interpreter.Eval(semProg, r.scope); err != nil {
+	if _, err := interpreter.Eval(semProg, r.scope, nil); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This commit adds Flux options as a separate entity to the scope, as well as an interface for getting and setting options at the current scope. The interpreter uses this interface to add any external options to the scope before evaluating the program, and to return all options available to the current scope after program evaluation. 

There is still a question of whether getting and setting options should only be valid at the global scope.