### PR TITLE
Add Cancel() call to DelimitedMultiResultEncoder if error is encountered

### DIFF
--- a/query/result.go
+++ b/query/result.go
@@ -159,6 +159,8 @@ func (e *DelimitedMultiResultEncoder) Encode(w io.Writer, results ResultIterator
 	for results.More() {
 		result := results.Next()
 		if _, err := e.Encoder.Encode(wc, result); err != nil {
+			// if we encounter an error, cancel the results to stop the query...
+			results.Cancel()
 			return wc.Count(), err
 		}
 		if _, err := wc.Write(e.Delimiter); err != nil {

--- a/query/result.go
+++ b/query/result.go
@@ -159,11 +159,13 @@ func (e *DelimitedMultiResultEncoder) Encode(w io.Writer, results ResultIterator
 	for results.More() {
 		result := results.Next()
 		if _, err := e.Encoder.Encode(wc, result); err != nil {
-			// if we encounter an error, cancel the results to stop the query...
+			// If we encounter an error, cancel the results to stop the query and free its resources
 			results.Cancel()
 			return wc.Count(), err
 		}
 		if _, err := wc.Write(e.Delimiter); err != nil {
+			// If we encounter an error, cancel the results to stop the query and free its resources
+			results.Cancel()
 			return wc.Count(), err
 		}
 		// Flush the writer after each result

--- a/query/result.go
+++ b/query/result.go
@@ -159,8 +159,6 @@ func (e *DelimitedMultiResultEncoder) Encode(w io.Writer, results ResultIterator
 	for results.More() {
 		result := results.Next()
 		if _, err := e.Encoder.Encode(wc, result); err != nil {
-			// if we encounter an error, cancel the results to stop the query...
-			results.Cancel()
 			return wc.Count(), err
 		}
 		if _, err := wc.Write(e.Delimiter); err != nil {

--- a/query/result.go
+++ b/query/result.go
@@ -159,13 +159,11 @@ func (e *DelimitedMultiResultEncoder) Encode(w io.Writer, results ResultIterator
 	for results.More() {
 		result := results.Next()
 		if _, err := e.Encoder.Encode(wc, result); err != nil {
-			// If we encounter an error, cancel the results to stop the query and free its resources
+			// if we encounter an error, cancel the results to stop the query...
 			results.Cancel()
 			return wc.Count(), err
 		}
 		if _, err := wc.Write(e.Delimiter); err != nil {
-			// If we encounter an error, cancel the results to stop the query and free its resources
-			results.Cancel()
 			return wc.Count(), err
 		}
 		// Flush the writer after each result


### PR DESCRIPTION
This prevents a deadlock. If an error is encountered in the encoder, the query's resources are never freed. If a query is submitted to the controller, errors, and brings the available goroutine count down to zero, the next query will be unable to execute. The previous query needs to be freed first. Normally, `More` takes care of cleaning up queries, but in this case, `More` is only called once when the error is returned. 