### PR TITLE
Add a mapping of sources ids and names to dashboard export (#4033)

### DIFF
--- a/chronograf/CHANGELOG.md
+++ b/chronograf/CHANGELOG.md
@@ -1,4 +1,24 @@
 ## v1.5.1.0 [unreleased]
+## v1.6.1 [unreleased]
+
+### Features
+
+1.  [#4033](https://github.com/influxdata/chronograf/pull/4033): Include sources id, links, and names in dashboard export
+
+### UI Improvements
+1.  [#4009](https://github.com/influxdata/chronograf/pull/4009): Make it to get mouse into hover legend
+
+### Bug Fixes
+
+1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Ensure text template variables reflect query parameters
+1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Enable using a new, blank text template variable in a query
+1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Ensure cells with broken queries display “No Data”
+1.  [#3978](https://github.com/influxdata/chronograf/pull/3978): Fix use of template variables within InfluxQL regexes
+1.  [#3994](https://github.com/influxdata/chronograf/pull/3994): Pressing play on log viewer goes to now
+1.  [#4008](https://github.com/influxdata/chronograf/pull/4008): Fix display of log viewer histogram when a basepath is enabled
+
+
+## v1.6.0 [2018-06-18]
 
 ### Features
 

--- a/chronograf/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/chronograf/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -35,6 +35,7 @@ import {DashboardFile, Cell} from 'src/types/dashboards'
 
 interface Props {
   source: Source
+  sources: Source[]
   router: InjectedRouter
   handleGetDashboards: () => Dashboard[]
   handleGetChronografVersion: () => string
@@ -122,8 +123,22 @@ class DashboardsPage extends PureComponent<Props> {
   private modifyDashboardForDownload = async (
     dashboard: Dashboard
   ): Promise<DashboardFile> => {
+    const {sources} = this.props
+    const sourceMappings = _.reduce(
+      sources,
+      (acc, s) => {
+        const {name, id, links} = s
+        const link = _.get(links, 'self', '')
+        acc[id] = {name, link}
+        return acc
+      },
+      {}
+    )
     const version = await this.props.handleGetChronografVersion()
-    return {meta: {chronografVersion: version}, dashboard}
+    return {
+      meta: {chronografVersion: version, sources: sourceMappings},
+      dashboard,
+    }
   }
 
   private handleImportDashboard = async (
@@ -144,9 +159,10 @@ class DashboardsPage extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps = ({dashboardUI: {dashboards, dashboard}}) => ({
+const mapStateToProps = ({dashboardUI: {dashboards, dashboard}, sources}) => ({
   dashboards,
   dashboard,
+  sources,
 })
 
 const mapDispatchToProps = {

--- a/chronograf/ui/src/types/dashboards.ts
+++ b/chronograf/ui/src/types/dashboards.ts
@@ -116,6 +116,12 @@ export interface DashboardName {
 
 interface DashboardFileMetaSection {
   chronografVersion?: string
+  sources?: {
+    [x: string]: {
+      name: string
+      link: string
+    }
+  }
 }
 
 export interface DashboardFile {


### PR DESCRIPTION
* Add a mapping of sources ids, links, and names to dashboard export

* Update Changelog

Closes https://github.com/influxdata/chronograf/issues/4032

Briefly describe your proposed changes:
What was the problem?
Exported dashboard cells have links to sources which contain the source's id but it does not contain any other information about the sources.

What was the solution?
Create an object that maps the names of sources to their ids and export that under the meta section of the export file.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass