### PR TITLE
fix(http): Fix status class when WriteHeader was not called

### DIFF
--- a/http/status.go
+++ b/http/status.go
@@ -13,7 +13,7 @@ func newStatusResponseWriter(w http.ResponseWriter) *statusResponseWriter {
 	}
 }
 
-// WriteHeader writes
+// WriteHeader writes the header and captures the status code.
 func (w *statusResponseWriter) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
 	w.ResponseWriter.WriteHeader(statusCode)
@@ -24,7 +24,8 @@ func (w *statusResponseWriter) statusCodeClass() string {
 	switch w.statusCode / 100 {
 	case 1:
 		class = "1XX"
-	case 2:
+	case 0, 2:
+		// When statusCode is 0 then WriteHeader was never called and we can assume that the ResponseWriter wrote an http.StatusOK.
 		class = "2XX"
 	case 3:
 		class = "3XX"


### PR DESCRIPTION
This change fixes the `XXX` status classes that are present in the metrics. The `XXX` class indicate that the response writer did not know what the status code was. Based on the docs https://golang.org/pkg/net/http/#ResponseWriter we can assume a 200 was written. All status code are >= 100 so this is safe.