### PR TITLE
feat(query): log panics with their stacktraces within the query executor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -535,12 +535,12 @@
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:78867fbb25230fd7dacdc62eab84f78593d74adee03ce974038cfd8299615167"
+  digest = "1:e788f8a9bd113b97bf37e03cb98be2df72dff19714ee17fdd887417c46bd46dd"
   name = "github.com/jsternberg/zap-logfmt"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ac4bd917e18a4548ce6e0e765b29a4e7f397b0b6"
-  version = "v1.0.0"
+  revision = "9a5340c241253a529cbf359db5038e5b3549bd53"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:86228f0e4ff0f954420afeee30b44fedebc2ceebc78228e4f9dd0a4e0c93bf68"
@@ -864,7 +864,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:973def4d3d414173bbc236b72680b76ec9509a62433b1814fcfd70c0386e272f"
+  digest = "1:ec84c73fae08866389c8ffb608073553cdbe0eea4c3236fddbe33a2f114e2453"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -872,7 +872,9 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
+    "internal/ztest",
     "zapcore",
+    "zaptest",
     "zaptest/observer",
   ]
   pruneopts = "UT"
@@ -1105,6 +1107,8 @@
     "github.com/uber/jaeger-client-go/log",
     "github.com/uber/jaeger-lib/metrics",
     "go.uber.org/zap",
+    "go.uber.org/zap/zapcore",
+    "go.uber.org/zap/zaptest",
     "go.uber.org/zap/zaptest/observer",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",

--- a/query/execute/executor_test.go
+++ b/query/execute/executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/platform/query/functions"
 	"github.com/influxdata/platform/query/plan"
 	uuid "github.com/satori/go.uuid"
+	"go.uber.org/zap/zaptest"
 )
 
 var epoch = time.Unix(0, 0)
@@ -488,7 +489,7 @@ func TestExecutor_Execute(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			exe := execute.NewExecutor(nil)
+			exe := execute.NewExecutor(nil, zaptest.NewLogger(t))
 			results, err := exe.Execute(context.Background(), orgID, tc.plan, executetest.UnlimitedAllocator)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The logger is now threaded into the query controller, executor, and the
dispatcher so that we can log panics. They are logged at the info level
because the panics do not result in the system crashing and becoming
unusable.