### PR TITLE
test: use zaptest logger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -864,7 +864,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:973def4d3d414173bbc236b72680b76ec9509a62433b1814fcfd70c0386e272f"
+  digest = "1:ec84c73fae08866389c8ffb608073553cdbe0eea4c3236fddbe33a2f114e2453"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -872,7 +872,9 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
+    "internal/ztest",
     "zapcore",
+    "zaptest",
     "zaptest/observer",
   ]
   pruneopts = "UT"
@@ -1105,6 +1107,7 @@
     "github.com/uber/jaeger-client-go/log",
     "github.com/uber/jaeger-lib/metrics",
     "go.uber.org/zap",
+    "go.uber.org/zap/zaptest",
     "go.uber.org/zap/zaptest/observer",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -13,12 +13,13 @@ import (
 	"github.com/influxdata/platform/task/backend"
 	"github.com/influxdata/platform/task/mock"
 	"github.com/influxdata/platform/task/options"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestScheduler_EveryValidation(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
-	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
+	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5, backend.WithLogger(zaptest.NewLogger(t)))
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
 	}
@@ -48,7 +49,7 @@ func TestScheduler_EveryValidation(t *testing.T) {
 func TestScheduler_StartScriptOnClaim(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
-	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
+	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5, backend.WithLogger(zaptest.NewLogger(t)))
 
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
@@ -80,7 +81,7 @@ func TestScheduler_StartScriptOnClaim(t *testing.T) {
 func TestScheduler_CreateRunOnTick(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
-	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
+	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5, backend.WithLogger(zaptest.NewLogger(t)))
 
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
@@ -123,7 +124,7 @@ func TestScheduler_CreateRunOnTick(t *testing.T) {
 func TestScheduler_Release(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
-	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
+	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5, backend.WithLogger(zaptest.NewLogger(t)))
 
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
@@ -153,7 +154,7 @@ func TestScheduler_RunLog(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
 	rl := backend.NewInMemRunReaderWriter()
-	s := backend.NewScheduler(d, e, rl, 5)
+	s := backend.NewScheduler(d, e, rl, 5, backend.WithLogger(zaptest.NewLogger(t)))
 
 	// Claim a task that starts later.
 	task := &backend.StoreTask{
@@ -283,7 +284,7 @@ func TestScheduler_RunLog(t *testing.T) {
 func TestScheduler_Metrics(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
-	s := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
+	s := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5, backend.WithLogger(zaptest.NewLogger(t)))
 
 	reg := prom.NewRegistry()
 	// PrometheusCollector isn't part of the Scheduler interface. Yet.


### PR DESCRIPTION
In places where we were explicitly passing a logger, or where we were
able to pass a logger via functional options, we now pass a zaptest
logger, which will call t.Logf, meaning you will see the log message if
the test fails or if you run go test -v.

I did not modify any of the places where we skip setting a logger with
the WithLogger method pattern, which I believe we've considered
deprecated now.
