### PR TITLE
feat: Add query statistics

### DIFF
--- a/query/execute/executor_test.go
+++ b/query/execute/executor_test.go
@@ -354,7 +354,7 @@ func TestExecutor_Execute(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			exe := execute.NewExecutor(nil)
-			results, err := exe.Execute(context.Background(), orgID, tc.plan)
+			results, err := exe.Execute(context.Background(), orgID, tc.plan, executetest.UnlimitedAllocator)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Introduces the Statisticser interface which ResultIterators may
implement.

The HTTP implementation uses HTTP trailers to preserve the statistics.
This way we do not need to have all encoders and decoders support
statistics.