### PR TITLE
fix(query/control): cancel the enqueue of a query if the context finishes

### DIFF
--- a/mock/bucket_service.go
+++ b/mock/bucket_service.go
@@ -24,7 +24,7 @@ type BucketService struct {
 	DeleteBucketFn   func(context.Context, platform.ID) error
 }
 
-// NewBucketService returns an mock BucketService where its methods will return
+// NewBucketService returns a mock BucketService where its methods will return
 // zero values.
 func NewBucketService() *BucketService {
 	return &BucketService{

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -1,0 +1,30 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/query/execute"
+	"github.com/influxdata/platform/query/plan"
+)
+
+var _ execute.Executor = (*Executor)(nil)
+
+// Executor is a mock implementation of an execute.Executor.
+type Executor struct {
+	ExecuteFn func(ctx context.Context, orgID platform.ID, p *plan.PlanSpec, a *execute.Allocator) (map[string]query.Result, error)
+}
+
+// NewExecutor returns a mock Executor where its methods will return zero values.
+func NewExecutor() *Executor {
+	return &Executor{
+		ExecuteFn: func(context.Context, platform.ID, *plan.PlanSpec, *execute.Allocator) (map[string]query.Result, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (e *Executor) Execute(ctx context.Context, orgID platform.ID, p *plan.PlanSpec, a *execute.Allocator) (map[string]query.Result, error) {
+	return e.ExecuteFn(ctx, orgID, p, a)
+}

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -1,0 +1,68 @@
+package control
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/mock"
+	"github.com/influxdata/platform/query"
+	_ "github.com/influxdata/platform/query/builtin"
+	"github.com/influxdata/platform/query/execute"
+	"github.com/influxdata/platform/query/plan"
+)
+
+// testQuerySpec is a spec that can be used for queries.
+var testQuerySpec *query.Spec
+
+func TestController_CancelQuery(t *testing.T) {
+	done := make(chan struct{})
+
+	executor := mock.NewExecutor()
+	executor.ExecuteFn = func(context.Context, platform.ID, *plan.PlanSpec, *execute.Allocator) (map[string]query.Result, error) {
+		<-done
+		return nil, nil
+	}
+
+	ctrl := New(Config{})
+	ctrl.executor = executor
+
+	// Run a query that will cause the controller to stall.
+	q, err := ctrl.Query(context.Background(), nil, testQuerySpec)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer func() {
+		close(done)
+		<-q.Ready()
+		q.Done()
+	}()
+
+	// Run another query. It should block in the Query call and then unblock when we cancel
+	// the context.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-timer.C:
+		case <-done:
+			timer.Stop()
+		}
+	}()
+
+	if _, err := ctrl.Query(ctx, nil, testQuerySpec); err == nil {
+		t.Fatal("expected error")
+	} else if got, want := err, context.Canceled; got != want {
+		t.Fatalf("unexpected error: got=%q want=%q", got, want)
+	}
+}
+
+func init() {
+	spec, err := query.Compile(context.Background(), `from(bucket: "telegraf") |> range(start: -5m) |> mean()`, time.Now())
+	if err != nil {
+		panic(err)
+	}
+	testQuerySpec = spec
+}


### PR DESCRIPTION
If a query is attempting to be enqueued and it gets canceled, it will
now stop attempting to add it to the new queries queue and return the
error reported by the context. This allows the http server to cancel a
running query when the client disconnects for whatever reason without
continuing to attempt to process the canceled query.