### PR TITLE
controller sets Now time before enqueuing a query

### DIFF
--- a/query/spec.go
+++ b/query/spec.go
@@ -45,6 +45,9 @@ func (q *Spec) Walk(f func(o *Operation) error) error {
 
 // Validate ensures the query is a valid DAG.
 func (q *Spec) Validate() error {
+	if q.Now.IsZero() {
+		return errors.New("now time must be set")
+	}
 	return q.prepare()
 }
 


### PR DESCRIPTION
A transpiled query is submitted to the controller but is not produced by the Flux interpreter. Hence it cannot take advantage of the `now` option in order to set its `Now` field. The controller must explicitly check that the Now field of a query spec is set, and if not, must set it before enqueuing it.