### PR TITLE
fix: Fix tests that are failing because of the rename

### DIFF
--- a/query/functions/difference_test.go
+++ b/query/functions/difference_test.go
@@ -313,7 +313,7 @@ func TestDifference_Process(t *testing.T) {
 				Columns:     []string{"x", "y"},
 				NonNegative: true,
 			},
-			data: []query.Block{&executetest.Block{
+			data: []query.Table{&executetest.Table{
 				ColMeta: []query.ColMeta{
 					{Label: "_time", Type: query.TTime},
 					{Label: "x", Type: query.TFloat},
@@ -321,7 +321,7 @@ func TestDifference_Process(t *testing.T) {
 				},
 				Data: [][]interface{}{},
 			}},
-			want: []*executetest.Block{{
+			want: []*executetest.Table{{
 				ColMeta: []query.ColMeta{
 					{Label: "_time", Type: query.TTime},
 					{Label: "x", Type: query.TFloat},
@@ -336,7 +336,7 @@ func TestDifference_Process(t *testing.T) {
 				Columns:     []string{"x", "y"},
 				NonNegative: true,
 			},
-			data: []query.Block{&executetest.Block{
+			data: []query.Table{&executetest.Table{
 				ColMeta: []query.ColMeta{
 					{Label: "_time", Type: query.TTime},
 					{Label: "x", Type: query.TFloat},
@@ -346,7 +346,7 @@ func TestDifference_Process(t *testing.T) {
 					{execute.Time(3), 10.0, 20.0},
 				},
 			}},
-			want: []*executetest.Block{{
+			want: []*executetest.Table{{
 				ColMeta: []query.ColMeta{
 					{Label: "_time", Type: query.TTime},
 					{Label: "x", Type: query.TFloat},

--- a/query/functions/testdata/difference.in.csv
+++ b/query/functions/testdata/difference.in.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true,true,true
 #default,_result,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
 ,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,34.98234271799806,used_percent,disk,disk1s1,apfs,host.local,/

--- a/query/functions/testdata/difference.out.csv
+++ b/query/functions/testdata/difference.out.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true,true,true
 #default,_result,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
 ,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,0.000006692848479872282,used_percent,disk,disk1s1,apfs,host.local,/

--- a/query/functions/testdata/difference_one_value.in.csv
+++ b/query/functions/testdata/difference_one_value.in.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 ,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,1,usage_guest,cpu,cpu-total,host.local

--- a/query/functions/testdata/difference_one_value.out.csv
+++ b/query/functions/testdata/difference_one_value.out.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true
 #default,_result,0,,,,,usage_guest,cpu,cpu-total,host.local
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 

--- a/query/functions/testdata/difference_panic.out.csv
+++ b/query/functions/testdata/difference_panic.out.csv
@@ -1,10 +1,10 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true
 #default,_result,0,,,,,usage_guest,cpu,cpu-total,host.local
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true
 #default,_result,1,,,,,usage_guest_nice,cpu,cpu-total,host.local
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 

--- a/query/functions/testdata/meta_query_fields.in.csv
+++ b/query/functions/testdata/meta_query_fields.in.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 ,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,0,usage_guest,cpu,cpu-total,host.local

--- a/query/functions/testdata/meta_query_fields.out.csv
+++ b/query/functions/testdata/meta_query_fields.out.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,string,string
-#partition,false,false,false,false
+#group,false,false,false,false
 #default,_result,,,
 ,result,table,_field,_value
 ,,0,usage_guest,usage_guest

--- a/query/functions/testdata/meta_query_keys.in.csv
+++ b/query/functions/testdata/meta_query_keys.in.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 ,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,0,usage_guest,cpu,cpu-total,host.local

--- a/query/functions/testdata/meta_query_keys.out.csv
+++ b/query/functions/testdata/meta_query_keys.out.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,string,string,string,string,string
-#partition,false,false,true,true,true,true,false
+#group,false,false,true,true,true,true,false
 #default,0,,,,,,
 ,result,table,_field,_measurement,cpu,host,_value
 ,,0,usage_guest,cpu,cpu-total,host.local,_field
@@ -34,7 +34,7 @@
 ,,4,usage_irq,cpu,cpu-total,host.local,host
 
 #datatype,string,long,string,string
-#partition,false,false,false,false
+#group,false,false,false,false
 #default,1,,,
 ,result,table,host,_value
 ,,0,host.local,host.local

--- a/query/functions/testdata/meta_query_measurements.in.csv
+++ b/query/functions/testdata/meta_query_measurements.in.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string,string,string
-#partition,false,false,false,false,false,false,true,true,true,true,true,true
+#group,false,false,false,false,false,false,true,true,true,true,true,true
 #default,_result,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
 ,,90,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,318324641792,free,disk,disk1s1,apfs,host.local,/

--- a/query/functions/testdata/meta_query_measurements.out.csv
+++ b/query/functions/testdata/meta_query_measurements.out.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,string,string
-#partition,false,false,false,false
+#group,false,false,false,false
 #default,_result,,,
 ,result,table,_measurement,_value
 ,,0,disk,disk


### PR DESCRIPTION
These tests were part of a PR when the rename was made.
The changes were not rebased before merge so we did not discover the
failures till after the merge.