### PR TITLE
feat(tasks): add get meta to the store interface.

### DIFF
--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -357,7 +357,7 @@ func (s *Store) FindTaskMetaByID(ctx context.Context, id platform.ID) (*pb.Store
 		b := tx.Bucket(s.bucket)
 		stmBytes = b.Bucket(taskMetaPath).Get(paddedID)
 		if stmBytes == nil {
-			return ErrNotFound
+			return errors.New("task meta not found")
 		}
 		return nil
 	})
@@ -371,7 +371,7 @@ func (s *Store) FindTaskMetaByID(ctx context.Context, id platform.ID) (*pb.Store
 		return nil, err
 	}
 
-	return &stm, err
+	return &stm, nil
 }
 
 // DeleteTask deletes the task

--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -158,7 +158,7 @@ func (s *Store) CreateTask(ctx context.Context, org, user platform.ID, script st
 
 		// metadata
 		stm := pb.StoredTaskInternalMeta{
-			MaxConcurrency: 1,
+			MaxConcurrency: int32(o.Concurrency),
 		}
 
 		stmBytes, err := stm.Marshal()
@@ -348,6 +348,30 @@ func (s *Store) FindTaskByID(ctx context.Context, id platform.ID) (*backend.Stor
 		Name:   string(name),
 		Script: string(script),
 	}, err
+}
+
+func (s *Store) FindTaskMetaByID(ctx context.Context, id platform.ID) (*pb.StoredTaskInternalMeta, error) {
+	var stmBytes []byte
+	paddedID := padID(id)
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(s.bucket)
+		stmBytes = b.Bucket(taskMetaPath).Get(paddedID)
+		if stmBytes == nil {
+			return ErrNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	stm := pb.StoredTaskInternalMeta{}
+	err = stm.Unmarshal(stmBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stm, err
 }
 
 // DeleteTask deletes the task

--- a/task/backend/inmem_store.go
+++ b/task/backend/inmem_store.go
@@ -57,7 +57,7 @@ func (s *inmem) CreateTask(_ context.Context, org, user platform.ID, script stri
 
 	s.mu.Lock()
 	s.tasks = append(s.tasks, task)
-	s.runners[id.String()] = pb.StoredTaskInternalMeta{MaxConcurrency: 1} // TODO:  make settable in the create
+	s.runners[id.String()] = pb.StoredTaskInternalMeta{MaxConcurrency: int32(o.Concurrency)} // TODO:  make settable in the create
 	s.mu.Unlock()
 
 	return id, nil
@@ -146,6 +146,14 @@ func (s *inmem) FindTaskByID(_ context.Context, id platform.ID) (*StoreTask, err
 	}
 
 	return nil, nil
+}
+func (s *inmem) FindTaskMetaByID(ctx context.Context, id platform.ID) (*pb.StoredTaskInternalMeta, error) {
+	meta, ok := s.runners[id.String()]
+	if !ok {
+		return nil, errors.New("task meta not found")
+	}
+
+	return &meta, nil
 }
 
 func (s *inmem) DeleteTask(_ context.Context, id platform.ID) (deleted bool, err error) {

--- a/task/backend/inmem_store.go
+++ b/task/backend/inmem_store.go
@@ -57,7 +57,7 @@ func (s *inmem) CreateTask(_ context.Context, org, user platform.ID, script stri
 
 	s.mu.Lock()
 	s.tasks = append(s.tasks, task)
-	s.runners[id.String()] = pb.StoredTaskInternalMeta{MaxConcurrency: int32(o.Concurrency)} // TODO:  make settable in the create
+	s.runners[id.String()] = pb.StoredTaskInternalMeta{MaxConcurrency: int32(o.Concurrency)}
 	s.mu.Unlock()
 
 	return id, nil

--- a/task/backend/store.go
+++ b/task/backend/store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/task/backend/pb"
 	"github.com/influxdata/platform/task/options"
 )
 
@@ -25,6 +26,9 @@ type Store interface {
 	// FindTaskByID returns the task with the given ID.
 	// If no task matches the ID, the returned task is nil.
 	FindTaskByID(ctx context.Context, id platform.ID) (*StoreTask, error)
+
+	// FindTaskMetaByID returns the metadata about a task.
+	FindTaskMetaByID(ctx context.Context, id platform.ID) (*pb.StoredTaskInternalMeta, error)
 
 	// DeleteTask returns whether an entry matching the given ID was deleted.
 	// If err is non-nil, deleted is false.


### PR DESCRIPTION
Grant access to backend task meta which should allow us to pick up where we left off in the event of a crash.

  - [ ] Rebased/mergeable
  - [x] Tests pass
