### PR TITLE
StoreTaskMeta cleanup and support for task option delay

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1092,6 +1092,8 @@
     "github.com/kevinburke/go-bindata",
     "github.com/mna/pigeon",
     "github.com/opentracing/opentracing-go",
+    "github.com/opentracing/opentracing-go/ext",
+    "github.com/opentracing/opentracing-go/log",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",

--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/influxdata/platform"
@@ -212,6 +213,7 @@ func (s *Store) CreateTask(ctx context.Context, org, user platform.ID, script st
 			Status:         string(backend.TaskEnabled),
 			LastCompleted:  scheduleAfter,
 			EffectiveCron:  o.EffectiveCronString(),
+			Delay:          int32(o.Delay / time.Second),
 		}
 
 		stmBytes, err := stm.Marshal()

--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -211,6 +211,7 @@ func (s *Store) CreateTask(ctx context.Context, org, user platform.ID, script st
 			MaxConcurrency: int32(o.Concurrency),
 			Status:         string(backend.TaskEnabled),
 			LastCompleted:  scheduleAfter,
+			EffectiveCron:  o.EffectiveCronString(),
 		}
 
 		stmBytes, err := stm.Marshal()

--- a/task/backend/inmem_store.go
+++ b/task/backend/inmem_store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/snowflake"
@@ -67,6 +68,7 @@ func (s *inmem) CreateTask(_ context.Context, org, user platform.ID, script stri
 		Status:         string(TaskEnabled),
 		LastCompleted:  scheduleAfter,
 		EffectiveCron:  o.EffectiveCronString(),
+		Delay:          int32(o.Delay / time.Second),
 	}
 
 	return id, nil

--- a/task/backend/inmem_store.go
+++ b/task/backend/inmem_store.go
@@ -62,7 +62,12 @@ func (s *inmem) CreateTask(_ context.Context, org, user platform.ID, script stri
 		}
 	}
 	s.tasks = append(s.tasks, task)
-	s.runners[id.String()] = StoreTaskMeta{MaxConcurrency: int32(o.Concurrency), Status: string(TaskEnabled), LastCompleted: scheduleAfter}
+	s.runners[id.String()] = StoreTaskMeta{
+		MaxConcurrency: int32(o.Concurrency),
+		Status:         string(TaskEnabled),
+		LastCompleted:  scheduleAfter,
+		EffectiveCron:  o.EffectiveCronString(),
+	}
 
 	return id, nil
 }

--- a/task/backend/meta.go
+++ b/task/backend/meta.go
@@ -2,8 +2,11 @@ package backend
 
 import (
 	"bytes"
+	"errors"
+	"time"
 
 	"github.com/influxdata/platform"
+	cron "gopkg.in/robfig/cron.v2"
 )
 
 // This file contains helper methods for the StoreTaskMeta type defined in protobuf.
@@ -24,4 +27,52 @@ func (stm *StoreTaskMeta) FinishRun(runID platform.ID) bool {
 		}
 	}
 	return false
+}
+
+// CreateNextRun attempts to update stm's CurrentlyRunning slice with a new run
+// whose now time is no later than the given now.
+// makeID is a function provided by the caller to create an ID, in case we can create a run.
+// Because a StoreTaskMeta doesn't know the ID of the task it belongs to, it never sets RunCreation.Created.TaskID.
+func (stm *StoreTaskMeta) CreateNextRun(now int64, makeID func() (platform.ID, error)) (RunCreation, error) {
+	if len(stm.CurrentlyRunning) >= int(stm.MaxConcurrency) {
+		return RunCreation{}, errors.New("cannot create next run when max concurrency already reached")
+	}
+
+	sch, err := cron.Parse(stm.EffectiveCron)
+	if err != nil {
+		return RunCreation{}, err
+	}
+
+	latest := stm.LastCompleted
+	for _, cr := range stm.CurrentlyRunning {
+		if cr.Now > latest {
+			latest = cr.Now
+		}
+	}
+
+	nextScheduled := sch.Next(time.Unix(latest, 0))
+	nextScheduledUnix := nextScheduled.Unix()
+	if dueAt := nextScheduledUnix + int64(stm.Delay); dueAt > now {
+		// Can't schedule yet.
+		return RunCreation{}, RunNotYetDueError{DueAt: dueAt}
+	}
+
+	id, err := makeID()
+	if err != nil {
+		return RunCreation{}, err
+	}
+
+	stm.CurrentlyRunning = append(stm.CurrentlyRunning, &StoreTaskMetaRun{
+		Now:   nextScheduledUnix,
+		Try:   1,
+		RunID: id,
+	})
+
+	return RunCreation{
+		Created: QueuedRun{
+			RunID: id,
+			Now:   nextScheduledUnix,
+		},
+		NextDue: sch.Next(nextScheduled).Unix() + int64(stm.Delay),
+	}, nil
 }

--- a/task/backend/meta.proto
+++ b/task/backend/meta.proto
@@ -10,15 +10,57 @@ option go_package = "backend";
 message StoreTaskMeta {
   int32 max_concurrency = 1;
 
-  // last_completed is a unix time stamp of the last completed run.
+  // last_completed is the unix timestamp of the last "naturally" completed run.
   int64 last_completed = 2;
+
+  // status indicates if the task is enabled or disabled.
   string status = 3;
+
+  // currently_running is the collection of runs in-progress.
+  // If a runner crashes or otherwise disappears, this indicates to the new runner what needs to be picked up.
   repeated StoreTaskMetaRun currently_running = 4;
+
+  // effective_cron is the effective cron string as reported by the task's options.
+  string effective_cron = 5;
+
+  // Task's configured delay, in seconds.
+  int32 delay = 6;
+
+  // Fields below here are less likely to be present, so we're counting from 16 in order to
+  // use the 1-byte-encodable values where we can be more sure they're present.
+
+  repeated StoreTaskMetaManualRun manual_runs = 16;
 }
 
 message StoreTaskMetaRun {
-  // now represents a unix timestamp
+  // now is the unix timestamp of the "now" value for the run.
   int64 now = 1;
   uint32 try = 2;
   bytes run_id = 3 [(gogoproto.customname) = "RunID"];
+
+  // range_start is the start of the manual run's time range.
+  int64 range_start = 4;
+
+  // range_end is the end of the manual run's time range.
+  int64 range_end = 5;
+
+  // requested_at is the unix timestamp indicating when this run was requested.
+  // It is the same value as the "parent" StoreTaskMetaManualRun, if this run was the result of a manual request.
+  int64 requested_at = 6;
+}
+
+// StoreTaskMetaManualRun indicates a manually requested run for a time range.
+// It has a start and end pair of unix timestamps indicating the time range covered by the request.
+message StoreTaskMetaManualRun {
+  // start is the earliest allowable unix time stamp for this queue of runs.
+  int64 start = 1;
+
+  // end is the latest allowable unix time stamp for this queue of runs.
+  int64 end = 2;
+
+  // latest_completed is the timestamp of the latest completed run from this queue.
+  int64 latest_completed = 3;
+
+  // requested_at is the unix timestamp indicating when this run was requested.
+  int64 requested_at = 4;
 }

