### PR TITLE
ci(deploy): nightlies use circleci/golang:1.10.3-node-browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/golang:1.10.2
+      - image: circleci/golang:1.10.3-node-browsers
     working_directory: /go/src/github.com/influxdata/platform
     steps:
       - checkout


### PR DESCRIPTION
_Briefly describe your proposed changes:_
We need to use a much larger container to test and release our master branch; it needs to include yarn and node.

_What was the problem?_
goreleaser is not able to be built with node/yarn etc.

_What was the solution?_
Use circles' circleci/golang:1.10.3-node-browsers container that has node, yarn and browsers for larger integration tests.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)