### PR TITLE
feat(http): support posting queries as a json body

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1073,6 +1073,7 @@ components:
               type: string
               default: ","
               maxLength: 1
+              minLength: 1
             annotations:
               description: https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
               type: array
@@ -1089,6 +1090,7 @@ components:
               type: string
               default: \#
               maxLength: 1
+              minLength: 0
             dateTimeFormat:
               description: format of timestamps
               type: string


### PR DESCRIPTION
Co-authored-by: Chris Goller <goller@gmail.com>

_What was the problem?_
Query endpoint assumed that if it was application JSON, it was a spec based query instead of a regular flux query.

_What was the solution?_
Add support for posting flux queries as a json body.
Add more validation.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
