### PR TITLE
go test examples must follow a very specific format

### DIFF
--- a/kit/signals/context_test.go
+++ b/kit/signals/context_test.go
@@ -25,7 +25,7 @@ func ExampleWithSignals() {
 	// finished
 }
 
-func ExampleWithUnregisteredSignals() {
+func Example_withUnregisteredSignals() {
 	dctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond*100)
 	defer cancel()
 


### PR DESCRIPTION
go test examples must follow a very specific format when not referring to a specific identifier.
Namely the example name must start with "Example" followed by an underscore and lowercase letter.