--- a/task/backend/meta_test.go
+++ b/task/backend/meta_test.go
@@ -1,0 +1,118 @@
+package backend_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/snowflake"
+	"github.com/influxdata/platform/task/backend"
+)
+
+var idGen = snowflake.NewIDGenerator()
+
+func makeID() (platform.ID, error) {
+	return idGen.ID(), nil
+}
+
+func TestMeta_CreateNextRun(t *testing.T) {
+	good := backend.StoreTaskMeta{
+		MaxConcurrency: 2,
+		Status:         "enabled",
+		EffectiveCron:  "* * * * *", // Every minute.
+		LastCompleted:  60,          // It has run once for the first minute.
+	}
+
+	_, err := good.CreateNextRun(59, makeID)
+	if e, ok := err.(backend.RunNotYetDueError); !ok {
+		t.Fatalf("expected RunNotYetDueError, got %v (%T)", err, err)
+	} else if e.DueAt != 120 {
+		t.Fatalf("expected run due at 120, got %d", e.DueAt)
+	}
+
+	bad := new(backend.StoreTaskMeta)
+	*bad = good
+	bad.MaxConcurrency = 0
+	if _, err := bad.CreateNextRun(120, makeID); err == nil || !strings.Contains(err.Error(), "max concurrency") {
+		t.Fatalf("expected error about max concurrency, got %v", err)
+	}
+
+	*bad = good
+	bad.EffectiveCron = "not a cron"
+	if _, err := bad.CreateNextRun(120, makeID); err == nil {
+		t.Fatal("expected error with bad cron")
+	}
+
+	idErr := errors.New("error making ID")
+	*bad = good
+	if _, err := bad.CreateNextRun(120, func() (platform.ID, error) { return nil, idErr }); err != idErr {
+		t.Fatalf("expected id creation error, got %v", err)
+	}
+
+	rc, err := good.CreateNextRun(300, makeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Created.TaskID != nil {
+		t.Fatalf("CreateNextRun should not have set task ID; got %v", rc.Created.TaskID)
+	}
+	if rc.Created.RunID == nil {
+		t.Fatal("CreateNextRun should have set run ID but didn't")
+	}
+	if rc.Created.Now != 120 {
+		t.Fatalf("expected created run to have time 120, got %d", rc.Created.Now)
+	}
+	if rc.NextDue != 180 {
+		t.Fatalf("unexpected next run time: %d", rc.NextDue)
+	}
+
+	rc, err = good.CreateNextRun(300, makeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Created.TaskID != nil {
+		t.Fatalf("CreateNextRun should not have set task ID; got %v", rc.Created.TaskID)
+	}
+	if rc.Created.RunID == nil {
+		t.Fatal("CreateNextRun should have set run ID but didn't")
+	}
+	if rc.Created.Now != 180 {
+		t.Fatalf("expected created run to have time 180, got %d", rc.Created.Now)
+	}
+	if rc.NextDue != 240 {
+		t.Fatalf("unexpected next run time: %d", rc.NextDue)
+	}
+
+	if _, err := good.CreateNextRun(300, makeID); err == nil || !strings.Contains(err.Error(), "max concurrency") {
+		t.Fatalf("expected error about max concurrency, got %v", err)
+	}
+}
+
+func TestMeta_CreateNextRun_Delay(t *testing.T) {
+	stm := backend.StoreTaskMeta{
+		MaxConcurrency: 2,
+		Status:         "enabled",
+		EffectiveCron:  "* * * * *", // Every minute.
+		Delay:          5,
+		LastCompleted:  30, // Arbitrary non-overlap starting point.
+	}
+
+	_, err := stm.CreateNextRun(61, makeID)
+	if e, ok := err.(backend.RunNotYetDueError); !ok {
+		t.Fatalf("expected RunNotYetDueError, got %v (%T)", err, err)
+	} else if e.DueAt != 65 {
+		t.Fatalf("expected run due at 65, got %d", e.DueAt)
+	}
+
+	rc, err := stm.CreateNextRun(300, makeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Created.Now != 60 {
+		t.Fatalf("expected created run to have time 60, got %d", rc.Created.Now)
+	}
+	if rc.NextDue != 125 {
+		t.Fatalf("unexpected next run time: %d", rc.NextDue)
+	}
+}

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/platform"
-	"github.com/influxdata/platform/task/options"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"gopkg.in/robfig/cron.v2"
 )
 
 var ErrRunCanceled = errors.New("run canceled")
@@ -20,9 +19,8 @@ var ErrTaskNotClaimed = errors.New("task not claimed")
 
 // DesiredState persists the desired state of a run.
 type DesiredState interface {
-	// CreateRun returns a run ID for a task and a now timestamp.
-	// If a run already exists for taskID and now, CreateRun must return an error without queuing a new run.
-	CreateRun(ctx context.Context, taskID platform.ID, now int64) (QueuedRun, error)
+	// CreateNextRun requests the next run from the desired state, occurring no later than the Unix timestamp now.
+	CreateNextRun(ctx context.Context, taskID platform.ID, now int64) (RunCreation, error)
 
 	// FinishRun indicates that the given run is no longer intended to be executed.
 	// This may be called after a successful or failed execution, or upon cancellation.
@@ -88,10 +86,7 @@ type Scheduler interface {
 	Tick(now int64)
 
 	// ClaimTask begins control of task execution in this scheduler.
-	// The timing schedule for the task is parsed from the script.
-	// startExecutionFrom is an exclusive timestamp, after which execution should start;
-	// you can set startExecutionFrom in the past to backfill a task.
-	ClaimTask(task *StoreTask, startExecutionFrom int64, opt *options.Options) error
+	ClaimTask(task *StoreTask, meta *StoreTaskMeta) error
 
 	// ReleaseTask immediately cancels any in-progress runs for the given task ID,
 	// and releases any resources related to management of that task.
@@ -115,23 +110,6 @@ func WithTicker(ctx context.Context, d time.Duration) SchedulerOption {
 	}
 }
 
-func WithCronTimer(ctx context.Context) SchedulerOption {
-	return func(s Scheduler) {
-		switch sched := s.(type) {
-		case *outerScheduler:
-			sched.cronTimer = cron.New()
-			sched.cronTimer.Start()
-
-			go func() {
-				<-ctx.Done()
-				sched.cronTimer.Stop()
-			}()
-		default:
-			panic(fmt.Sprintf("cannot apply WithCronTimer to Scheduler of type %T", s))
-		}
-	}
-}
-
 // WithLogger sets the logger for the scheduler.
 // If not set, the scheduler will use a no-op logger.
 func WithLogger(logger *zap.Logger) SchedulerOption {
@@ -148,13 +126,13 @@ func WithLogger(logger *zap.Logger) SchedulerOption {
 // NewScheduler returns a new scheduler with the given desired state and the given now UTC timestamp.
 func NewScheduler(desiredState DesiredState, executor Executor, lw LogWriter, now int64, opts ...SchedulerOption) Scheduler {
 	o := &outerScheduler{
-		desiredState: desiredState,
-		executor:     executor,
-		logWriter:    lw,
-		now:          now,
-		tasks:        make(map[string]*taskScheduler),
-		logger:       zap.NewNop(),
-		metrics:      newSchedulerMetrics(),
+		desiredState:   desiredState,
+		executor:       executor,
+		logWriter:      lw,
+		now:            now,
+		taskSchedulers: make(map[string]*taskScheduler),
+		logger:         zap.NewNop(),
+		metrics:        newSchedulerMetrics(),
 	}
 
 	for _, opt := range opts {
@@ -169,93 +147,68 @@ type outerScheduler struct {
 	executor     Executor
 	logWriter    LogWriter
 
-	now       int64
-	logger    *zap.Logger
-	cronTimer *cron.Cron
+	now    int64
+	logger *zap.Logger
 
 	metrics *schedulerMetrics
 
-	mu sync.Mutex
-
-	tasks map[string]*taskScheduler
+	schedulerMu    sync.Mutex                // Protects access and modification of taskSchedulers map.
+	taskSchedulers map[string]*taskScheduler // Stringified task ID -> task scheduler.
 }
 
 func (s *outerScheduler) Tick(now int64) {
 	atomic.StoreInt64(&s.now, now)
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
 
-	for _, ts := range s.tasks {
-		ts.Start(now)
+	for _, ts := range s.taskSchedulers {
+		if now >= ts.NextDue() {
+			ts.Work(now)
+		}
 	}
 }
 
-func (s *outerScheduler) ClaimTask(task *StoreTask, startExecutionFrom int64, opts *options.Options) (err error) {
+func (s *outerScheduler) ClaimTask(task *StoreTask, meta *StoreTaskMeta) (err error) {
 	defer s.metrics.ClaimTask(err == nil)
 
-	if err := opts.Validate(); err != nil {
-		return fmt.Errorf("cannot claim task with invalid options: %v", err)
-	}
-
-	timer := opts.EffectiveCronString()
-	if timer == "" {
-		return errors.New("cannot claim task without a schedule")
-	}
-	sch, err := cron.Parse(timer)
+	ts, err := newTaskScheduler(s, task, meta, s.metrics)
 	if err != nil {
-		return fmt.Errorf("error parsing cron expression: %v", err)
+		return err
 	}
 
-	ts := newTaskScheduler(
-		s,
-		task,
-		sch,
-		startExecutionFrom,
-		uint8(opts.Concurrency),
-	)
-
-	if s.cronTimer != nil {
-		cronID, err := s.cronTimer.AddFunc(timer, func() {
-			ts.Start(time.Now().Unix())
-		})
-		if err != nil {
-			return fmt.Errorf("error starting cron timer: %v", err)
-		}
-		ts.cronID = cronID
-	}
-
-	s.mu.Lock()
-	_, ok := s.tasks[task.ID.String()]
+	tid := task.ID.String()
+	s.schedulerMu.Lock()
+	_, ok := s.taskSchedulers[tid]
 	if ok {
-		s.mu.Unlock()
+		s.schedulerMu.Unlock()
 		return errors.New("task has already been claimed")
 	}
 
-	s.tasks[task.ID.String()] = ts
+	s.taskSchedulers[tid] = ts
 
-	s.mu.Unlock()
+	s.schedulerMu.Unlock()
 
-	ts.Start(s.now)
+	// Okay to read ts.nextDue without locking,
+	// because we just created it and there won't be any concurrent access.
+	if now := atomic.LoadInt64(&s.now); now >= ts.nextDue {
+		ts.Work(now)
+	}
 	return nil
 }
 
 func (s *outerScheduler) ReleaseTask(taskID platform.ID) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
 
 	tid := taskID.String()
-	t, ok := s.tasks[tid]
+	t, ok := s.taskSchedulers[tid]
 	if !ok {
 		return ErrTaskNotClaimed
 	}
 
-	if s.cronTimer != nil {
-		s.cronTimer.Remove(t.cronID)
-	}
-
 	t.Cancel()
-	delete(s.tasks, tid)
+	delete(s.taskSchedulers, tid)
 
 	s.metrics.ReleaseTask(tid)
 
@@ -271,65 +224,56 @@ type taskScheduler struct {
 	// Task we are scheduling for.
 	task *StoreTask
 
-	// Seconds since UTC epoch.
-	now int64
-
 	// CancelFunc for context passed to runners, to enable Cancel method.
 	cancel context.CancelFunc
-
-	// cronID is used when we need to remove a taskSchedule from the cron scheduler.
-	cronID cron.EntryID
 
 	// Fixed-length slice of runners.
 	runners []*runner
 
-	// Record updates to run state.
-	logWriter LogWriter
-
 	logger *zap.Logger
+
+	metrics *schedulerMetrics
+
+	nextDueMu     sync.RWMutex // Protects following fields.
+	nextDue       int64        // Unix timestamp of next due.
+	nextDueSource int64        // Run time that produced nextDue.
 }
 
 func newTaskScheduler(
 	s *outerScheduler,
 	task *StoreTask,
-	cron cron.Schedule,
-	startExecutionFrom int64,
-	concurrencyLimit uint8,
-) *taskScheduler {
-	firstScheduled := cron.Next(time.Unix(startExecutionFrom, 0).UTC()).Unix()
-	ctx, cancel := context.WithCancel(context.Background())
-	ts := &taskScheduler{
-		task:    task,
-		now:     startExecutionFrom,
-		cancel:  cancel,
-		runners: make([]*runner, concurrencyLimit),
-		logger:  s.logger.With(zap.String("task_id", task.ID.String())),
+	meta *StoreTaskMeta,
+	metrics *schedulerMetrics,
+) (*taskScheduler, error) {
+	firstDue, err := meta.NextDueRun()
+	if err != nil {
+		return nil, err
 	}
 
-	tt := &taskTimer{
-		taskNow: &ts.now,
-		cron:    cron,
-
-		nextScheduledRun: firstScheduled,
-		latestInProgress: startExecutionFrom,
-
-		metrics: s.metrics,
+	ctx, cancel := context.WithCancel(context.Background())
+	ts := &taskScheduler{
+		task:          task,
+		cancel:        cancel,
+		runners:       make([]*runner, meta.MaxConcurrency),
+		logger:        s.logger.With(zap.String("task_id", task.ID.String())),
+		metrics:       s.metrics,
+		nextDue:       firstDue,
+		nextDueSource: math.MinInt64,
 	}
 
 	for i := range ts.runners {
 		logger := ts.logger.With(zap.Int("run_slot", i))
-		ts.runners[i] = newRunner(ctx, logger, task, s.desiredState, s.executor, s.logWriter, tt)
+		ts.runners[i] = newRunner(ctx, logger, task, s.desiredState, s.executor, s.logWriter, ts)
 	}
 
-	return ts
+	return ts, nil
 }
 
-// Start enqueues as many immediate jobs as possible,
-// without exceeding the now timestamp from the outer scheduler.
-func (ts *taskScheduler) Start(now int64) {
-	atomic.StoreInt64(&ts.now, now)
+// Work begins a work cycle on the taskScheduler.
+// As many runners are started as possible.
+func (ts *taskScheduler) Work(now int64) {
 	for _, r := range ts.runners {
-		r.Start()
+		r.Start(now)
 		if r.IsIdle() {
 			// Ran out of jobs to start.
 			break
@@ -337,63 +281,28 @@ func (ts *taskScheduler) Start(now int64) {
 	}
 }
 
+// Cancel interrupts this taskScheduler and its runners.
 func (ts *taskScheduler) Cancel() {
 	ts.cancel()
 }
 
-// taskTimer holds information about global timing, and scheduled and in-progress runs of a task.
-// A single taskTimer is shared among many runners in a taskScheduler.
-type taskTimer struct {
-	// Reference to task scheduler's now field that gets updated by Start().
-	// By using a pointer here we are allowing any Start() calls to the task scheduler to
-	// update the taskTimer with a single atomic update.
-	// This value must be accessed with sync.Atomic.
-	taskNow *int64
-
-	// Schedule of task.
-	cron cron.Schedule
-
-	metrics *schedulerMetrics
-
-	mu sync.RWMutex
-
-	// Timestamp of the next scheduled run.
-	nextScheduledRun int64
-
-	// Timestamp of the latest run in progress, i.e. a run that has been created.
-	// This value is not affected by a single runner going idle.
-	latestInProgress int64
+// NextDue returns the next due timestamp.
+func (ts *taskScheduler) NextDue() int64 {
+	ts.nextDueMu.RLock()
+	defer ts.nextDueMu.RUnlock()
+	return ts.nextDue
 }
 
-// NextScheduledRun returns the timestamp of the next run that should be scheduled,
-// and whether it is okay to schedule that run now.
-func (tt *taskTimer) NextScheduledRun() (int64, bool) {
-	tt.mu.RLock()
-	next := tt.nextScheduledRun
-	tt.mu.RUnlock()
-
-	return next, next <= atomic.LoadInt64(tt.taskNow)
-}
-
-// StartRun updates tt's internal state to indicate that a run is starting with the given timestamp.
-func (tt *taskTimer) StartRun(now int64) {
-	tt.mu.Lock()
-
-	if now > tt.latestInProgress {
-		tt.latestInProgress = now
-	}
-	if tt.latestInProgress == tt.nextScheduledRun {
-		tt.nextScheduledRun = tt.cron.Next(time.Unix(now, 0).UTC()).Unix()
-	} else if tt.latestInProgress > tt.nextScheduledRun {
-		panic(fmt.Sprintf("skipped a scheduled run: %d", tt.nextScheduledRun))
-	}
-
-	tt.mu.Unlock()
+// SetNextDue sets the next due timestamp and records the source (the now value of the run who reported nextDue).
+func (ts *taskScheduler) SetNextDue(nextDue, source int64) {
+	// TODO(mr): we may need some logic around source to handle if SetNextDue is called out of order.
+	ts.nextDueMu.Lock()
+	defer ts.nextDueMu.Unlock()
+	ts.nextDue = nextDue
+	ts.nextDueSource = source
 }
 
 // A runner is one eligible "concurrency slot" for a given task.
-// Each runner in a taskScheduler shares a taskTimer, and by locking that taskTimer they decide whether
-// there is a new run that needs to be created and executed.
 type runner struct {
 	state *uint32
 
@@ -406,7 +315,8 @@ type runner struct {
 	executor     Executor
 	logWriter    LogWriter
 
-	tt *taskTimer
+	// Parent taskScheduler.
+	ts *taskScheduler
 
 	logger *zap.Logger
 }
@@ -418,7 +328,7 @@ func newRunner(
 	desiredState DesiredState,
 	executor Executor,
 	logWriter LogWriter,
-	tt *taskTimer,
+	ts *taskScheduler,
 ) *runner {
 	return &runner{
 		ctx:          ctx,
@@ -427,7 +337,7 @@ func newRunner(
 		desiredState: desiredState,
 		executor:     executor,
 		logWriter:    logWriter,
-		tt:           tt,
+		ts:           ts,
 		logger:       logger,
 	}
 }
@@ -451,46 +361,48 @@ func (r *runner) IsIdle() bool {
 
 // Start checks if a new run is ready to be scheduled, and if so,
 // creates a run on this goroutine and begins executing it on a separate goroutine.
-func (r *runner) Start() {
+func (r *runner) Start(now int64) {
 	if !atomic.CompareAndSwapUint32(r.state, runnerIdle, runnerWorking) {
 		// Already working. Cannot start.
 		return
 	}
 
-	r.startFromWorking()
+	r.startFromWorking(now)
 }
 
 // startFromWorking attempts to create a run if one is due, and then begins execution on a separate goroutine.
 // r.state must be runnerWorking when this is called.
-func (r *runner) startFromWorking() {
-	if next, ready := r.tt.NextScheduledRun(); ready {
-		// It's possible that two runners may attempt to create the same run for this "next" timestamp,
-		// but the contract of DesiredState requires that only one succeeds.
-		qr, err := r.desiredState.CreateRun(r.ctx, r.task.ID, next)
-		if err != nil {
-			r.logger.Info("Failed to create run", zap.Error(err))
-			atomic.StoreUint32(r.state, runnerIdle)
-			return
-		}
-
-		// Create a new child logger for the individual run.
-		// We can't do r.logger = r.logger.With(zap.String("run_id", qr.RunID.String()) because zap doesn't deduplicate fields,
-		// and we'll quickly end up with many run_ids associated with the log.
-		runLogger := r.logger.With(zap.String("run_id", qr.RunID.String()))
-
-		r.tt.StartRun(next)
-
-		go r.executeAndWait(qr, runLogger)
-
-		r.updateRunState(qr, RunStarted, runLogger)
+func (r *runner) startFromWorking(now int64) {
+	if now < r.ts.NextDue() {
+		// Not ready for a new run. Go idle again.
+		atomic.StoreUint32(r.state, runnerIdle)
 		return
 	}
 
-	// Wasn't ready for a new run, so we're idle again.
-	atomic.StoreUint32(r.state, runnerIdle)
+	rc, err := r.desiredState.CreateNextRun(r.ctx, r.task.ID, now)
+	if err != nil {
+		r.logger.Info("Failed to create run", zap.Error(err))
+		atomic.StoreUint32(r.state, runnerIdle)
+		return
+	}
+	qr := rc.Created
+	r.ts.SetNextDue(rc.NextDue, qr.Now)
+
+	// Create a new child logger for the individual run.
+	// We can't do r.logger = r.logger.With(zap.String("run_id", qr.RunID.String()) because zap doesn't deduplicate fields,
+	// and we'll quickly end up with many run_ids associated with the log.
+	runLogger := r.logger.With(zap.String("run_id", qr.RunID.String()), zap.Int64("now", qr.Now))
+
+	// TODO(mr): this used to record metrics or something?
+	// r.tt.StartRun(next)
+
+	runLogger.Info("Beginning execution")
+	go r.executeAndWait(now, qr, runLogger)
+
+	r.updateRunState(qr, RunStarted, runLogger)
 }
 
-func (r *runner) executeAndWait(qr QueuedRun, runLogger *zap.Logger) {
+func (r *runner) executeAndWait(now int64, qr QueuedRun, runLogger *zap.Logger) {
 	rp, err := r.executor.Execute(r.ctx, qr)
 	if err != nil {
 		// TODO(mr): retry? and log error.
@@ -536,19 +448,20 @@ func (r *runner) executeAndWait(qr QueuedRun, runLogger *zap.Logger) {
 		return
 	}
 	r.updateRunState(qr, RunSuccess, runLogger)
+	runLogger.Info("Execution succeeded")
 
 	// Check again if there is a new run available, without returning to idle state.
-	r.startFromWorking()
+	r.startFromWorking(now)
 }
 
 func (r *runner) updateRunState(qr QueuedRun, s RunStatus, runLogger *zap.Logger) {
 	switch s {
 	case RunStarted:
-		r.tt.metrics.StartRun(r.task.ID.String())
+		r.ts.metrics.StartRun(r.task.ID.String())
 	case RunSuccess:
-		r.tt.metrics.FinishRun(r.task.ID.String(), true)
+		r.ts.metrics.FinishRun(r.task.ID.String(), true)
 	case RunFail, RunCanceled:
-		r.tt.metrics.FinishRun(r.task.ID.String(), false)
+		r.ts.metrics.FinishRun(r.task.ID.String(), false)
 	default:
 		// We are deliberately not handling RunQueued yet.
 		// There is not really a notion of being queued in this runner architecture.

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -56,7 +56,7 @@ func TestScheduler_StartScriptOnClaim(t *testing.T) {
 	}
 }
 
-func TestScheduler_CreateRunOnTick(t *testing.T) {
+func TestScheduler_CreateNextRunOnTick(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
 	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/kit/prom"
@@ -12,49 +11,24 @@ import (
 	_ "github.com/influxdata/platform/query/builtin"
 	"github.com/influxdata/platform/task/backend"
 	"github.com/influxdata/platform/task/mock"
-	"github.com/influxdata/platform/task/options"
+	"go.uber.org/zap/zaptest"
 )
-
-func TestScheduler_EveryValidation(t *testing.T) {
-	d := mock.NewDesiredState()
-	e := mock.NewExecutor()
-	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
-	task := &backend.StoreTask{
-		ID: platform.ID{1},
-	}
-
-	badOptions := []options.Options{
-		{
-			Every: time.Millisecond,
-		},
-		{
-			Every: time.Hour * -1,
-		},
-		{
-			Every: 1500 * time.Millisecond,
-		},
-		{
-			Every: 1232 * time.Millisecond,
-		},
-	}
-
-	for _, badOption := range badOptions {
-		if err := o.ClaimTask(task, 3, &badOption); err == nil {
-			t.Fatal("no error returned for :", badOption)
-		}
-	}
-}
 
 func TestScheduler_StartScriptOnClaim(t *testing.T) {
 	d := mock.NewDesiredState()
 	e := mock.NewExecutor()
-	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5)
+	o := backend.NewScheduler(d, e, backend.NopLogWriter{}, 5, backend.WithLogger(zaptest.NewLogger(t)))
 
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
 	}
-	opts := &options.Options{Every: time.Minute, Name: "x", Retry: 1, Concurrency: 1}
-	if err := o.ClaimTask(task, 3, opts); err != nil {
+	meta := &backend.StoreTaskMeta{
+		MaxConcurrency: 1,
+		EffectiveCron:  "* * * * *",
+		LastCompleted:  3,
+	}
+	d.SetTaskMeta(task.ID, *meta)
+	if err := o.ClaimTask(task, meta); err != nil {
 		t.Fatal(err)
 	}
 
@@ -67,8 +41,13 @@ func TestScheduler_StartScriptOnClaim(t *testing.T) {
 	task = &backend.StoreTask{
 		ID: platform.ID{2},
 	}
-	opts = &options.Options{Every: time.Second, Concurrency: 99, Retry: 1, Name: "y"}
-	if err := o.ClaimTask(task, 3, opts); err != nil {
+	meta = &backend.StoreTaskMeta{
+		MaxConcurrency: 99,
+		EffectiveCron:  "@every 1s",
+		LastCompleted:  3,
+	}
+	d.SetTaskMeta(task.ID, *meta)
+	if err := o.ClaimTask(task, meta); err != nil {
 		t.Fatal(err)
 	}
 
@@ -85,9 +64,14 @@ func TestScheduler_CreateRunOnTick(t *testing.T) {
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
 	}
+	meta := &backend.StoreTaskMeta{
+		MaxConcurrency: 2,
+		EffectiveCron:  "@every 1s",
+		LastCompleted:  5,
+	}
 
-	opts := &options.Options{Every: time.Second, Concurrency: 2, Name: "x", Retry: 1}
-	if err := o.ClaimTask(task, 5, opts); err != nil {
+	d.SetTaskMeta(task.ID, *meta)
+	if err := o.ClaimTask(task, meta); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,9 +112,14 @@ func TestScheduler_Release(t *testing.T) {
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
 	}
+	meta := &backend.StoreTaskMeta{
+		MaxConcurrency: 99,
+		EffectiveCron:  "@every 1s",
+		LastCompleted:  5,
+	}
 
-	opts := &options.Options{Every: time.Second, Concurrency: 99, Name: "x", Retry: 1}
-	if err := o.ClaimTask(task, 5, opts); err != nil {
+	d.SetTaskMeta(task.ID, *meta)
+	if err := o.ClaimTask(task, meta); err != nil {
 		t.Fatal(err)
 	}
 
@@ -159,9 +148,14 @@ func TestScheduler_RunLog(t *testing.T) {
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
 	}
+	meta := &backend.StoreTaskMeta{
+		MaxConcurrency: 99,
+		EffectiveCron:  "@every 1s",
+		LastCompleted:  5,
+	}
 
-	opts := &options.Options{Every: time.Second, Concurrency: 99, Name: "x", Retry: 1}
-	if err := s.ClaimTask(task, 5, opts); err != nil {
+	d.SetTaskMeta(task.ID, *meta)
+	if err := s.ClaimTask(task, meta); err != nil {
 		t.Fatal(err)
 	}
 
@@ -294,9 +288,14 @@ func TestScheduler_Metrics(t *testing.T) {
 	task := &backend.StoreTask{
 		ID: platform.ID{1},
 	}
+	meta := &backend.StoreTaskMeta{
+		MaxConcurrency: 99,
+		EffectiveCron:  "@every 1s",
+		LastCompleted:  5,
+	}
 
-	opts := &options.Options{Every: time.Second, Concurrency: 99, Name: "x", Retry: 1}
-	if err := s.ClaimTask(task, 5, opts); err != nil {
+	d.SetTaskMeta(task.ID, *meta)
+	if err := s.ClaimTask(task, meta); err != nil {
 		t.Fatal(err)
 	}
 

--- a/task/backend/store.go
+++ b/task/backend/store.go
@@ -57,6 +57,28 @@ func (r RunStatus) String() string {
 	panic(fmt.Sprintf("unknown RunStatus: %d", r))
 }
 
+// RunNotYetDueError is returned from CreateNextRun if a run is not yet due.
+type RunNotYetDueError struct {
+	// DueAt is the unix timestamp of when the next run is due.
+	DueAt int64
+}
+
+func (e RunNotYetDueError) Error() string {
+	return "run not due until " + time.Unix(e.DueAt, 0).Format(time.RFC3339)
+}
+
+// RunCreation is returned by CreateNextRun.
+type RunCreation struct {
+	Created QueuedRun
+
+	// Unix timestamp for when the next run is due.
+	NextDue int64
+
+	// Whether there are any manual runs queued for this task.
+	// If so, the scheduler should begin executing them after handling real-time tasks.
+	HasQueue bool
+}
+
 // Store is the interface around persisted tasks.
 type Store interface {
 	// CreateTask creates a task with the given script, belonging to the given org and user.

--- a/task/backend/store.go
+++ b/task/backend/store.go
@@ -113,9 +113,6 @@ type Store interface {
 	// or deleted is true if there was a matching entry and it was deleted.
 	DeleteTask(ctx context.Context, id platform.ID) (deleted bool, err error)
 
-	// CreateRun adds `now` to the task's metaData if we have not exceeded 'max_concurrency'.
-	CreateRun(ctx context.Context, taskID platform.ID, now int64) (QueuedRun, error)
-
 	// CreateNextRun creates the earliest needed run scheduled no later than the given Unix timestamp now.
 	// Internally, the Store should rely on the underlying task's StoreTaskMeta to create the next run.
 	CreateNextRun(ctx context.Context, taskID platform.ID, now int64) (RunCreation, error)

--- a/task/backend/store.go
+++ b/task/backend/store.go
@@ -116,6 +116,10 @@ type Store interface {
 	// CreateRun adds `now` to the task's metaData if we have not exceeded 'max_concurrency'.
 	CreateRun(ctx context.Context, taskID platform.ID, now int64) (QueuedRun, error)
 
+	// CreateNextRun creates the earliest needed run scheduled no later than the given Unix timestamp now.
+	// Internally, the Store should rely on the underlying task's StoreTaskMeta to create the next run.
+	CreateNextRun(ctx context.Context, taskID platform.ID, now int64) (RunCreation, error)
+
 	// FinishRun removes runID from the list of running tasks and if its `now` is later then last completed update it.
 	FinishRun(ctx context.Context, taskID, runID platform.ID) error
 

--- a/task/backend/storetest/storetest.go
+++ b/task/backend/storetest/storetest.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/task/backend"
@@ -405,6 +406,7 @@ func testStoreFindMeta(t *testing.T, create CreateStoreFunc, destroy DestroyStor
 		name: "a task",
 		cron: "* * * * *",
 		concurrency: 3,
+		delay: 2m,
 	}
 
 from(db:"test") |> range(start:-1h)`
@@ -435,6 +437,10 @@ from(db:"test") |> range(start:-1h)`
 
 	if meta.EffectiveCron != "* * * * *" {
 		t.Fatalf("unexpected cron stored in meta: %q", meta.EffectiveCron)
+	}
+
+	if time.Duration(meta.Delay)*time.Second != 2*time.Minute {
+		t.Fatalf("unexpected delay stored in meta: %v", meta.Delay)
 	}
 
 	badID := []byte("bad")

--- a/task/backend/storetest/storetest.go
+++ b/task/backend/storetest/storetest.go
@@ -433,6 +433,10 @@ from(db:"test") |> range(start:-1h)`
 		t.Fatalf("last completed should have been set to 6000, got %d", meta.LastCompleted)
 	}
 
+	if meta.EffectiveCron != "* * * * *" {
+		t.Fatalf("unexpected cron stored in meta: %q", meta.EffectiveCron)
+	}
+
 	badID := []byte("bad")
 	meta, err = s.FindTaskMetaByID(context.Background(), badID)
 	if err == nil {

--- a/task/backend/storetest/storetest.go
+++ b/task/backend/storetest/storetest.go
@@ -30,6 +30,7 @@ func NewStoreTest(name string, cf CreateStoreFunc, df DestroyStoreFunc, funcName
 			"EnableDisableTask",
 			"DeleteTask",
 			"CreateRun",
+			"CreateNextRun",
 			"FinishRun",
 		}
 	}
@@ -42,6 +43,7 @@ func NewStoreTest(name string, cf CreateStoreFunc, df DestroyStoreFunc, funcName
 		"EnableDisableTask": testStoreTaskEnableDisable,
 		"DeleteTask":        testStoreDelete,
 		"CreateRun":         testStoreCreateRun,
+		"CreateNextRun":     testStoreCreateNextRun,
 		"FinishRun":         testStoreFinishRun,
 		"DeleteOrg":         testStoreDeleteOrg,
 		"DeleteUser":        testStoreDeleteUser,
@@ -613,6 +615,68 @@ from(db:"test") |> range(start:-1h)`
 		t.Fatal("expected error for exceeding MaxConcurrency")
 	} else if !strings.Contains(err.Error(), "MaxConcurrency") {
 		t.Fatalf("expected error for MaxConcurrency, got %v", err)
+	}
+}
+
+func testStoreCreateNextRun(t *testing.T, create CreateStoreFunc, destroy DestroyStoreFunc) {
+	const script = `option task = {
+		name: "a task",
+		cron: "* * * * *",
+		delay: 5s,
+		concurrency: 2,
+	}
+
+from(db:"test") |> range(start:-1h)`
+
+	s := create(t)
+	defer destroy(t, s)
+
+	taskID, err := s.CreateTask(context.Background(), []byte{1}, []byte{2}, script, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badID := append([]byte(nil), taskID...)
+	badID[len(badID)-1]++
+	if _, err := s.CreateNextRun(context.Background(), badID, 999); err == nil {
+		t.Fatal("expected error for CreateNextRun with bad ID, got none")
+	}
+
+	_, err = s.CreateNextRun(context.Background(), taskID, 64)
+	if e, ok := err.(backend.RunNotYetDueError); !ok {
+		t.Fatalf("expected RunNotYetDueError, got %v (%T)", err, err)
+	} else if e.DueAt != 65 {
+		t.Fatalf("expected run due at 65, got %d", e.DueAt)
+	}
+
+	rc, err := s.CreateNextRun(context.Background(), taskID, 65)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(rc.Created.TaskID, taskID) {
+		t.Fatalf("bad created task ID; exp %x got %x", taskID, rc.Created.TaskID)
+	}
+	if rc.Created.Now != 60 {
+		t.Fatalf("unexpected time for created run: %d", rc.Created.Now)
+	}
+	if rc.NextDue != 125 {
+		t.Fatalf("unexpected next due time: %d", rc.NextDue)
+	}
+
+	rc, err = s.CreateNextRun(context.Background(), taskID, 125)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(rc.Created.TaskID, taskID) {
+		t.Fatalf("bad created task ID; exp %x got %x", taskID, rc.Created.TaskID)
+	}
+	if rc.Created.Now != 120 {
+		t.Fatalf("unexpected time for created run: %d", rc.Created.Now)
+	}
+	if rc.NextDue != 185 {
+		t.Fatalf("unexpected next due time: %d", rc.NextDue)
 	}
 }
 

--- a/task/mock/scheduler.go
+++ b/task/mock/scheduler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/task/backend"
 	scheduler "github.com/influxdata/platform/task/backend"
-	"github.com/influxdata/platform/task/options"
 	"go.uber.org/zap"
 )
 
@@ -24,6 +23,7 @@ type Scheduler struct {
 	lastTick int64
 
 	claims map[string]*Task
+	meta   map[string]backend.StoreTaskMeta
 
 	createChan  chan *Task
 	releaseChan chan *Task
@@ -42,6 +42,7 @@ type Task struct {
 func NewScheduler() *Scheduler {
 	return &Scheduler{
 		claims: map[string]*Task{},
+		meta:   map[string]backend.StoreTaskMeta{},
 	}
 }
 
@@ -54,7 +55,7 @@ func (s *Scheduler) Tick(now int64) {
 
 func (s *Scheduler) WithLogger(l *zap.Logger) {}
 
-func (s *Scheduler) ClaimTask(task *backend.StoreTask, startExecutionFrom int64, opts *options.Options) error {
+func (s *Scheduler) ClaimTask(task *backend.StoreTask, meta *backend.StoreTaskMeta) error {
 	if s.claimError != nil {
 		return s.claimError
 	}
@@ -66,8 +67,9 @@ func (s *Scheduler) ClaimTask(task *backend.StoreTask, startExecutionFrom int64,
 	if ok {
 		return errors.New("task already in list")
 	}
+	s.meta[task.ID.String()] = *meta
 
-	t := &Task{task.Script, startExecutionFrom, uint8(opts.Concurrency)}
+	t := &Task{task.Script, meta.LastCompleted, uint8(meta.MaxConcurrency)}
 
 	s.claims[task.ID.String()] = t
 
@@ -95,6 +97,7 @@ func (s *Scheduler) ReleaseTask(taskID platform.ID) error {
 	}
 
 	delete(s.claims, taskID.String())
+	delete(s.meta, taskID.String())
 
 	return nil
 }
@@ -130,6 +133,9 @@ type DesiredState struct {
 
 	// Map of stringified, concatenated task and platform ID, to runs that have been created.
 	created map[string]backend.QueuedRun
+
+	// Map of stringified task ID to task meta.
+	meta map[string]backend.StoreTaskMeta
 }
 
 var _ backend.DesiredState = (*DesiredState)(nil)
@@ -138,6 +144,7 @@ func NewDesiredState() *DesiredState {
 	return &DesiredState{
 		runIDs:  make(map[string]uint32),
 		created: make(map[string]backend.QueuedRun),
+		meta:    make(map[string]backend.StoreTaskMeta),
 	}
 }
 
@@ -160,6 +167,45 @@ func (d *DesiredState) CreateRun(_ context.Context, taskID platform.ID, now int6
 	d.created[tid+platform.ID(runID).String()] = qr
 
 	return qr, nil
+}
+
+// SetTaskMeta sets the task meta for the given task ID.
+// SetTaskMeta must be called before CreateNextRun, for a given task ID.
+func (d *DesiredState) SetTaskMeta(taskID platform.ID, meta backend.StoreTaskMeta) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.meta[taskID.String()] = meta
+}
+
+// CreateNextRun creates the next run for the given task.
+// Refer to the documentation for SetTaskPeriod to understand how the times are determined.
+func (d *DesiredState) CreateNextRun(_ context.Context, taskID platform.ID, now int64) (backend.RunCreation, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	tid := taskID.String()
+
+	meta, ok := d.meta[tid]
+	if !ok {
+		panic(fmt.Sprintf("meta not set for task with ID %s", tid))
+	}
+
+	makeID := func() (platform.ID, error) {
+		d.runIDs[tid]++
+		runID := make([]byte, 4)
+		binary.BigEndian.PutUint32(runID, d.runIDs[tid])
+		return platform.ID(runID), nil
+	}
+
+	rc, err := meta.CreateNextRun(now, makeID)
+	if err != nil {
+		return backend.RunCreation{}, err
+	}
+	d.meta[tid] = meta
+	rc.Created.TaskID = append([]byte(nil), taskID...)
+	d.created[tid+rc.Created.RunID.String()] = rc.Created
+	return rc, nil
 }
 
 func (d *DesiredState) FinishRun(_ context.Context, taskID, runID platform.ID) error {

--- a/task/mock/scheduler.go
+++ b/task/mock/scheduler.go
@@ -148,27 +148,6 @@ func NewDesiredState() *DesiredState {
 	}
 }
 
-// TODO(mr): inject a way to treat CreateRun as blocking?
-func (d *DesiredState) CreateRun(_ context.Context, taskID platform.ID, now int64) (backend.QueuedRun, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	tid := taskID.String()
-	d.runIDs[tid]++
-
-	runID := make([]byte, 4)
-	binary.BigEndian.PutUint32(runID, d.runIDs[tid])
-	qr := backend.QueuedRun{
-		TaskID: taskID,
-		RunID:  runID,
-		Now:    now,
-	}
-
-	d.created[tid+platform.ID(runID).String()] = qr
-
-	return qr, nil
-}
-
 // SetTaskMeta sets the task meta for the given task ID.
 // SetTaskMeta must be called before CreateNextRun, for a given task ID.
 func (d *DesiredState) SetTaskMeta(taskID platform.ID, meta backend.StoreTaskMeta) {

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -144,6 +144,11 @@ func (o *Options) Validate() error {
 		}
 	}
 
+	if o.Delay.Truncate(time.Second) != o.Delay {
+		// For now, allowing negative delays. Maybe they're useful for forecasting?
+		errs = append(errs, "delay option must be expressible as whole seconds")
+	}
+
 	if o.Concurrency < 1 {
 		errs = append(errs, "concurrency must be at least 1")
 	} else if o.Concurrency > maxConcurrency {

--- a/task/options/options_test.go
+++ b/task/options/options_test.go
@@ -2,6 +2,7 @@ package options_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -72,6 +73,75 @@ func TestFromScript(t *testing.T) {
 		if !cmp.Equal(o, c.exp) {
 			t.Fatalf("script %q got unexpected result -got/+exp\n%s", c.script, cmp.Diff(o, c.exp))
 		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	good := options.Options{Name: "x", Cron: "* * * * *", Concurrency: 1, Retry: 1}
+	if err := good.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	bad := new(options.Options)
+	*bad = good
+	bad.Name = ""
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for options without name")
+	}
+
+	*bad = good
+	bad.Cron = ""
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for options without cron or every")
+	}
+
+	*bad = good
+	bad.Every = time.Minute
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for options with both cron and every")
+	}
+
+	*bad = good
+	bad.Cron = "not a cron string"
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for options with invalid cron")
+	}
+
+	*bad = good
+	bad.Cron = ""
+	bad.Every = -1 * time.Minute
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for negative every")
+	}
+
+	*bad = good
+	bad.Delay = 1500 * time.Millisecond
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for sub-second delay resolution")
+	}
+
+	*bad = good
+	bad.Concurrency = 0
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for 0 concurrency")
+	}
+
+	*bad = good
+	bad.Concurrency = math.MaxInt64
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for concurrency too large")
+	}
+
+	*bad = good
+	bad.Retry = 0
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for 0 retry")
+	}
+
+	*bad = good
+	bad.Retry = math.MaxInt64
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for retry too large")
 	}
 }
 


### PR DESCRIPTION
This is a fairly wide refactor that pushes schedule determination responsibility into StoreTaskMeta, and then replaces Store.CreateRun with Store.CreateNextRun. The work has been organized into a logical progression of commits.

The old behavior of Store.CreateRun was to just create a run for whatever timestamp was requested. The new behavior of Store.CreateNextRun is to track the runs that have been created and enforce that runs are created in the correct chronological order (via the StoreTaskMeta type).

As part of this change, a task's `delay` option is respected when scheduling a task.

This change also updates StoreTaskMeta to include new fields to handle manually requested runs (#613). Other than adding those fields, I have not yet begun work on that. Supporting manual re-runs should be a small change after this is merged.

Fixes #571.