### PR TITLE
set now time at query spec level

### DIFF
--- a/query/builtin/builtin.go
+++ b/query/builtin/builtin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/platform/query/complete"
 	_ "github.com/influxdata/platform/query/functions" // Import the built-in functions
 	"github.com/influxdata/platform/query/interpreter"
+	_ "github.com/influxdata/platform/query/options" // Import the built-in options
 )
 
 func init() {

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -114,7 +114,7 @@ func (c *Controller) compileQuery(q *Query, queryStr string) error {
 	if !q.tryCompile() {
 		return errors.New("failed to transition query to compiling state")
 	}
-	spec, err := query.Compile(q.compilingCtx, queryStr, query.Verbose(c.verbose))
+	spec, err := query.Compile(q.compilingCtx, queryStr, q.now, query.Verbose(c.verbose))
 	if err != nil {
 		return errors.Wrap(err, "failed to compile query")
 	}
@@ -226,7 +226,7 @@ func (c *Controller) processQuery(q *Query) (pop bool, err error) {
 			log.Println("logical plan", plan.Formatted(lp))
 		}
 
-		p, err := c.pplanner.Plan(lp, nil, q.now)
+		p, err := c.pplanner.Plan(lp, nil)
 		if err != nil {
 			return true, errors.Wrap(err, "failed to create physical plan")
 		}

--- a/query/functions/count_test.go
+++ b/query/functions/count_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/plan"
 	"github.com/influxdata/platform/query/plan/plantest"
 	"github.com/influxdata/platform/query/querytest"

--- a/query/functions/join.go
+++ b/query/functions/join.go
@@ -127,7 +127,7 @@ func createJoinOpSpec(args query.Arguments, a *query.Administration) (query.Oper
 				return
 			}
 			p := t.(*query.TableObject)
-			joinParams.add(k /*parameter*/, p /*argument*/)
+			joinParams.add(k, p)
 			spec.tableNames[p] = k
 		})
 		if err != nil {

--- a/query/functions/mean_test.go
+++ b/query/functions/mean_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/querytest"
 )
 

--- a/query/functions/percentile_test.go
+++ b/query/functions/percentile_test.go
@@ -4,10 +4,10 @@ import (
 	"math"
 	"testing"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/querytest"
 )
 

--- a/query/functions/prepcsvtests/prepcsvtests.go
+++ b/query/functions/prepcsvtests/prepcsvtests.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/influxdata/platform/query"
 	_ "github.com/influxdata/platform/query/builtin"
@@ -69,7 +70,7 @@ func main() {
 		}
 
 		qs := querytest.GetQueryServiceBridge()
-		qspec, err := query.Compile(context.Background(), string(querytext))
+		qspec, err := query.Compile(context.Background(), string(querytext), time.Now().UTC())
 		if err != nil {
 			fmt.Printf("error compiling. \n query: \n %s \n err: %s", string(querytext), err)
 			return

--- a/query/functions/query_test.go
+++ b/query/functions/query_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdata/platform/query"
 	_ "github.com/influxdata/platform/query/builtin"
@@ -83,7 +84,7 @@ func queryTester(t *testing.T, qs query.QueryService, prefix, queryExt string) e
 		t.Fatal(err)
 	}
 
-	spec, err := query.Compile(context.Background(), q)
+	spec, err := query.Compile(context.Background(), q, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("failed to compile: %v", err)
 	}

--- a/query/functions/range_test.go
+++ b/query/functions/range_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/plan"
 	"github.com/influxdata/platform/query/plan/plantest"
 	"github.com/influxdata/platform/query/querytest"

--- a/query/functions/skew_test.go
+++ b/query/functions/skew_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/querytest"
 )
 

--- a/query/functions/spread_test.go
+++ b/query/functions/spread_test.go
@@ -3,9 +3,9 @@ package functions_test
 import (
 	"testing"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/querytest"
 )
 

--- a/query/functions/stddev_test.go
+++ b/query/functions/stddev_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/querytest"
 )
 

