### PR TITLE
Add flux string interpolation test

### DIFF
--- a/query/functions/query_test.go
+++ b/query/functions/query_test.go
@@ -24,6 +24,7 @@ var skipTests = map[string]string{
 	"string_max":                "error: invalid use of function: *functions.MaxSelector has no implementation for type string (https://github.com/influxdata/platform/issues/224)",
 	"null_as_value":             "null not supported as value in influxql (https://github.com/influxdata/platform/issues/353)",
 	"difference_panic":          "difference() panics when no table is supplied",
+	"string_interp":             "string interpolation not working as expected in flux (https://github.com/influxdata/platform/issues/404)",
 }
 
 func Test_QueryEndToEnd(t *testing.T) {

--- a/query/functions/testdata/string_interp.flux
+++ b/query/functions/testdata/string_interp.flux
@@ -1,0 +1,5 @@
+n = 1
+fieldSelect = "field{n}"
+from(db:"test")
+    |> range(start:-5m)
+    |> filter(fn: (r) => r._field == fieldSelect)

--- a/query/functions/testdata/string_interp.in.csv
+++ b/query/functions/testdata/string_interp.in.csv
@@ -1,0 +1,10 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
+#partition,false,false,false,false,false,false,true,true,true,true,true,true
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
+,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,34.98234271799806,used_percent,disk,disk1s1,apfs,host.local,/
+,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,34.98234941084654,used_percent,disk,disk1s1,apfs,host.local,/
+,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,34.982447293755506,used_percent,disk,disk1s1,apfs,host.local,/
+,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,34.982447293755506,field1,disk,disk1s1,apfs,host.local,/
+,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:06Z,34.98204153981662,field1,disk,disk1s1,apfs,host.local,/
+,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:16Z,34.982252364543626,field1,disk,disk1s1,apfs,host.local,/

--- a/query/functions/testdata/string_interp.out.csv
+++ b/query/functions/testdata/string_interp.out.csv
@@ -1,0 +1,8 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
+#partition,false,false,false,false,false,false,true,true,true,true,true,true
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,34.982447293755506,field1,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:06Z,34.98204153981662,field1,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:54:16Z,34.982252364543626,field1,disk,disk1s1,apfs,host.local,/
+


### PR DESCRIPTION
Addresses #404; Adds a test for string interpolation using `filter` with an interpolated string. Currently failing. 