### PR TITLE
feat(kit/cli): add viper simplification

### DIFF
--- a/kit/cli/doc.go
+++ b/kit/cli/doc.go
@@ -1,0 +1,48 @@
+// Package cli creates simple CLI options with ENV overrides using viper.
+//
+// This is a small simplification over viper to move most of the boilerplate
+// into one place.
+//
+//
+// In this example the flags can be set with MYPROGRAM_MONITOR_HOST and
+// MYPROGRAM_NUMBER or with the flags --monitor-host and --number
+//
+// var flags struct {
+// 	monitorHost string
+// 	number int
+// }
+//
+// func main() {
+// 	cmd := cli.NewCommand(&cli.Program{
+// 		Run:  run,
+// 		Name: "myprogram",
+// 		Opts: []cli.Opt{
+// 			{
+// 				DestP:   &flags.monitorHost,
+// 				Flag:    "monitor-host",
+// 				Default: "http://localhost:8086",
+// 				Desc:    "host to send influxdb metrics",
+// 			},
+// 			{
+// 			 	DestP:   &flags.number,
+// 				Flag:    "number",
+// 				Default: 2,
+// 				Desc:    "number of times to loop",
+//
+// 			},
+// 		},
+// 	})
+//
+// 	if err := cmd.Execute(); err != nil {
+// 		fmt.Fprintln(os.Stderr, err)
+// 		os.Exit(1)
+// 	}
+// }
+//
+// func run() error {
+// 	for i := 0; i < number; i++ {
+// 		fmt.Printf("%d\n", i)
+// 		feturn nil
+// 	}
+// }
+package cli

--- a/kit/cli/viper.go
+++ b/kit/cli/viper.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Opt is a single command-line option
+type Opt struct {
+	DestP   interface{} // pointer to the destination
+	Flag    string
+	Default interface{}
+	Desc    string
+}
+
+// NewOpt creates a new command line option.
+func NewOpt(destP interface{}, flag string, dflt interface{}, desc string) Opt {
+	return Opt{
+		DestP:   destP,
+		Flag:    flag,
+		Default: dflt,
+		Desc:    desc,
+	}
+}
+
+// Program parses CLI options
+type Program struct {
+	// Run is invoked by cobra on execute.
+	Run func() error
+	// Name is the name of the program in help usage and the env var prefix.
+	Name string
+	// Opts are the command line/env var options to the program
+	Opts []Opt
+}
+
+// NewCommand creates a new cobra command to be executed that respects env vars.
+//
+// Uses the upper-case version of the program's name as a prefix
+// to all environment variables.
+//
+// This is to simplify the viper/cobra boilerplate.
+func NewCommand(p *Program) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:  p.Name,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return p.Run()
+		},
+	}
+
+	viper.SetEnvPrefix(strings.ToUpper(p.Name))
+	viper.AutomaticEnv()
+	// This normalizes "-" to an underscore in env names.
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	for _, o := range p.Opts {
+		switch o.DestP.(type) {
+		case *string:
+			if o.Default == nil {
+				o.Default = ""
+			}
+			cmd.Flags().StringVar(o.DestP.(*string), o.Flag, o.Default.(string), o.Desc)
+			viper.BindPFlag(o.Flag, cmd.Flags().Lookup(o.Flag))
+			*o.DestP.(*string) = viper.GetString(o.Flag)
+		case *int:
+			if o.Default == nil {
+				o.Default = 0
+			}
+			cmd.Flags().IntVar(o.DestP.(*int), o.Flag, o.Default.(int), o.Desc)
+			viper.BindPFlag(o.Flag, cmd.Flags().Lookup(o.Flag))
+			*o.DestP.(*int) = viper.GetInt(o.Flag)
+		default:
+			// if you get a panic here, sorry about that!
+			// anyway, go ahead and make a PR and add another type.
+			panic(fmt.Errorf("unknown destination type %t", o.DestP))
+		}
+	}
+
+	return cmd
+}

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+func ExampleNewCommand() {
+	var monitorHost string
+	var number int
+	cmd := NewCommand(&Program{
+		Run: func() error {
+			fmt.Println(monitorHost)
+			for i := 0; i < number; i++ {
+				fmt.Printf("%d\n", i)
+			}
+			return nil
+		},
+		Name: "myprogram",
+		Opts: []Opt{
+			{
+				DestP:   &monitorHost,
+				Flag:    "monitor-host",
+				Default: "http://localhost:8086",
+				Desc:    "host to send influxdb metrics",
+			},
+			{
+				DestP:   &number,
+				Flag:    "number",
+				Default: 2,
+				Desc:    "number of times to loop",
+			},
+		},
+	})
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	// Output:
+	// http://localhost:8086
+	// 0
+	// 1
+}


### PR DESCRIPTION
This is a small simplification of cobra/viper with all the environment variables. 

See `doc.go` and the example in `viper_test.go`