### PR TITLE
tests(query/functions): add benchmarks for all of the query tests

### DIFF
--- a/query/functions/from_csv.go
+++ b/query/functions/from_csv.go
@@ -3,7 +3,6 @@ package functions
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 
 	"context"
@@ -168,14 +167,12 @@ func (c *CSVSource) Run(ctx context.Context) {
 
 	if maxSet {
 		for _, t := range c.ts {
-			log.Println("UpdateWatermark", max)
 			t.UpdateWatermark(c.id, max)
 		}
 	}
 
 FINISH:
 	for _, t := range c.ts {
-		log.Println("FINISH")
 		t.Finish(c.id, err)
 	}
 }


### PR DESCRIPTION
This uses the same code as the other end to end so we can benchmark the
entire query engine.

Related to #433, but it doesn't complete it because we should also have benchmarks for only the parser itself.