### PR TITLE
Take into account ':<type>' when computing column header widths

### DIFF
--- a/query/execute/format.go
+++ b/query/execute/format.go
@@ -87,7 +87,8 @@ func (f *Formatter) WriteTo(out io.Writer) (int64, error) {
 	// Compute header widths
 	f.widths = make([]int, len(cols))
 	for j, c := range cols {
-		l := len(c.Label)
+		// Column header is "<label>:<type>"
+		l := len(c.Label) + len(c.Type.String()) + 1
 		min := minWidthsByType[c.Type]
 		if min > l {
 			l = min


### PR DESCRIPTION

_Briefly describe your proposed changes:_

Fixes an issue with formatting tables that was causing a panic when a column header was long.

_What was the problem?_

Code that computes column widths was not taking the `:<type>` part of the column headers.

_What was the solution?_

Update the logic to include the complete width of the column header.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)