--- a/query/functions/sum_test.go
+++ b/query/functions/sum_test.go
@@ -3,9 +3,9 @@ package functions_test
 import (
 	"testing"
 
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute/executetest"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/plan"
 	"github.com/influxdata/platform/query/plan/plantest"
 	"github.com/influxdata/platform/query/querytest"

--- a/query/functions/system_time.go
+++ b/query/functions/system_time.go
@@ -1,0 +1,29 @@
+package functions
+
+import (
+	"time"
+
+	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/semantic"
+	"github.com/influxdata/platform/query/values"
+)
+
+var systemTimeFuncName = "systemTime"
+
+func init() {
+	nowFunc := SystemTime()
+	query.RegisterBuiltInValue(systemTimeFuncName, nowFunc)
+}
+
+// SystemTime return a function value that when called will give the current system time
+func SystemTime() values.Value {
+	name := systemTimeFuncName
+	ftype := semantic.NewFunctionType(semantic.FunctionSignature{
+		ReturnType: semantic.Time,
+	})
+	call := func(args values.Object) (values.Value, error) {
+		return values.NewTimeValue(values.ConvertTime(time.Now().UTC())), nil
+	}
+	sideEffect := false
+	return values.NewFunction(name, ftype, call, sideEffect)
+}

--- a/query/interpreter/interpreter.go
+++ b/query/interpreter/interpreter.go
@@ -10,19 +10,63 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Eval(program *semantic.Program, scope *Scope) ([]values.Value, error) {
-	itrp := interpreter{}
-	err := itrp.eval(program, scope)
-	return itrp.values, err
+// Interpreter used to interpret a Flux program
+type Interpreter struct {
+	values  []values.Value
+	options *Scope
+	globals *Scope
 }
 
-type interpreter struct {
-	values []values.Value
+// NewInterpreter instantiates a new Flux Interpreter
+func NewInterpreter(options, builtins map[string]values.Value) *Interpreter {
+	optionScope := NewScopeWithValues(options)
+	globalScope := optionScope.NestWithValues(builtins)
+	interpreter := new(Interpreter)
+	interpreter.options = optionScope
+	interpreter.globals = globalScope
+	return interpreter
 }
 
-func (itrp *interpreter) eval(program *semantic.Program, scope *Scope) error {
+// Return gives the return value from the block
+func (itrp *Interpreter) Return() values.Value {
+	return itrp.globals.Return()
+}
+
+// GlobalScope returns a pointer to the global scope of the program.
+// That is the scope nested directly below the options scope.
+func (itrp *Interpreter) GlobalScope() *Scope {
+	return itrp.globals
+}
+
+// SetVar adds a variable binding to the global scope
+func (itrp *Interpreter) SetVar(name string, val values.Value) {
+	itrp.globals.Set(name, val)
+}
+
+// SideEffects returns the evaluated expressions of a Flux program
+func (itrp *Interpreter) SideEffects() []values.Value {
+	return itrp.values
+}
+
+// Option returns a Flux option by name
+func (itrp *Interpreter) Option(name string) values.Value {
+	return itrp.options.Get(name)
+}
+
+// SetOption sets a new option binding
+func (itrp *Interpreter) SetOption(name string, val values.Value) {
+	itrp.options.Set(name, val)
+}
+
+// Eval evaluates the expressions composing a Flux program.
+func (itrp *Interpreter) Eval(program *semantic.Program) error {
+	return itrp.eval(program)
+}
+
+func (itrp *Interpreter) eval(program *semantic.Program) error {
+	topLevelScope := itrp.globals
 	for _, stmt := range program.Body {
-		val, err := itrp.doStatement(stmt, scope)
+		val, err := itrp.doStatement(stmt, topLevelScope)
 		if err != nil {
 			return err
 		}
@@ -34,11 +78,11 @@ func (itrp *interpreter) eval(program *semantic.Program, scope *Scope) error {
 }
 
 // doStatement returns the resolved value of a top-level statement
-func (itrp *interpreter) doStatement(stmt semantic.Statement, scope *Scope) (values.Value, error) {
+func (itrp *Interpreter) doStatement(stmt semantic.Statement, scope *Scope) (values.Value, error) {
 	scope.SetReturn(values.InvalidValue)
 	switch s := stmt.(type) {
 	case *semantic.OptionStatement:
-		return itrp.doStatement(s.Declaration, scope)
+		return itrp.doOptionStatement(s.Declaration.(*semantic.NativeVariableDeclaration), scope)
 	case *semantic.NativeVariableDeclaration:
 		return itrp.doVariableDeclaration(s, scope)
 	case *semantic.ExpressionStatement:
@@ -62,8 +106,8 @@ func (itrp *interpreter) doStatement(stmt semantic.Statement, scope *Scope) (val
 				}
 			}
 		}
-		// Propgate any return value from the nested scope out.
-		// Since a return statement is always last we do not have to worry about overriding an existing return value.
+		// Propgate any return value from the nested scope out. Since a return statement is
+		// always last we do not have to worry about overriding an existing return value.
 		scope.SetReturn(nested.Return())
 	case *semantic.ReturnStatement:
 		v, err := itrp.doExpression(s.Argument, scope)
@@ -77,7 +121,16 @@ func (itrp *interpreter) doStatement(stmt semantic.Statement, scope *Scope) (val
 	return nil, nil
 }
 
-func (itrp *interpreter) doVariableDeclaration(declaration *semantic.NativeVariableDeclaration, scope *Scope) (values.Value, error) {
+func (itrp *Interpreter) doOptionStatement(declaration *semantic.NativeVariableDeclaration, scope *Scope) (values.Value, error) {
+	value, err := itrp.doExpression(declaration.Init, scope)
+	if err != nil {
+		return nil, err
+	}
+	itrp.options.Set(declaration.Identifier.Name, value)
+	return value, nil
+}
+
+func (itrp *Interpreter) doVariableDeclaration(declaration *semantic.NativeVariableDeclaration, scope *Scope) (values.Value, error) {
 	value, err := itrp.doExpression(declaration.Init, scope)
 	if err != nil {
 		return nil, err
@@ -86,7 +139,7 @@ func (itrp *interpreter) doVariableDeclaration(declaration *semantic.NativeVaria
 	return value, nil
 }
 
-func (itrp *interpreter) doExpression(expr semantic.Expression, scope *Scope) (values.Value, error) {
+func (itrp *Interpreter) doExpression(expr semantic.Expression, scope *Scope) (values.Value, error) {
 	switch e := expr.(type) {
 	case semantic.Literal:
 		return itrp.doLiteral(e)
@@ -208,7 +261,7 @@ func (itrp *interpreter) doExpression(expr semantic.Expression, scope *Scope) (v
 	}
 }
 
-func (itrp *interpreter) doArray(a *semantic.ArrayExpression, scope *Scope) (values.Value, error) {
+func (itrp *Interpreter) doArray(a *semantic.ArrayExpression, scope *Scope) (values.Value, error) {
 	elements := make([]values.Value, len(a.Elements))
 	elementType := semantic.EmptyArrayType.ElementType()
 	for i, el := range a.Elements {
@@ -227,7 +280,7 @@ func (itrp *interpreter) doArray(a *semantic.ArrayExpression, scope *Scope) (val
 	return values.NewArrayWithBacking(elementType, elements), nil
 }
 
-func (itrp *interpreter) doObject(m *semantic.ObjectExpression, scope *Scope) (values.Value, error) {
+func (itrp *Interpreter) doObject(m *semantic.ObjectExpression, scope *Scope) (values.Value, error) {
 	obj := values.NewObject()
 	for _, p := range m.Properties {
 		v, err := itrp.doExpression(p.Value, scope)
@@ -242,7 +295,7 @@ func (itrp *interpreter) doObject(m *semantic.ObjectExpression, scope *Scope) (v
 	return obj, nil
 }
 
-func (itrp *interpreter) doLiteral(lit semantic.Literal) (values.Value, error) {
+func (itrp *Interpreter) doLiteral(lit semantic.Literal) (values.Value, error) {
 	switch l := lit.(type) {
 	case *semantic.DateTimeLiteral:
 		return values.NewTimeValue(values.Time(l.Value.UnixNano())), nil
@@ -288,7 +341,7 @@ func DoFunctionCall(f func(args Arguments) (values.Value, error), argsObj values
 	return v, nil
 }
 
-func (itrp *interpreter) doCall(call *semantic.CallExpression, scope *Scope) (values.Value, error) {
+func (itrp *Interpreter) doCall(call *semantic.CallExpression, scope *Scope) (values.Value, error) {
 	callee, err := itrp.doExpression(call.Callee, scope)
 	if err != nil {
 		return nil, err
@@ -319,7 +372,7 @@ func (itrp *interpreter) doCall(call *semantic.CallExpression, scope *Scope) (va
 	return value, nil
 }
 
-func (itrp *interpreter) doArguments(args *semantic.ObjectExpression, scope *Scope) (values.Object, error) {
+func (itrp *Interpreter) doArguments(args *semantic.ObjectExpression, scope *Scope) (values.Object, error) {
 	obj := values.NewObject()
 	if args == nil || len(args.Properties) == 0 {
 		return obj, nil
@@ -337,6 +390,7 @@ func (itrp *interpreter) doArguments(args *semantic.ObjectExpression, scope *Sco
 	return obj, nil
 }
 
+// TODO(Josh): Scope methods should be private
 type Scope struct {
 	parent      *Scope
 	values      map[string]values.Value
@@ -348,9 +402,35 @@ func NewScope() *Scope {
 		values: make(map[string]values.Value),
 	}
 }
-func NewScopeWithValues(values map[string]values.Value) *Scope {
+func NewScopeWithValues(vals map[string]values.Value) *Scope {
+	cp := make(map[string]values.Value, len(vals))
+	for k, v := range vals {
+		cp[k] = v
+	}
 	return &Scope{
-		values: values,
+		values: cp,
+	}
+}
+
+func (s *Scope) Get(name string) values.Value {
+	return s.values[name]
+}
+
+func (s *Scope) Set(name string, value values.Value) {
+	s.values[name] = value
+}
+
+func (s *Scope) Values() map[string]values.Value {
+	cp := make(map[string]values.Value, len(s.values))
+	for k, v := range s.values {
+		cp[k] = v
+	}
+	return cp
+}
+
+func (s *Scope) SetValues(vals map[string]values.Value) {
+	for k, v := range vals {
+		s.values[k] = v
 	}
 }
 
@@ -363,10 +443,6 @@ func (s *Scope) Lookup(name string) (values.Value, bool) {
 		return s.parent.Lookup(name)
 	}
 	return v, ok
-}
-
-func (s *Scope) Set(name string, value values.Value) {
-	s.values[name] = value
 }
 
 // SetReturn sets the return value of this scope.
@@ -393,6 +469,12 @@ func (s *Scope) Names() []string {
 // Nest returns a new nested scope.
 func (s *Scope) Nest() *Scope {
 	c := NewScope()
+	c.parent = s
+	return c
+}
+
+func (s *Scope) NestWithValues(values map[string]values.Value) *Scope {
+	c := NewScopeWithValues(values)
 	c.parent = s
 	return c
 }
@@ -455,7 +537,7 @@ type function struct {
 	scope *Scope
 	call  func(Arguments) (values.Value, error)
 
-	itrp *interpreter
+	itrp *Interpreter
 }
 
 func (f *function) Type() semantic.Type {

--- a/query/options/now.go
+++ b/query/options/now.go
@@ -1,0 +1,10 @@
+package options
+
+import (
+	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/functions"
+)
+
+func init() {
+	query.RegisterBuiltInOption("now", functions.SystemTime())
+}

--- a/query/plan/logical.go
+++ b/query/plan/logical.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/influxdata/platform/query"
 	uuid "github.com/satori/go.uuid"
@@ -14,6 +15,7 @@ type LogicalPlanSpec struct {
 	Procedures map[ProcedureID]*Procedure
 	Order      []ProcedureID
 	Resources  query.ResourceManagement
+	Now        time.Time
 }
 
 func (lp *LogicalPlanSpec) Do(f func(pr *Procedure)) {
@@ -49,6 +51,7 @@ func (p *logicalPlanner) Plan(q *query.Spec) (*LogicalPlanSpec, error) {
 	if err != nil {
 		return nil, err
 	}
+	p.plan.Now = q.Now
 	return p.plan, nil
 }
 

--- a/query/plan/logical_test.go
+++ b/query/plan/logical_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/plan"
 	"github.com/influxdata/platform/query/plan/plantest"
 )
@@ -171,6 +171,10 @@ func TestLogicalPlanner_Plan(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// Set Now time on query spec
+			tc.q.Now = time.Now().UTC()
+			tc.ap.Now = tc.q.Now
+
 			planner := plan.NewLogicalPlanner()
 			got, err := planner.Plan(tc.q)
 			if err != nil {

--- a/query/plan/physical.go
+++ b/query/plan/physical.go
@@ -14,15 +14,16 @@ import (
 const DefaultYieldName = "_result"
 
 type PlanSpec struct {
-	// Now represents the relative currentl time of the plan.
+	// Now represents the relative current time of the plan.
 	Now    time.Time
 	Bounds BoundsSpec
+
 	// Procedures is a set of all operations
 	Procedures map[ProcedureID]*Procedure
 	Order      []ProcedureID
-	// Results is a list of datasets that are the result of the plan
-	Results map[string]YieldSpec
 
+	// Results is a list of datasets that are the result of the plan
+	Results   map[string]YieldSpec
 	Resources query.ResourceManagement
 }
 
@@ -42,7 +43,7 @@ func (p *PlanSpec) lookup(id ProcedureID) *Procedure {
 
 type Planner interface {
 	// Plan create a plan from the logical plan and available storage.
-	Plan(p *LogicalPlanSpec, s Storage, now time.Time) (*PlanSpec, error)
+	Plan(p *LogicalPlanSpec, s Storage) (*PlanSpec, error)
 }
 
 type PlanRewriter interface {
@@ -61,7 +62,9 @@ func NewPlanner() Planner {
 	return new(planner)
 }
 
-func (p *planner) Plan(lp *LogicalPlanSpec, s Storage, now time.Time) (*PlanSpec, error) {
+func (p *planner) Plan(lp *LogicalPlanSpec, s Storage) (*PlanSpec, error) {
+	now := lp.Now
+
 	p.plan = &PlanSpec{
 		Now:        now,
 		Procedures: make(map[ProcedureID]*Procedure, len(lp.Procedures)),

--- a/query/plan/physical_test.go
+++ b/query/plan/physical_test.go
@@ -1050,12 +1050,14 @@ func TestPhysicalPlanner_Plan_PushDown_Mixed(t *testing.T) {
 
 func PhysicalPlanTestHelper(t *testing.T, lp *plan.LogicalPlanSpec, want *plan.PlanSpec) {
 	t.Helper()
+
 	// Setup expected now time
 	now := time.Now()
+	lp.Now = now
 	want.Now = now
 
 	planner := plan.NewPlanner()
-	got, err := planner.Plan(lp, nil, now)
+	got, err := planner.Plan(lp, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1076,10 +1078,11 @@ func BenchmarkPhysicalPlan(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	planner := plan.NewPlanner()
 	now := time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC)
+	lp.Now = now
+	planner := plan.NewPlanner()
 	for n := 0; n < b.N; n++ {
-		benchmarkPhysicalPlan, err = planner.Plan(lp, nil, now)
+		benchmarkPhysicalPlan, err = planner.Plan(lp, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1097,7 +1100,8 @@ func BenchmarkQueryToPhysicalPlan(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		benchmarkQueryToPhysicalPlan, err = pp.Plan(lp, nil, now)
+		lp.Now = now
+		benchmarkQueryToPhysicalPlan, err = pp.Plan(lp, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -3,15 +3,25 @@ package query_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/functions"
+	_ "github.com/influxdata/platform/query/options"
+	"github.com/influxdata/platform/query/parser"
+	"github.com/influxdata/platform/query/semantic"
+	"github.com/influxdata/platform/query/values"
 )
+
+func init() {
+	query.FinalizeBuiltIns()
+}
 
 var ignoreUnexportedQuerySpec = cmpopts.IgnoreUnexported(query.Spec{})
 
@@ -265,4 +275,94 @@ func TestQuery_Walk(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Example_option demonstrates retrieving an option from the Flux interpreter
+func Example_option() {
+	// Instantiate a new Flux interpreter with pre-populated option and global scopes
+	itrp := query.NewInterpreter()
+
+	// Retrieve the default value for an option
+	nowFunc := itrp.Option("now")
+
+	// The now option is a function value whose default behavior is to return
+	// the current system time when called. The function now() doesn't take
+	// any arguments so can be called with nil.
+	nowTime, _ := nowFunc.Function().Call(nil)
+	fmt.Fprintf(os.Stderr, "The current system time (UTC) is: %v\n", nowTime)
+	// Output:
+}
+
+// Example_setOption demonstrates setting an option from the Flux interpreter
+func Example_setOption() {
+	// Instantiate a new Flux interpreter with pre-populated option and global scopes
+	itrp := query.NewInterpreter()
+
+	// Set a new option from the interpreter
+	itrp.SetOption("dummy_option", values.NewIntValue(3))
+
+	fmt.Printf("dummy_option = %d", itrp.Option("dummy_option").Int())
+	// Output: dummy_option = 3
+}
+
+// Example_overrideDefaultOptionExternally demonstrates how declaring an option
+// in a Flux script will change that option's binding in the options scope of the interpreter.
+func Example_overrideDefaultOptionExternally() {
+	queryString := `
+		now = () => 2018-07-13T00:00:00Z
+		what_time_is_it = now()`
+
+	itrp := query.NewInterpreter()
+	_, declarations := query.BuiltIns()
+
+	ast, _ := parser.NewAST(queryString)
+	semanticProgram, _ := semantic.New(ast, declarations)
+
+	// Evaluate program
+	itrp.Eval(semanticProgram)
+
+	// After evaluating the program, lookup the value of what_time_is_it
+	now, _ := itrp.GlobalScope().Lookup("what_time_is_it")
+
+	// what_time_is_it? Why it's ....
+	fmt.Printf("The new current time (UTC) is: %v", now)
+	// Output: The new current time (UTC) is: 2018-07-13T00:00:00.000000000Z
+}
+
+// Example_overrideDefaultOptionInternally demonstrates how one can override a default
+// option that is used in a query before that query is evaluated by the interpreter.
+func Example_overrideDefaultOptionInternally() {
+	queryString := `what_time_is_it = now()`
+
+	itrp := query.NewInterpreter()
+	_, declarations := query.BuiltIns()
+
+	ast, _ := parser.NewAST(queryString)
+	semanticProgram, _ := semantic.New(ast, declarations)
+
+	// Define a new now function which returns a static time value of 2018-07-13T00:00:00.000000000Z
+	timeValue := time.Date(2018, 7, 13, 0, 0, 0, 0, time.UTC)
+	functionName := "newTime"
+	functionType := semantic.NewFunctionType(semantic.FunctionSignature{
+		ReturnType: semantic.Time,
+	})
+	functionCall := func(args values.Object) (values.Value, error) {
+		return values.NewTimeValue(values.ConvertTime(timeValue)), nil
+	}
+	sideEffect := false
+
+	newNowFunc := values.NewFunction(functionName, functionType, functionCall, sideEffect)
+
+	// Override the default now function with the new one
+	itrp.SetOption("now", newNowFunc)
+
+	// Evaluate program
+	itrp.Eval(semanticProgram)
+
+	// After evaluating the program, lookup the value of what_time_is_it
+	now, _ := itrp.GlobalScope().Lookup("what_time_is_it")
+
+	// what_time_is_it? Why it's ....
+	fmt.Printf("The new current time (UTC) is: %v", now)
+	// Output: The new current time (UTC) is: 2018-07-13T00:00:00.000000000Z
 }

--- a/query/querytest/compile.go
+++ b/query/querytest/compile.go
@@ -1,13 +1,14 @@
 package querytest
 
 import (
-	"github.com/influxdata/platform/query/functions"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/semantic/semantictest"
 )
 
@@ -29,13 +30,17 @@ var opts = append(
 func NewQueryTestHelper(t *testing.T, tc NewQueryTestCase) {
 	t.Helper()
 
-	got, err := query.Compile(context.Background(), tc.Raw)
+	now := time.Now().UTC()
+	got, err := query.Compile(context.Background(), tc.Raw, now)
 	if (err != nil) != tc.WantErr {
 		t.Errorf("query.NewQuery() error = %v, wantErr %v", err, tc.WantErr)
 		return
 	}
 	if tc.WantErr {
 		return
+	}
+	if tc.Want != nil {
+		tc.Want.Now = now
 	}
 	if !cmp.Equal(tc.Want, got, opts...) {
 		t.Errorf("query.NewQuery() = -want/+got %s", cmp.Diff(tc.Want, got, opts...))

--- a/query/querytest/compspecs/compspecs.go
+++ b/query/querytest/compspecs/compspecs.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/platform/query"
@@ -62,7 +63,7 @@ func main() {
 			return
 		}
 
-		fluxSpec, err := query.Compile(context.Background(), string(fluxText))
+		fluxSpec, err := query.Compile(context.Background(), string(fluxText), time.Now().UTC())
 		if err != nil {
 			fmt.Printf("error compiling. \n query: \n %s \n err: %s", string(fluxText), err)
 			return

--- a/query/spec.go
+++ b/query/spec.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -11,6 +12,7 @@ type Spec struct {
 	Operations []*Operation       `json:"operations"`
 	Edges      []Edge             `json:"edges"`
 	Resources  ResourceManagement `json:"resources"`
+	Now        time.Time          `json:"now"`
 
 	sorted   []*Operation
 	children map[OperationID][]*Operation

--- a/query/values/function.go
+++ b/query/values/function.go
@@ -1,0 +1,96 @@
+package values
+
+import (
+	"regexp"
+
+	"github.com/influxdata/platform/query/semantic"
+)
+
+// Function represents a callable type
+type Function interface {
+	Value
+	HasSideEffect() bool
+	Call(args Object) (Value, error)
+}
+
+// NewFunction returns a new function value
+func NewFunction(name string, typ semantic.Type, call func(args Object) (Value, error), sideEffect bool) Function {
+	return &function{
+		name:          name,
+		t:             typ,
+		call:          call,
+		hasSideEffect: sideEffect,
+	}
+}
+
+// function implements Value interface and more specifically the Function interface
+type function struct {
+	name          string
+	t             semantic.Type
+	call          func(args Object) (Value, error)
+	hasSideEffect bool
+}
+
+func (f *function) Type() semantic.Type {
+	return f.t
+}
+
+func (f *function) Str() string {
+	panic(UnexpectedKind(semantic.Object, semantic.String))
+}
+
+func (f *function) Int() int64 {
+	panic(UnexpectedKind(semantic.Object, semantic.Int))
+}
+
+func (f *function) UInt() uint64 {
+	panic(UnexpectedKind(semantic.Object, semantic.UInt))
+}
+
+func (f *function) Float() float64 {
+	panic(UnexpectedKind(semantic.Object, semantic.Float))
+}
+
+func (f *function) Bool() bool {
+	panic(UnexpectedKind(semantic.Object, semantic.Bool))
+}
+
+func (f *function) Time() Time {
+	panic(UnexpectedKind(semantic.Object, semantic.Time))
+}
+
+func (f *function) Duration() Duration {
+	panic(UnexpectedKind(semantic.Object, semantic.Duration))
+}
+
+func (f *function) Regexp() *regexp.Regexp {
+	panic(UnexpectedKind(semantic.Object, semantic.Regexp))
+}
+
+func (f *function) Array() Array {
+	panic(UnexpectedKind(semantic.Object, semantic.Function))
+}
+
+func (f *function) Object() Object {
+	panic(UnexpectedKind(semantic.Object, semantic.Object))
+}
+
+func (f *function) Function() Function {
+	return f
+}
+
+func (f *function) Equal(rhs Value) bool {
+	if f.Type() != rhs.Type() {
+		return false
+	}
+	v, ok := rhs.(*function)
+	return ok && (f == v)
+}
+
+func (f *function) HasSideEffect() bool {
+	return f.hasSideEffect
+}
+
+func (f *function) Call(args Object) (Value, error) {
+	return f.call(args)
+}

--- a/query/values/values.go
+++ b/query/values/values.go
@@ -27,13 +27,6 @@ type Value interface {
 	Equal(Value) bool
 }
 
-// Function represents a callable type
-type Function interface {
-	Value
-	HasSideEffect() bool
-	Call(args Object) (Value, error)
-}
-
 type value struct {
 	t semantic.Type
 	v interface{}


### PR DESCRIPTION
This commit adds a `now` field to a query spec as well as `Now` fields to logical and physical plans. These fields represent the current system time that a query will execute with respect to. This commit is in preparation for adding an interface for getting and setting Flux options - in particular the **now** option.