### PR TITLE
feat: do not require the makefile for go generate

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -208,14 +208,37 @@
   version = "v1.38.1"
 
 [[projects]]
-  digest = "1:32e6bf93f32b6562d44dcdae34fd11a819224db80627bbc4ee108bfc01f81922"
+  digest = "1:f211070279a54483ab7923376cebb4c024e84aeee17a989537e054413a0f88f4"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
+    "plugin/compare",
+    "plugin/defaultcheck",
+    "plugin/description",
+    "plugin/embedcheck",
+    "plugin/enumstringer",
+    "plugin/equal",
+    "plugin/face",
+    "plugin/gostring",
+    "plugin/marshalto",
+    "plugin/oneofcheck",
+    "plugin/populate",
+    "plugin/size",
+    "plugin/stringer",
+    "plugin/testgen",
+    "plugin/union",
+    "plugin/unmarshal",
     "proto",
+    "protoc-gen-gogo",
     "protoc-gen-gogo/descriptor",
+    "protoc-gen-gogo/generator",
+    "protoc-gen-gogo/grpc",
+    "protoc-gen-gogo/plugin",
+    "protoc-gen-gogofaster",
     "sortkeys",
     "types",
+    "vanity",
+    "vanity/command",
   ]
   pruneopts = "UT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
@@ -1050,6 +1073,8 @@
     "github.com/elazarl/go-bindata-assetfs",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",
+    "github.com/gogo/protobuf/protoc-gen-gogo",
+    "github.com/gogo/protobuf/protoc-gen-gogofaster",
     "github.com/gogo/protobuf/types",
     "github.com/gonum/stat/distuv",
     "github.com/google/go-cmp/cmp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,10 @@ required = [
     "github.com/mna/pigeon",
     # goreleaser is a utility to build and upload to S3
     "github.com/goreleaser/goreleaser",
-    "github.com/kevinburke/go-bindata"
+    "github.com/kevinburke/go-bindata",
+
+    "github.com/gogo/protobuf/protoc-gen-gogo",
+    "github.com/gogo/protobuf/protoc-gen-gogofaster",
 ]
 
 [[constraint]]

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ CMDS := \
 
 # List of utilities to build as part of the build process
 UTILS := \
-	bin/$(GOOS)/pigeon \
-	bin/$(GOOS)/cmpgen \
 	bin/$(GOOS)/goreleaser
 
 # Default target to build all commands.
@@ -54,7 +52,7 @@ all: dep generate Gopkg.lock $(UTILS) subdirs $(CMDS)
 
 # Target to build subdirs.
 # Each subdirs must support the `all` target.
-subdirs: $(SUBDIRS)
+subdirs: $(SUBDIRS) | vendor
 	@for d in $^; do $(MAKE) -C $$d all; done
 
 #
@@ -66,12 +64,6 @@ $(CMDS): $(SOURCES)
 #
 # Define targets for utilities
 #
-
-bin/$(GOOS)/pigeon: ./vendor/github.com/mna/pigeon/main.go
-	go build -i -o $@  ./vendor/github.com/mna/pigeon
-
-bin/$(GOOS)/cmpgen: ./query/ast/asttest/cmpgen/main.go
-	go build -i -o $@ ./query/ast/asttest/cmpgen
 
 bin/$(GOOS)/goreleaser: ./vendor/github.com/goreleaser/goreleaser/main.go
 	go build -i -o $@ ./vendor/github.com/goreleaser/goreleaser
@@ -97,12 +89,9 @@ endif
 # Define how source dependencies are managed
 #
 
-Gopkg.lock: Gopkg.toml
+Gopkg.lock vendor: Gopkg.toml
 	dep ensure -v
 	touch Gopkg.lock
-
-vendor/github.com/mna/pigeon/main.go: Gopkg.lock
-	dep ensure -v -vendor-only
 
 vendor/github.com/goreleaser/goreleaser/main.go: Gopkg.lock
 	dep ensure -v -vendor-only

