### PR TITLE
feat(query): Change Encode interface to return bytes written

### DIFF
--- a/http/transpiler_handler.go
+++ b/http/transpiler_handler.go
@@ -86,5 +86,6 @@ func encodeResult(w http.ResponseWriter, results query.ResultIterator, contentTy
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
 
-	return encoder.Encode(w, results)
+	_, err := encoder.Encode(w, results)
+	return err
 }

--- a/query/csv/result_test.go
+++ b/query/csv/result_test.go
@@ -517,13 +517,16 @@ func TestResultEncoder(t *testing.T) {
 			}
 			encoder := csv.NewResultEncoder(tc.encoderConfig)
 			var got bytes.Buffer
-			err := encoder.Encode(&got, tc.result)
+			n, err := encoder.Encode(&got, tc.result)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if g, w := got.String(), string(tc.encoded); g != w {
 				t.Errorf("unexpected encoding -want/+got:\n%s", diff.LineDiff(w, g))
+			}
+			if g, w := n, int64(len(tc.encoded)); g != w {
+				t.Errorf("unexpected encoding count -want/+got:\n%s", cmp.Diff(w, g))
 			}
 		})
 	}
@@ -680,13 +683,16 @@ test error,
 		t.Run(tc.name, func(t *testing.T) {
 			encoder := csv.NewMultiResultEncoder(tc.config)
 			var got bytes.Buffer
-			err := encoder.Encode(&got, tc.results)
+			n, err := encoder.Encode(&got, tc.results)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if g, w := got.String(), string(tc.encoded); g != w {
 				t.Errorf("unexpected encoding -want/+got:\n%s", diff.LineDiff(w, g))
+			}
+			if g, w := n, int64(len(tc.encoded)); g != w {
+				t.Errorf("unexpected encoding count -want/+got:\n%s", cmp.Diff(w, g))
 			}
 		})
 	}

--- a/query/iocounter/counter.go
+++ b/query/iocounter/counter.go
@@ -1,0 +1,6 @@
+package iocounter
+
+// Counter counts a number of bytes during an IO operation.
+type Counter interface {
+	Count() int64
+}

--- a/query/iocounter/writer.go
+++ b/query/iocounter/writer.go
@@ -1,0 +1,22 @@
+package iocounter
+
+import (
+	"io"
+)
+
+// Writer is counter for io.Writer
+type Writer struct {
+	io.Writer
+	count int64
+}
+
+func (c *Writer) Write(buf []byte) (int, error) {
+	n, err := c.Writer.Write(buf)
+	c.count += int64(n)
+	return n, err
+}
+
+// Count function return counted bytes
+func (c *Writer) Count() int64 {
+	return c.count
+}

--- a/query/querytest/execute.go
+++ b/query/querytest/execute.go
@@ -42,7 +42,7 @@ func GetQueryEncodedResults(qs query.QueryService, spec *query.Spec, inputFile s
 	}
 
 	buf := new(bytes.Buffer)
-	if err := enc.Encode(buf, results); err != nil {
+	if _, err := enc.Encode(buf, results); err != nil {
 		return "", err
 	}
 	return buf.String(), results.Err()


### PR DESCRIPTION
The bytes written count is used to know if an HTTP handler can safely write its own HTTP status code in the event of an error.