### PR TITLE
feat(query/influxql): support for group by

### DIFF
--- a/query/influxql/result_test.go
+++ b/query/influxql/result_test.go
@@ -34,7 +34,7 @@ func TestMultiResultEncoder_Encode(t *testing.T) {
 							{Label: "value", Type: query.TFloat},
 						},
 						Data: [][]interface{}{
-							{mustParseTime("2018-05-24T09:00:00Z"), "m0", "server01", float64(2)},
+							{ts("2018-05-24T09:00:00Z"), "m0", "server01", float64(2)},
 						},
 					}},
 				}},
@@ -81,10 +81,15 @@ func (ri *resultErrorIterator) Err() error {
 	return errors.New(ri.Error)
 }
 
-func mustParseTime(s string) execute.Time {
+func mustParseTime(s string) time.Time {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		panic(err)
 	}
-	return execute.Time(t.UnixNano())
+	return t
+}
+
+// ts takes an RFC3339 time string and returns an execute.Time from it using the unix timestamp.
+func ts(s string) execute.Time {
+	return execute.Time(mustParseTime(s).UnixNano())
 }

--- a/query/querytest/query_test.go
+++ b/query/querytest/query_test.go
@@ -18,7 +18,6 @@ import (
 var skipTests = map[string]string{
 	"derivative":                "derivative not supported by influxql (https://github.com/influxdata/platform/issues/93)",
 	"filter_by_tags":            "arbitrary filtering not supported by influxql (https://github.com/influxdata/platform/issues/94)",
-	"group_ungroup":             "influxql/flux disagreement on keycols (https://github.com/influxdata/platform/issues/95)",
 	"window":                    "ordering of results differs between queries (https://github.com/influxdata/platform/issues/96)",
 	"window_group_mean_ungroup": "error in influxql: failed to run query: timeValue column \"_start\" does not exist (https://github.com/influxdata/platform/issues/97)",
 }

--- a/query/querytest/test_cases/group.flux
+++ b/query/querytest/test_cases/group.flux
@@ -1,3 +1,7 @@
 from(db:"testdb")
   |> range(start: 2018-05-23T13:09:22.885021542Z)
-  |> group(by: ["name"])
+  |> filter(fn: (r) => r._measurement == "diskio" and r._field == "io_time")
+  |> group(by: ["_measurement", "name"])
+  |> max()
+  |> map(fn: (r) => {_time: r._time, max: r._value})
+  |> yield(name: "0")

--- a/query/querytest/test_cases/group.influxql
+++ b/query/querytest/test_cases/group.influxql
@@ -1,0 +1,1 @@
+SELECT max(io_time) FROM testdb..diskio GROUP BY "name"

--- a/query/querytest/test_cases/group.out.csv
+++ b/query/querytest/test_cases/group.out.csv
@@ -1,17 +1,7 @@
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
-#partition,false,false,false,false,false,false,false,false,false,true
-#default,_result,,,,,,,,,
-,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
-,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
-,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
-,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
-,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
-,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
-,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
-,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
-,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
-,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
-,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
-,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:06Z,648,io_time,diskio,host.local,disk2
-,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:16Z,648,io_time,diskio,host.local,disk2
+#datatype,string,long,string,string,dateTime:RFC3339,long
+#partition,false,false,true,true,false,false
+#default,0,,,,,
+,result,table,_measurement,name,_time,max
+,,0,diskio,disk0,2018-05-22T19:54:16Z,15205755
+,,1,diskio,disk2,2018-05-22T19:53:26Z,648
 

--- a/query/querytest/test_cases/group_ungroup.influxql
+++ b/query/querytest/test_cases/group_ungroup.influxql
@@ -1,1 +1,0 @@
-select io_time from testdb..diskio group by "name"


### PR DESCRIPTION
The transpiler now supports grouping by tags.

Fixes #95.