### PR TITLE
chore(query): remove id package

### DIFF
--- a/query/execute/transformation.go
+++ b/query/execute/transformation.go
@@ -3,8 +3,8 @@ package execute
 import (
 	"fmt"
 
+	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/query"
-	"github.com/influxdata/platform/query/id"
 	"github.com/influxdata/platform/query/plan"
 )
 
@@ -17,7 +17,7 @@ type Transformation interface {
 }
 
 type Administration interface {
-	OrganizationID() id.ID
+	OrganizationID() platform.ID
 
 	ResolveTime(qt query.Time) Time
 	Bounds() Bounds

--- a/query/id/id.go
+++ b/query/id/id.go
@@ -1,8 +1,0 @@
-// Package id exports one type, ID, which is aliased to github.com/influxdata/platform.ID.
-// This package was introduced when the query code was in the separate ifql repository,
-// and this type alias is provided only temporarily until other repositories have migrated to platform.ID.
-package id
-
-import "github.com/influxdata/platform"
-
-type ID = platform.ID


### PR DESCRIPTION
Finishes up work started in #145, now that our internal dependencies no
longer refer to plaform/query/id.