--- a/gorunpkg.go
+++ b/gorunpkg.go
@@ -1,0 +1,121 @@
+// +build ignore
+
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"go/build"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// loadPkgFiles loads the go files that should be compiled from a package.
+func loadPkgFiles(pkgpath string) (string, []string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", nil, err
+	}
+
+	pkg, err := build.Import(pkgpath, wd, 0)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Combine the files with the directory path to get absolute file names.
+	files := make([]string, len(pkg.GoFiles))
+	for i, fpath := range pkg.GoFiles {
+		files[i] = filepath.Join(pkg.Dir, fpath)
+	}
+
+	gopath := os.Getenv("GOPATH")
+	pkgdir, err := filepath.Rel(filepath.Join(gopath, "src"), pkg.Dir)
+	if err != nil {
+		return "", nil, err
+	}
+	return pkgdir, files, nil
+}
+
+// hashInputs takes the file inputs and creates a file hash for them.
+// This hash is used to cache file outputs.
+func hashInputs(inputs []string) (string, error) {
+	h := md5.New()
+	for _, fpath := range inputs {
+		f, err := os.Open(fpath)
+		if err != nil {
+			return "", err
+		}
+		io.Copy(h, f)
+		if err := f.Close(); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// compile will compile the file from the inputs and output the result to bin.
+func compile(bin, pkgdir string) error {
+	cmd := exec.Command("go", "build", "-i", "-o", bin, pkgdir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// run will run the binary or, if it does not exist, will compile it from the inputs.
+func run(bin, pkgdir string, args []string) error {
+	if _, err := os.Stat(bin); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		// Compile the file.
+		if err := compile(bin, pkgdir); err != nil {
+			return err
+		}
+	}
+
+	// The file should exist if we get here so try to execute it and pass all of the arguments.
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// realMain is the real main function that returns an error so main can print an appropriate message.
+// It prevents cluttering main with the same error handling logic.
+func realMain() error {
+	if len(os.Args) < 2 {
+		return errors.New("gorunpkg must be run with at least one argument")
+	}
+
+	pkgdir, inputs, err := loadPkgFiles(os.Args[1])
+	if err != nil {
+		return fmt.Errorf("unable to load package: %s", err)
+	}
+
+	// Hash the inputs so that we can find where the binary should be compiled to.
+	hash, err := hashInputs(inputs)
+	if err != nil {
+		return err
+	}
+
+	// Compute the filepath and then run the file. This will automatically compile it if needed.
+	binpath := filepath.Join(os.TempDir(), "gopkgrun", fmt.Sprintf("%s-%s", filepath.Base(os.Args[1]), hash))
+	return run(binpath, pkgdir, os.Args[2:])
+}
+
+func main() {
+	if err := realMain(); err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			// The binary that failed should have already printed the error output.
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "error: %s.\n", err)
+		os.Exit(1)
+	}
+}

--- a/query/ast/asttest/Makefile
+++ b/query/ast/asttest/Makefile
@@ -1,6 +1,6 @@
 all: cmpopts.go
 
-cmpopts.go: ../ast.go gen.go ../../../bin/$(GOOS)/cmpgen
+cmpopts.go: ../ast.go gen.go
 	PATH=../../../bin/${GOOS}:${PATH} $(GO_GENERATE) -x ./...
 
 clean:

--- a/query/ast/asttest/gen.go
+++ b/query/ast/asttest/gen.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-//go:generate cmpgen cmpopts.go
+//go:generate go run ../../../gorunpkg.go ./cmpgen cmpopts.go
 
 var CompareOptions = append(IgnoreBaseNodeOptions,
 	cmp.Comparer(func(x, y *regexp.Regexp) bool { return x.String() == y.String() }),

--- a/query/parser/Makefile
+++ b/query/parser/Makefile
@@ -1,6 +1,6 @@
 all: flux.go
 
-flux.go: flux.peg parser.go parser_debug.go ../../bin/$(GOOS)/pigeon
+flux.go: flux.peg parser.go parser_debug.go | ../../vendor
 	PATH=../../bin/${GOOS}:${PATH} $(GO_GENERATE) -x ./...
 
 clean:

--- a/query/parser/parser.go
+++ b/query/parser/parser.go
@@ -2,7 +2,7 @@
 
 package parser
 
-//go:generate pigeon -optimize-parser -optimize-grammar -o flux.go flux.peg
+//go:generate go run ../../gorunpkg.go github.com/mna/pigeon -optimize-parser -optimize-grammar -o flux.go flux.peg
 
 import (
 	"github.com/influxdata/platform/query/ast"

--- a/query/parser/parser_debug.go
+++ b/query/parser/parser_debug.go
@@ -2,7 +2,7 @@
 
 package parser
 
-//go:generate pigeon -optimize-grammar -o flux.go flux.peg
+//go:generate go run ../../gorunpkg.go github.com/mna/pigeon -optimize-grammar -o flux.go flux.peg
 
 import (
 	"github.com/influxdata/platform/query/ast"

--- a/query/promql/gen.go
+++ b/query/promql/gen.go
@@ -1,3 +1,3 @@
 package promql
 
-//go:generate pigeon -o promql.go promql.peg
+//go:generate go run ../../gorunpkg.go github.com/mna/pigeon -o promql.go promql.peg

--- a/scripts/protoc-gen-gogo
+++ b/scripts/protoc-gen-gogo
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+dirname=$(dirname $0)
+exec go run ${dirname}/../gorunpkg.go github.com/gogo/protobuf/protoc-gen-gogo "$@"

--- a/scripts/protoc-gen-gogofaster
+++ b/scripts/protoc-gen-gogofaster
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+dirname=$(dirname $0)
+exec go run ${dirname}/../gorunpkg.go github.com/gogo/protobuf/protoc-gen-gogofaster "$@"

--- a/task/backend/pb/pb.go
+++ b/task/backend/pb/pb.go
@@ -4,4 +4,4 @@ package pb
 
 // The tooling needed to correctly run go generate is managed by the Makefile.
 // Run `make` from the project root to ensure these generate commands execute correctly.
-//go:generate protoc -I ../../../vendor -I . --plugin ../../../bin/${GOOS}/protoc-gen-gogofaster --gogofaster_out=plugins=grpc:. ./tasks.proto
+//go:generate protoc -I ../../../vendor -I . --plugin ../../../scripts/protoc-gen-gogofaster --gogofaster_out=plugins=grpc:. ./tasks.proto


### PR DESCRIPTION
There is now a gorunpkg.go script that will perform the simple tasks of
compiling a module and running it similar to how `go run` works for a
file. This script can be run and used for generating files so `go
generate ./...` works properly without installing any dependencies
manually.