### PR TITLE
fix(query/influxql): influxql transpiler should set the now time

### DIFF
--- a/query/influxql/cursor.go
+++ b/query/influxql/cursor.go
@@ -53,7 +53,7 @@ func createVarRefCursor(t *transpilerState, ref *influxql.VarRef) (cursor, error
 		return nil, err
 	}
 
-	valuer := influxql.NowValuer{Now: t.now}
+	valuer := influxql.NowValuer{Now: t.spec.Now}
 	_, tr, err := influxql.ConditionExpr(t.stmt.Condition, &valuer)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func createVarRefCursor(t *transpilerState, ref *influxql.VarRef) (cursor, error
 	// the end time will be set to now.
 	if tr.Max.IsZero() {
 		if window, err := t.stmt.GroupByInterval(); err == nil && window > 0 {
-			tr.Max = t.now
+			tr.Max = t.spec.Now
 		}
 	}
 

--- a/query/influxql/group.go
+++ b/query/influxql/group.go
@@ -133,7 +133,7 @@ func (gr *groupInfo) createCursor(t *transpilerState) (cursor, error) {
 		tags map[influxql.VarRef]struct{}
 		cond influxql.Expr
 	)
-	valuer := influxql.NowValuer{Now: t.now}
+	valuer := influxql.NowValuer{Now: t.spec.Now}
 	if t.stmt.Condition != nil {
 		var err error
 		if cond, _, err = influxql.ConditionExpr(t.stmt.Condition, &valuer); err != nil {
@@ -312,7 +312,7 @@ func (gr *groupInfo) group(t *transpilerState, in cursor) (cursor, error) {
 							} else if len(lit2.Args) != 0 {
 								return nil, errors.New("time dimension offset now() function requires no arguments")
 							}
-							now := t.now
+							now := t.spec.Now
 							windowOffset = now.Sub(now.Truncate(windowEvery))
 
 							// Use the evaluated offset to replace the argument. Ideally, we would

--- a/query/influxql/spectests/aggregates.go
+++ b/query/influxql/spectests/aggregates.go
@@ -160,6 +160,7 @@ func init() {
 						{Parent: aggregate.ID, Child: "map0"},
 						{Parent: "map0", Child: "yield0"},
 					},
+					Now: Now(),
 				}
 		}),
 	)

--- a/query/influxql/spectests/aggregates_with_condition.go
+++ b/query/influxql/spectests/aggregates_with_condition.go
@@ -145,6 +145,7 @@ func init() {
 						{Parent: aggregate.ID, Child: "map0"},
 						{Parent: "map0", Child: "yield0"},
 					},
+					Now: Now(),
 				}
 		}),
 	)

--- a/query/influxql/spectests/aggregates_with_groupby.go
+++ b/query/influxql/spectests/aggregates_with_groupby.go
@@ -122,6 +122,7 @@ func init() {
 						{Parent: aggregate.ID, Child: "map0"},
 						{Parent: "map0", Child: "yield0"},
 					},
+					Now: Now(),
 				}
 		}),
 	)

--- a/query/influxql/spectests/aggregates_with_window.go
+++ b/query/influxql/spectests/aggregates_with_window.go
@@ -147,6 +147,7 @@ func init() {
 						{Parent: "window1", Child: "map0"},
 						{Parent: "map0", Child: "yield0"},
 					},
+					Now: Now(),
 				}
 		}),
 	)

--- a/query/influxql/spectests/aggregates_with_window_offset.go
+++ b/query/influxql/spectests/aggregates_with_window_offset.go
@@ -148,6 +148,7 @@ func init() {
 						{Parent: "window1", Child: "map0"},
 						{Parent: "map0", Child: "yield0"},
 					},
+					Now: Now(),
 				}
 		}),
 	)

--- a/query/influxql/spectests/math.go
+++ b/query/influxql/spectests/math.go
@@ -219,6 +219,7 @@ func init() {
 					{Parent: "group0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/multiple_aggregates.go
+++ b/query/influxql/spectests/multiple_aggregates.go
@@ -247,6 +247,7 @@ func init() {
 					{Parent: "join0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/multiple_statements.go
+++ b/query/influxql/spectests/multiple_statements.go
@@ -240,6 +240,7 @@ func init() {
 					{Parent: "max0", Child: "map1"},
 					{Parent: "map1", Child: "yield1"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/raw.go
+++ b/query/influxql/spectests/raw.go
@@ -119,6 +119,7 @@ func init() {
 					{Parent: "group0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/raw_with_condition.go
+++ b/query/influxql/spectests/raw_with_condition.go
@@ -142,6 +142,7 @@ func init() {
 					{Parent: "group0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/raw_with_regex_condition.go
+++ b/query/influxql/spectests/raw_with_regex_condition.go
@@ -143,6 +143,7 @@ func init() {
 					{Parent: "group0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)
@@ -278,6 +279,7 @@ func init() {
 					{Parent: "group0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/retention_policy.go
+++ b/query/influxql/spectests/retention_policy.go
@@ -119,6 +119,7 @@ func init() {
 					{Parent: "group0", Child: "map0"},
 					{Parent: "map0", Child: "yield0"},
 				},
+				Now: Now(),
 			},
 		),
 	)

--- a/query/influxql/spectests/selectors.go
+++ b/query/influxql/spectests/selectors.go
@@ -161,6 +161,7 @@ func init() {
 						{Parent: selector.ID, Child: "map0"},
 						{Parent: "map0", Child: "yield0"},
 					},
+					Now: Now(),
 				}
 		}),
 	)

--- a/query/influxql/transpiler.go
+++ b/query/influxql/transpiler.go
@@ -56,7 +56,6 @@ type transpilerState struct {
 	config         Config
 	spec           *query.Spec
 	nextID         map[string]int
-	now            time.Time
 	dbrpMappingSvc platform.DBRPMappingService
 }
 
@@ -74,7 +73,7 @@ func newTranspilerState(dbrpMappingSvc platform.DBRPMappingService, config *Conf
 	}
 
 	// Stamp the current time using the now function from the config or the default.
-	state.now = state.config.NowFn()
+	state.spec.Now = state.config.NowFn()
 	return state
 }
 


### PR DESCRIPTION
The now time is stamped by the influxql transpiler and used inside of
the actual query. It will result in more accuracy if we take the
timestamp we have created and send it as part of the spec to queryd
rather than force ourselves to ensure absolute times exist everywhere.