### PR TITLE
Add flux tests demonstrating counts with no data on some time intervals

### DIFF
--- a/query/functions/testdata/count.flux
+++ b/query/functions/testdata/count.flux
@@ -1,0 +1,5 @@
+from(db:"test")
+    |> range(start:2018-05-22T19:53:26Z)
+    |> filter(fn: (r) => r._field == "usage_guest")
+    |> window(every:1m)
+    |> count()

--- a/query/functions/testdata/count.in.csv
+++ b/query/functions/testdata/count.in.csv
@@ -1,0 +1,15 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#partition,false,false,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:06Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:16Z,0,usage_guest,cpu,cpu-total,host.local
+,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,0,usage_guest_nice,cpu,cpu-total,host.local
+,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,0,usage_guest_nice,cpu,cpu-total,host.local
+,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,0,usage_guest_nice,cpu,cpu-total,host.local
+,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,0,usage_guest_nice,cpu,cpu-total,host.local
+,,1,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:06Z,0,usage_guest_nice,cpu,cpu-total,host.local

--- a/query/functions/testdata/count.out.csv
+++ b/query/functions/testdata/count.out.csv
@@ -1,0 +1,7 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,dateTime:RFC3339,long
+#partition,false,false,true,true,true,true,true,true,false,false
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,cpu,host,_time,_value
+,,0,2018-05-22T19:53:26Z,2018-05-22T19:54:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:54:00Z,4
+,,1,2018-05-22T19:54:00Z,2018-05-22T19:55:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:55:00Z,2
+

--- a/query/functions/testdata/count_no_data.flux
+++ b/query/functions/testdata/count_no_data.flux
@@ -1,0 +1,5 @@
+from(db:"test")
+    |> range(start:2018-05-22T19:53:26Z, stop:2018-05-22T20:00:00Z)
+    |> filter(fn: (r) => r._field == "usage_guest")
+    |> window(every:1m)
+    |> count()

--- a/query/functions/testdata/count_no_data.in.csv
+++ b/query/functions/testdata/count_no_data.in.csv
@@ -1,0 +1,9 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#partition,false,false,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,2018-05-22T19:53:00.421470485Z,2018-05-22T19:54:00.421470485Z,2018-05-22T19:53:26Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:54:00.421470485Z,2018-05-22T19:55:00.421470485Z,2018-05-22T19:54:36Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:55:00.421470485Z,2018-05-22T19:56:00.421470485Z,2018-05-22T19:55:46Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:56:00.421470485Z,2018-05-22T19:57:00.421470485Z,2018-05-22T19:56:56Z,0,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:57:00.421470485Z,2018-05-22T19:58:00.421470485Z,2018-05-22T19:57:06Z,0,usage_guest,cpu,cpu-total,host.local

--- a/query/functions/testdata/count_no_data.out.csv
+++ b/query/functions/testdata/count_no_data.out.csv
@@ -1,0 +1,10 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,dateTime:RFC3339,long
+#partition,false,false,true,true,true,true,true,true,false,false
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,cpu,host,_time,_value
+,,0,2018-05-22T19:53:26Z,2018-05-22T19:54:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:54:00Z,1
+,,1,2018-05-22T19:54:00Z,2018-05-22T19:55:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:55:00Z,1
+,,2,2018-05-22T19:55:00Z,2018-05-22T19:56:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:56:00Z,1
+,,3,2018-05-22T19:56:00Z,2018-05-22T19:57:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:57:00Z,1
+,,4,2018-05-22T19:57:00Z,2018-05-22T19:58:00Z,usage_guest,cpu,cpu-total,host.local,2018-05-22T19:58:00Z,1
+


### PR DESCRIPTION
Addresses #307; Adds a test for `count` with data gaps, in addition to a general `count` test. In the included test for data gaps (`count_no_data`), there is no data for the last two windows that the query is requesting a `count` for. The current behavior of `count` is to ignore those windows and only provide counts for windows that contain data. If this   test's output  was in accordance with [this](https://github.com/influxdata/influxdb/issues/6412) feature request (also see https://github.com/influxdata/influxdb/issues/6967), one might expect two more windows in the output, both with `count` 0.  @nathanielc is this behavior desired? 