### PR TITLE
feat(http): Add /ping endpoint to fluxd

### DIFF
--- a/http/query_service.go
+++ b/http/query_service.go
@@ -39,8 +39,15 @@ func NewQueryHandler() *QueryHandler {
 		csvEncoder: csv.NewMultiResultEncoder(csv.DefaultEncoderConfig()),
 	}
 
+	h.HandlerFunc("GET", "/ping", h.handlePing)
 	h.HandlerFunc("POST", queryPath, h.handlePostQuery)
 	return h
+}
+
+// handlePing returns a simple response to let the client know the server is running.
+func (h *QueryHandler) handlePing(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handlePostQuery is the HTTP handler for the POST /v1/query route.

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1,10 +1,26 @@
 openapi: "3.0.0"
 info:
-  title: Gateway Service
+  title: Influx API Service
   version: 0.1.0
 servers:
   - url: /v1
 paths:
+  /ping:
+    servers:
+      - url: /
+    get:
+      tags:
+        - Health
+      summary: Report if service is running
+      responses:
+        '204':
+          description: Server is healthy
+        default:
+          description: Any response other than 204 is an internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /authorizations:
     get:
       tags:


### PR DESCRIPTION
Closes #470 

Problem: We needed a way to verify that a flux connection was valid before updating or creating it on the Chronograf side. 

Solution: Add a ping endpoint for fluxd.