### PR TITLE
feature(kit/signals): add standard method to capture signals with context

### DIFF
--- a/kit/signals/context_test.go
+++ b/kit/signals/context_test.go
@@ -1,0 +1,64 @@
+package signals
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func ExampleWithSignals() {
+	ctx := WithSignals(context.Background(), syscall.SIGUSR1)
+	go func() {
+		time.Sleep(500 * time.Millisecond) // after some time SIGUSR1 is sent
+		// mimicking a signal from the outside
+		syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	}()
+
+	select {
+	case <-ctx.Done():
+		fmt.Println("finished")
+	}
+	// Output:
+	// finished
+}
+
+func TestWithSignals(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		sigs       []os.Signal
+		wantSignal bool
+	}{
+		{
+			name:       "sending signal SIGUSR2 should exit context.",
+			ctx:        context.Background(),
+			sigs:       []os.Signal{syscall.SIGUSR2},
+			wantSignal: true,
+		},
+		{
+			name: "sending signal SIGUSR2 should NOT exit context.",
+			ctx:  context.Background(),
+			sigs: []os.Signal{syscall.SIGUSR1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithSignals(tt.ctx, tt.sigs...)
+			syscall.Kill(syscall.Getpid(), syscall.SIGUSR2)
+			timer := time.NewTimer(500 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				if !tt.wantSignal {
+					t.Errorf("unexpected exit with signal")
+				}
+			case <-timer.C:
+				if tt.wantSignal {
+					t.Errorf("expected to exit with signal but did not")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
I'm adding various nice-to-haves in the kit package.

Here is a helper function to capture signals and receive notifications via `<-ctx.Done()`