### PR TITLE
Use platform branch on influxDB

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:315c5f2f60c76d89b871c73f9bd5fe689cad96597afd50fb9992228ef80bdd34"
+  digest = "1:45a787c1adea69a03a5384865b307c7a72bb28bd5844bd57679d889a726a588b"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
@@ -46,7 +46,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:861e7c55835e36c4bb41132ee48a4669429096cc184b634b99809822b416f66b"
+  digest = "1:2b78355891c0c2d46ef0ddbd943eedbb079aae8e08734484926c475a039fee8f"
   name = "github.com/apex/log"
   packages = [
     ".",
@@ -56,7 +56,7 @@
   revision = "941dea75d3ebfbdd905a5d8b7b232965c5e5c684"
 
 [[projects]]
-  digest = "1:b42949704aad6dc86a9fa457ce3c80267d8875ba727bc3eb0eaa966e64e960b2"
+  digest = "1:33cfec13a3534ccca9eebcb19db7f98a743d92bdf7b1ef9b7a3522b4c570ff09"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -208,7 +208,7 @@
   version = "v1.38.1"
 
 [[projects]]
-  digest = "1:32e6bf93f32b6562d44dcdae34fd11a819224db80627bbc4ee108bfc01f81922"
+  digest = "1:dcfb52b8e9ca0cdee25b6d9a22153563bf7f8f5fda1c89418305d391883c9b3b"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -222,7 +222,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
+  digest = "1:cb22af0ed7c72d495d8be1106233ee553898950f15fd3f5404406d44c2e86888"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -237,7 +237,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5601ae3024d6657d6655a043fefce0ca8924af535fe56bcd184ecd2f7cfc5335"
+  digest = "1:53c27c02a8cf280f55d96c623b3a17a1ec6d4671b480e611f130e8b879bda02c"
   name = "github.com/gonum/blas"
   packages = [
     ".",
@@ -258,7 +258,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dc7c82ea61b3c8da96b40b7c87c1c26b41f735f516babec25ebe826acf359b43"
+  digest = "1:0ae62dc5709171737e0f80a606d6fddb3d9186bada5d97edb0b9f59929804eb8"
   name = "github.com/gonum/internal"
   packages = [
     "asm/f32",
@@ -269,7 +269,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2854c77b7dbe7f340e37d3b01c07f9da33b5ff7d21c915f195b4a0ae9f37d6f5"
+  digest = "1:19ee8b5eec201f8e1644adc42b12d25d4892b514ad6f3d3eb3b6bf9aca47543d"
   name = "github.com/gonum/lapack"
   packages = [
     ".",
@@ -281,7 +281,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fb0e34cdca23afa879f1d81cc9f514b8d9c34b84e83af9c642bb771d2583ed38"
+  digest = "1:3cb1fbc0aeca5cd0c1b8ca7d6ee6c5f8691b7736a5ee293c9cd084c0b67376cb"
   name = "github.com/gonum/mathext"
   packages = [
     ".",
@@ -305,7 +305,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bf0e5a82e5f51b7bbcdb3fa176368766dfb7e004846fb2cad398ea74e9239099"
+  digest = "1:7941ccd51e69364e11b810e2f7de3a672f8723c73147c120a09c8b20ab6d35cb"
   name = "github.com/gonum/stat"
   packages = [
     ".",
@@ -315,7 +315,7 @@
   revision = "ec9c8a1062f4be6c6ad671f0f5dba12d4a76826d"
 
 [[projects]]
-  digest = "1:d2754cafcab0d22c13541618a8029a70a8959eb3525ff201fe971637e2274cd0"
+  digest = "1:b787093a6b46cbdb290b2b304d12352eeff1bf7870852c3a0636acf87128c32b"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
@@ -345,7 +345,7 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
-  digest = "1:806381a928989b6d1dc01474d67a9d4df266172eadc976d46cb51633d0d0998e"
+  digest = "1:4510852611df80988ed8c13b81f7d5da9a6d11e872b35c91d6c2289375e14ac9"
   name = "github.com/goreleaser/archive"
   packages = [
     ".",
@@ -357,7 +357,7 @@
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:7b23aa84cb488f83b9a1519b1fbc19b43976dd5c47e7afa82e919f73f4cc0c40"
+  digest = "1:c8ca234cf3cd67c6c578c9f8a06f96308d29a309726bd1c0c0ae51122f86ae72"
   name = "github.com/goreleaser/goreleaser"
   packages = [
     ".",
@@ -404,7 +404,7 @@
   version = "v0.81.0"
 
 [[projects]]
-  digest = "1:555e46bfe479a0c08e69f57cbce309be0c5fb2f8bc203dc0be6132758a8dd158"
+  digest = "1:2e54c9033c450abc539c08a3373a8b22bcbfa0086e409b45ef0b47d8e16a5e5a"
   name = "github.com/goreleaser/nfpm"
   packages = [
     ".",
@@ -418,7 +418,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a361611b8c8c75a1091f00027767f7779b29cb37c456a71b8f2604c88057ab40"
+  digest = "1:ac64f01acc5eeea9dde40e326de6b6471e501392ec06524c3b51033aa50789bc"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -452,19 +452,19 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2fc879f3aea6394bcf801604a723d1e2c922a533b5cd0503ef36e293e06afe7e"
+  branch = "platform"
+  digest = "1:d1a6a9bc37b0d18e410b12e5d9eb2b18b833771d3847615f061c9c8b2e2b9c4a"
   name = "github.com/influxdata/influxdb"
   packages = [
     "logger",
     "pkg/snowflake",
   ]
   pruneopts = "UT"
-  revision = "200fda999f915dfc13c2b4030a2db6e0b08c689f"
+  revision = "468497c11f2583a9c702758da263dc238c430722"
 
 [[projects]]
   branch = "master"
-  digest = "1:5f9e39f96abf8babb7bdb3a51691b0693c48b08aba4ebaafe33710158487fd72"
+  digest = "1:2a6c3ea1ee3c12481676d47fa7be55512c8063c449e8de22e5d7e8be111288c5"
   name = "github.com/influxdata/influxql"
   packages = [
     ".",
@@ -528,7 +528,7 @@
   revision = "d1898390779332322e6b5ca5011da4bf249bb056"
 
 [[projects]]
-  digest = "1:d65b917f934f8a870c0d4c251dbc524cef0cf8d6bdf7da8275213b75c1205019"
+  digest = "1:3163684742ecef17798d82465a90ca81c459b934ad0c4d404d1a24d12d1a99ad"
   name = "github.com/kevinburke/go-bindata"
   packages = ["."]
   pruneopts = "UT"
@@ -577,7 +577,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:41bb99cfb6d5462fb3d1b935f47c79c7f6821f54b7aad99751697f8e013f4708"
+  digest = "1:d5d43384da435c333632c1677508b6014301ac54ca5fcf017d1e22c631752a7f"
   name = "github.com/mattn/go-zglob"
   packages = [
     ".",
@@ -612,7 +612,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:34fe82b3e3fd1a84348a21788e3a547112452bafd1cd061651875ea69b755a29"
+  digest = "1:55f13bd293ce115e09a4ead3c7aeae7a45064c4a77420eaaefef9c852c2c4bec"
   name = "github.com/mna/pigeon"
   packages = [
     ".",
@@ -623,7 +623,7 @@
   revision = "2ad051b8b508f69e7dcf8febdea2856ec2db73ed"
 
 [[projects]]
-  digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
+  digest = "1:27af6024faa3c28426a698b8c653be0fd908bc96e25b7d76f2192eb342427db6"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -659,7 +659,7 @@
   revision = "cda20d4ac917ad418d86e151eff439648b06185b"
 
 [[projects]]
-  digest = "1:70f78dea42b8c0ff38ecf5487eaa79006fa2193fc804fc7c1d7222745d9e2522"
+  digest = "1:cfdb4da10d5fbcb0bb608ed88ca69667bbc084535f46e2f613f64857383ba0e8"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -670,7 +670,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
+  digest = "1:53a76eb11bdc815fcf0c757a9648fda0ab6887da13f07587181ff2223b67956c"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "UT"
@@ -678,7 +678,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e469cd65badf7694aeb44874518606d93c1d59e7735d3754ad442782437d3cc3"
+  digest = "1:4d291d51042ed9de40eef61a3c1b56e969d6e0f8aa5fd3da5e958ec66bee68e4"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -690,7 +690,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:570784e0ddbf67f14087c6d8cfb7b999b9c55e75518a755e88cb202566ea8a17"
+  digest = "1:3269eaf682c80587cf6c3038d7848aee55d808126b17693b591f2656208fba5d"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -734,7 +734,7 @@
   version = "v1.0.6"
 
 [[projects]]
-  digest = "1:fe0b7f0c9a5e5511001fe085b0a156b29266012cd984a63e4059a30e84bba03a"
+  digest = "1:e4168390bb505389d58a8f5bca9e3cd9a34ffb32fbb00c4df5c0ca30fddc3d74"
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -753,7 +753,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
+  digest = "1:872fa275c31e1f9db31d66fa9b1d4a7bb9a080ff184e6977da01f36bfbe07f11"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = "UT"
@@ -793,7 +793,7 @@
   version = "v1.2.15"
 
 [[projects]]
-  digest = "1:104a2d7446f4628e4663d7c029b18da1aad4313735de775f37b6e7720b1d0aa7"
+  digest = "1:7627e9377eb0551bc8c6e2b0c54abbbf67e9afb675f45ea916bc63d8acb1d690"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -842,7 +842,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:973def4d3d414173bbc236b72680b76ec9509a62433b1814fcfd70c0386e272f"
+  digest = "1:5da4c6444c1b4531c6b88df4be7eadf3867e172f4702814fd59945d777ee1d44"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -867,7 +867,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3f14180c6649aeae872e969dd5ff1243cd34449532a7d057a117dce153249b04"
+  digest = "1:83e499528a73081ac36c2b9bbe83daf20bed8e33691dd37693bdc2083517ba42"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -884,7 +884,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:64615044c310a6e6c19bf7891bc33358e1819c069c25a6056c0a8ebaabc03205"
+  digest = "1:eafd05faf55389011cbc41d8144a6013d4b96331819cb16baa63fee38a5aa0ba"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -905,7 +905,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:105645ed366a17f9ed1007059f0d3506e73e2098f2a1e793ffa92917d6461060"
+  digest = "1:9f14317f6f15863d0342b7d6835513920bb44fc2c6932ed9cc4f3810c3932cbb"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -915,7 +915,7 @@
   revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  digest = "1:7509ba4347d1f8de6ae9be8818b0cd1abc3deeffe28aeaf4be6d4b6b5178d9ca"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -939,7 +939,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4d63ca26a477869856c95a8a9760a8405686065538bd375d1f1481a8f5528094"
+  digest = "1:27e34c3cdf937ac29cedfbf25b92f38a08411df54be07528f1a3938d9f8a2bb2"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -951,7 +951,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b6e61b553fead421d0090a416a44afc2073ba443d9c13b8de0374b4ac4dc80c1"
+  digest = "1:3ce4a9870f8b14fe931e66972abee3cba24e51b5759be13f47d31c959741f5e1"
   name = "google.golang.org/api"
   packages = [
     "gensupport",
@@ -963,7 +963,7 @@
   revision = "cd7aead8ef3786a3a18faf2d54d3960991153b64"
 
 [[projects]]
-  digest = "1:9cf45e754ab2dff5f53a553e6948b994ff738e4d1092ca608dcada945d8be0ef"
+  digest = "1:5b1b922276e3bd88f101cf1c235bbadecdd19c6fda4b635968d7cfff6ca5f23d"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -987,7 +987,7 @@
   revision = "ff3583edef7de132f219f0efc00e097cabcc0ec0"
 
 [[projects]]
-  digest = "1:2dab32a43451e320e49608ff4542fdfc653c95dcc35d0065ec9c6c3dd540ed74"
+  digest = "1:4515e3030c440845b046354fd5d57671238428b820deebce2e9dabb5cd3c51ac"
   name = "google.golang.org/grpc"
   packages = [
     ".",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@ required = [
 
 [[constraint]]
   name = "github.com/influxdata/influxdb"
-  branch = "master"
+  branch = "platform"
 
 [[constraint]]
   name = "github.com/influxdata/tdigest"


### PR DESCRIPTION
We will now use the `platform` branch of InfluxDB, so that we can make breaking changes to the storage engine, and import them into Platform.

This is preferable to migrating code into Platform, or using a fork, as it will make it easier to keep the InfluxDB `platform` branch up-to-date with the InfluxDB `master` branch whilst the 1.7 development cycle is ongoing.