### PR TITLE
fix(ci): update to sirupsen/logrus from Sirupsen/logrus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,12 +8,6 @@
   version = "v1.0.1"
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
-  version = "v1.0.6"
-
-[[projects]]
   name = "github.com/alecthomas/kingpin"
   packages = ["."]
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
@@ -592,6 +586,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
+
+[[projects]]
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -841,6 +841,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b9db764d51c0ab5a91f4bedf6befa4ca7d562b9f310441e77dd74dfa1f739d71"
+  inputs-digest = "98278f4964b8c10b5c7667b2d695a8249efda38bdf7e11d756afeb0c76fa7005"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/chronograf/LICENSE_OF_DEPENDENCIES.md
+++ b/chronograf/LICENSE_OF_DEPENDENCIES.md
@@ -1,6 +1,6 @@
 ### Go
 * github.com/NYTimes/gziphandler [APACHE-2.0](https://github.com/NYTimes/gziphandler/blob/master/LICENSE.md)
-* github.com/Sirupsen/logrus [MIT](https://github.com/Sirupsen/logrus/blob/master/LICENSE)
+* github.com/sirupsen/logrus [MIT](https://github.com/sirupsen/logrus/blob/master/LICENSE)
 * github.com/boltdb/bolt [MIT](https://github.com/boltdb/bolt/blob/master/LICENSE)
 * github.com/bouk/httprouter [BSD](https://github.com/bouk/httprouter/blob/master/LICENSE)
 * github.com/dgrijalva/jwt-go [MIT](https://github.com/dgrijalva/jwt-go/blob/master/LICENSE)

--- a/chronograf/log/log.go
+++ b/chronograf/log/log.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/influxdata/platform/chronograf"
+	"github.com/sirupsen/logrus"
 )
 
 // Level type


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Update logrus dep to use new lowercase. 

_What was the problem?_
Import of chronograf used the older uppercase `Sirupsen` repo.  This causes downstream problems in projects vendoring this repo.

_What was the solution?_
Change to lowercase

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)