### PR TITLE
chore(vendor): update tdigest library fixing percentile panics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -371,7 +371,7 @@
   branch = "master"
   name = "github.com/influxdata/tdigest"
   packages = ["."]
-  revision = "617b83f940fd9acd207f712561a8a0590277fb38"
+  revision = "a7d76c6f093a59b94a01c6c2b8429122d444a8cc"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
@@ -758,6 +758,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "386ae3e065a4de07944b9c04b34a23918a3788df6788870e0a8ce5405205ff1f"
+  inputs-digest = "3f8fd8ca672e7b714bab7f109f469ad1a6ffb69f2452736747e6d40a5bad5776"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,6 +40,9 @@ required = [
   name = "github.com/influxdata/influxdb"
   branch = "master"
 
+[[constraint]]
+  name = "github.com/influxdata/tdigest"
+  branch = "master"
 
 # Pigeon hasn't made official releases for a while, we need to use master for now.
 # We plan to replace pigeon with a hand written parser, as such this dependency is short lived.


### PR DESCRIPTION
Problem:

Under some circumstances tdigest would panic if the quantile was before 1/2 of the mean of the first centroid.
https://github.com/influxdata/tdigest/issues/7

Solution:
Library has fix; update the vendoring