### PR TITLE
fix: Panic in query/controller on Statistics

### DIFF
--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -435,6 +435,9 @@ func (q *Query) Done() {
 // Statistics reports the statisitcs for the query.
 // The statisitcs are not complete until the query is finished.
 func (q *Query) Statistics() query.Statistics {
+	q.mu.Lock()
+	defer q.mu.Lock()
+
 	stats := query.Statistics{}
 	stats.TotalDuration = q.parentSpan.Duration
 	if q.compileSpan != nil {
@@ -453,7 +456,9 @@ func (q *Query) Statistics() query.Statistics {
 		stats.ExecuteDuration = q.executeSpan.Duration
 	}
 	stats.Concurrency = q.concurrency
-	stats.MaxAllocated = q.alloc.Max()
+	if q.alloc != nil {
+		stats.MaxAllocated = q.alloc.Max()
+	}
 	return stats
 }
 


### PR DESCRIPTION

_Briefly describe your proposed changes:_
Guard against nil allocator, since the allocator will only exist of the query managed to get to the execution step.

_What was the problem?_

Panic on nil allocator

_What was the solution?_

Guard against nill allocator


  - [x] Rebased/mergeable
  - [x] Tests pass