### PR TITLE
feat(query): result encoders convert truncated storage-layer column labels to human readable values

### DIFF
--- a/query/csv/result.go
+++ b/query/csv/result.go
@@ -788,7 +788,7 @@ func writeSchema(writer *csv.Writer, c *ResultEncoderConfig, row []string, cols 
 	if !c.NoHeader {
 		// Write labels header
 		for j, c := range cols {
-			row[j] = c.Label
+			row[j] = deNormalizeColName(c.Label)
 		}
 		writer.Write(row)
 	}
@@ -864,6 +864,21 @@ func writeDefaults(writer *csv.Writer, row, defaults []string) error {
 		}
 	}
 	return writer.Write(row)
+}
+
+func deNormalizeColName(colName string) string {
+	switch colName {
+	case "_m!":
+		return "_m"
+	case "_f!":
+		return "_f"
+	case "_m":
+		return "_measurement"
+	case "_f":
+		return "_field"
+	default:
+		return colName
+	}
 }
 
 func decodeValue(value string, c colMeta) (values.Value, error) {

--- a/query/influxql/result.go
+++ b/query/influxql/result.go
@@ -51,7 +51,7 @@ func (e *MultiResultEncoder) Encode(w io.Writer, results query.ResultIterator) (
 					return fmt.Errorf("partition column %q is not a string type", c.Label)
 				}
 				v := b.Key().Value(j).Str()
-				if c.Label == "_measurement" {
+				if c.Label == "_measurement" || c.Label == "_m" {
 					row.Name = v
 				} else {
 					if row.Tags == nil {


### PR DESCRIPTION
required for an update on idpe: https://github.com/influxdata/idpe/pull/990