### PR TITLE
chore: Update 'from' to match spec

### DIFF
--- a/query/docs/SPEC.md
+++ b/query/docs/SPEC.md
@@ -1071,16 +1071,18 @@ The tables schema will include the following columns:
 
 Additionally any tags on the series will be added as columns.
 
-Example:
-
-    from(bucket:"telegraf")
 
 From has the following properties:
 
 * `bucket` string
-    The name of the bucket to query.
-* `db` string
-    The name of the database to query.
+    Bucket is the name of the bucket to query
+* `bucketID` string
+    The string encoding of the bucketID to query.
+
+Example:
+
+    from(bucket:"telegraf/autogen")
+    from(bucketID:"0261d8287f4d6000")
 
 #### Yield
 

--- a/query/functions/count_test.go
+++ b/query/functions/count_test.go
@@ -17,13 +17,13 @@ func TestCount_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with range and count",
-			Raw:  `from(db:"mydb") |> range(start:-4h, stop:-2h) |> count()`,
+			Raw:  `from(bucket:"mydb") |> range(start:-4h, stop:-2h) |> count()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mydb",
 						},
 					},
 					{

--- a/query/functions/covariance_test.go
+++ b/query/functions/covariance_test.go
@@ -14,13 +14,13 @@ func TestCovariance_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "simple covariance",
-			Raw:  `from(db:"mydb") |> covariance(columns:["a","b"],)`,
+			Raw:  `from(bucket:"mybucket") |> covariance(columns:["a","b"],)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -42,13 +42,13 @@ func TestCovariance_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "pearsonr",
-			Raw:  `from(db:"mydb")|>covariance(columns:["a","b"],pearsonr:true)`,
+			Raw:  `from(bucket:"mybucket")|>covariance(columns:["a","b"],pearsonr:true)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -71,19 +71,19 @@ func TestCovariance_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "global covariance",
-			Raw:  `cov(x: from(db:"mydb"), y:from(db:"mydb"), on:["host"], pearsonr:true)`,
+			Raw:  `cov(x: from(bucket:"mybucket"), y:from(bucket:"mybucket"), on:["host"], pearsonr:true)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
 						ID: "from1",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/functions/filter_test.go
+++ b/query/functions/filter_test.go
@@ -20,13 +20,13 @@ func TestFilter_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with database filter and range",
-			Raw:  `from(db:"mydb") |> filter(fn: (r) => r["t1"]=="val1" and r["t2"]=="val2") |> range(start:-4h, stop:-2h) |> count()`,
+			Raw:  `from(bucket:"mybucket") |> filter(fn: (r) => r["t1"]=="val1" and r["t2"]=="val2") |> range(start:-4h, stop:-2h) |> count()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -88,7 +88,7 @@ func TestFilter_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database filter (and with or) and range",
-			Raw: `from(db:"mydb")
+			Raw: `from(bucket:"mybucket")
 						|> filter(fn: (r) =>
 								(
 									(r["t1"]=="val1")
@@ -105,7 +105,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -178,7 +178,7 @@ func TestFilter_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database filter including fields",
-			Raw: `from(db:"mydb")
+			Raw: `from(bucket:"mybucket")
 						|> filter(fn: (r) =>
 							(r["t1"] =="val1")
 							and
@@ -191,7 +191,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -253,7 +253,7 @@ func TestFilter_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database filter with no parens including fields",
-			Raw: `from(db:"mydb")
+			Raw: `from(bucket:"mybucket")
 						|> filter(fn: (r) =>
 							r["t1"]=="val1"
 							and
@@ -266,7 +266,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -328,7 +328,7 @@ func TestFilter_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database filter with no parens including regex and field",
-			Raw: `from(db:"mydb")
+			Raw: `from(bucket:"mybucket")
 						|> filter(fn: (r) =>
 							r["t1"]==/val1/
 							and
@@ -341,7 +341,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -403,7 +403,7 @@ func TestFilter_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database regex with escape",
-			Raw: `from(db:"mydb")
+			Raw: `from(bucket:"mybucket")
 						|> filter(fn: (r) =>
 							r["t1"]==/va\/l1/
 						)`,
@@ -412,7 +412,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -439,7 +439,7 @@ func TestFilter_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database with two regex",
-			Raw: `from(db:"mydb")
+			Raw: `from(bucket:"mybucket")
 						|> filter(fn: (r) =>
 							r["t1"]==/va\/l1/
 							and
@@ -450,7 +450,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/functions/from.go
+++ b/query/functions/from.go
@@ -7,7 +7,6 @@ import (
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/functions/storage"
-	"github.com/influxdata/platform/query/interpreter"
 	"github.com/influxdata/platform/query/plan"
 	"github.com/influxdata/platform/query/semantic"
 	"github.com/pkg/errors"
@@ -16,18 +15,14 @@ import (
 const FromKind = "from"
 
 type FromOpSpec struct {
-	Database string      `json:"db,omitempty"`
 	Bucket   string      `json:"bucket,omitempty"`
 	BucketID platform.ID `json:"bucketID,omitempty"`
-	Hosts    []string    `json:"hosts"`
 }
 
 var fromSignature = semantic.FunctionSignature{
 	Params: map[string]semantic.Type{
-		"db":       semantic.String,
 		"bucket":   semantic.String,
 		"bucketID": semantic.String,
-		"hosts":    semantic.NewArrayType(semantic.String),
 	},
 	ReturnType: query.TableObjectType,
 }
@@ -41,12 +36,6 @@ func init() {
 
 func createFromOpSpec(args query.Arguments, a *query.Administration) (query.OperationSpec, error) {
 	spec := new(FromOpSpec)
-
-	if db, ok, err := args.GetString("db"); err != nil {
-		return nil, err
-	} else if ok {
-		spec.Database = db
-	}
 
 	if bucket, ok, err := args.GetString("bucket"); err != nil {
 		return nil, err
@@ -63,22 +52,12 @@ func createFromOpSpec(args query.Arguments, a *query.Administration) (query.Oper
 		}
 	}
 
-	if spec.Database == "" && spec.Bucket == "" && len(spec.BucketID) == 0 {
-		return nil, errors.New("must specify one of db or bucket")
+	if spec.Bucket == "" && len(spec.BucketID) == 0 {
+		return nil, errors.New("must specify one of bucket or bucketID")
 	}
-	if spec.Database != "" && spec.Bucket != "" && len(spec.BucketID) == 0 {
-		return nil, errors.New("must specify only one of db or bucket")
+	if spec.Bucket != "" && len(spec.BucketID) != 0 {
+		return nil, errors.New("must specify only one of bucket or bucketID")
 	}
-
-	if array, ok, err := args.GetArray("hosts", semantic.String); err != nil {
-		return nil, err
-	} else if ok {
-		spec.Hosts, err = interpreter.ToStringArray(array)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return spec, nil
 }
 
@@ -91,10 +70,8 @@ func (s *FromOpSpec) Kind() query.OperationKind {
 }
 
 type FromProcedureSpec struct {
-	Database string
 	Bucket   string
 	BucketID platform.ID
-	Hosts    []string
 
 	BoundsSet bool
 	Bounds    plan.BoundsSpec
@@ -129,10 +106,8 @@ func newFromProcedure(qs query.OperationSpec, pa plan.Administration) (plan.Proc
 	}
 
 	return &FromProcedureSpec{
-		Database: spec.Database,
 		Bucket:   spec.Bucket,
 		BucketID: spec.BucketID,
-		Hosts:    spec.Hosts,
 	}, nil
 }
 
@@ -145,24 +120,17 @@ func (s *FromProcedureSpec) TimeBounds() plan.BoundsSpec {
 func (s *FromProcedureSpec) Copy() plan.ProcedureSpec {
 	ns := new(FromProcedureSpec)
 
-	ns.Database = s.Database
 	ns.Bucket = s.Bucket
 	if len(s.BucketID) > 0 {
 		ns.BucketID = make(platform.ID, len(s.BucketID))
 		copy(ns.BucketID, s.BucketID)
 	}
 
-	if len(s.Hosts) > 0 {
-		ns.Hosts = make([]string, len(s.Hosts))
-		copy(ns.Hosts, s.Hosts)
-	}
-
 	ns.BoundsSet = s.BoundsSet
 	ns.Bounds = s.Bounds
 
 	ns.FilterSet = s.FilterSet
-	// TODO copy predicate
-	ns.Filter = s.Filter
+	ns.Filter = s.Filter.Copy().(*semantic.FunctionExpression)
 
 	ns.DescendingSet = s.DescendingSet
 	ns.Descending = s.Descending
@@ -211,17 +179,14 @@ func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execu
 	var bucketID platform.ID
 	// Determine bucketID
 	switch {
-	case spec.Database != "":
-		// The bucket ID will be treated as the database name
-		bucketID = platform.ID(spec.Database)
-	case len(spec.BucketID) != 0:
-		bucketID = spec.BucketID
 	case spec.Bucket != "":
 		b, ok := deps.BucketLookup.Lookup(orgID, spec.Bucket)
 		if !ok {
 			return nil, fmt.Errorf("could not find bucket %q", spec.Bucket)
 		}
 		bucketID = b
+	case len(spec.BucketID) != 0:
+		bucketID = spec.BucketID
 	}
 
 	return storage.NewSource(
@@ -230,7 +195,6 @@ func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execu
 		storage.ReadSpec{
 			OrganizationID:  orgID,
 			BucketID:        bucketID,
-			Hosts:           spec.Hosts,
 			Predicate:       spec.Filter,
 			PointsLimit:     spec.PointsLimit,
 			SeriesLimit:     spec.SeriesLimit,

--- a/query/functions/from_test.go
+++ b/query/functions/from_test.go
@@ -20,17 +20,17 @@ func TestFrom_NewQuery(t *testing.T) {
 		},
 		{
 			Name:    "from conflicting args",
-			Raw:     `from(db:"d", bucket:"b")`,
+			Raw:     `from(bucket:"d", bucket:"b")`,
 			WantErr: true,
 		},
 		{
 			Name:    "from repeat arg",
-			Raw:     `from(db:"telegraf", db:"oops")`,
+			Raw:     `from(bucket:"telegraf", bucket:"oops")`,
 			WantErr: true,
 		},
 		{
 			Name:    "from",
-			Raw:     `from(db:"telegraf", chicken:"what is this?")`,
+			Raw:     `from(bucket:"telegraf", chicken:"what is this?")`,
 			WantErr: true,
 		},
 		{
@@ -54,13 +54,13 @@ func TestFrom_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from with database",
-			Raw:  `from(db:"mydb") |> range(start:-4h, stop:-2h) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> range(start:-4h, stop:-2h) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -103,11 +103,11 @@ func TestFrom_NewQuery(t *testing.T) {
 }
 
 func TestFromOperation_Marshaling(t *testing.T) {
-	data := []byte(`{"id":"from","kind":"from","spec":{"db":"mydb"}}`)
+	data := []byte(`{"id":"from","kind":"from","spec":{"bucket":"mybucket"}}`)
 	op := &query.Operation{
 		ID: "from",
 		Spec: &functions.FromOpSpec{
-			Database: "mydb",
+			Bucket: "mybucket",
 		},
 	}
 	querytest.OperationMarshalingTestHelper(t, data, op)

--- a/query/functions/join_test.go
+++ b/query/functions/join_test.go
@@ -20,15 +20,15 @@ func TestJoin_NewQuery(t *testing.T) {
 		{
 			Name: "basic two-way join",
 			Raw: `
-				a = from(db:"dbA") |> range(start:-1h)
-				b = from(db:"dbB") |> range(start:-1h)
+				a = from(bucket:"dbA") |> range(start:-1h)
+				b = from(bucket:"dbB") |> range(start:-1h)
 				join(tables:{a:a,b:b}, on:["host"])`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "dbA",
+							Bucket: "dbA",
 						},
 					},
 					{
@@ -49,7 +49,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from2",
 						Spec: &functions.FromOpSpec{
-							Database: "dbB",
+							Bucket: "dbB",
 						},
 					},
 					{
@@ -87,8 +87,8 @@ func TestJoin_NewQuery(t *testing.T) {
 		{
 			Name: "from with join with complex ast",
 			Raw: `
-				a = from(db:"flux") |> range(start:-1h)
-				b = from(db:"flux") |> range(start:-1h)
+				a = from(bucket:"flux") |> range(start:-1h)
+				b = from(bucket:"flux") |> range(start:-1h)
 				join(tables:{a:a,b:b}, on:["t1"])
 			`,
 			Want: &query.Spec{
@@ -96,7 +96,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "flux",
+							Bucket: "flux",
 						},
 					},
 					{
@@ -117,7 +117,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from2",
 						Spec: &functions.FromOpSpec{
-							Database: "flux",
+							Bucket: "flux",
 						},
 					},
 					{

--- a/query/functions/map_test.go
+++ b/query/functions/map_test.go
@@ -16,13 +16,13 @@ func TestMap_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "simple static map",
-			Raw:  `from(db:"mydb") |> map(fn: (r) => r._value + 1)`,
+			Raw:  `from(bucket:"mybucket") |> map(fn: (r) => r._value + 1)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -52,13 +52,13 @@ func TestMap_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "resolve map",
-			Raw:  `x = 2 from(db:"mydb") |> map(fn: (r) => r._value + x)`,
+			Raw:  `x = 2 from(bucket:"mybucket") |> map(fn: (r) => r._value + x)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/functions/pivot.go
+++ b/query/functions/pivot.go
@@ -24,7 +24,7 @@ var pivotSignature = query.DefaultFunctionSignature()
 
 var fromRowsBuiltin = `
 // fromRows will access a database and retrieve data aligned into time-aligned tuples, grouped by measurement.  
-fromRows = (db) => from(db:db) |> pivot(rowKey:["_time"], colKey: ["_field"], valueCol: "_value")
+fromRows = (bucket="",bucketID="") => from(bucket:bucket,bucketID:bucketID) |> pivot(rowKey:["_time"], colKey: ["_field"], valueCol: "_value")
 `
 
 func init() {

--- a/query/functions/pivot_test.go
+++ b/query/functions/pivot_test.go
@@ -16,13 +16,13 @@ func TestPivot_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "pivot [_measurement, _field] around _time",
-			Raw:  `from(db:"testdb") |> range(start: -1h) |> pivot(rowKey: ["_time"], colKey: ["_measurement", "_field"], valueCol: "_value")`,
+			Raw:  `from(bucket:"testdb") |> range(start: -1h) |> pivot(rowKey: ["_time"], colKey: ["_measurement", "_field"], valueCol: "_value")`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "testdb",
+							Bucket: "testdb",
 						},
 					},
 					{

--- a/query/functions/range_test.go
+++ b/query/functions/range_test.go
@@ -21,13 +21,13 @@ func TestRange_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with database with range",
-			Raw:  `from(db:"mydb") |> range(start:-4h, stop:-2h) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> range(start:-4h, stop:-2h) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/functions/schema_functions_test.go
+++ b/query/functions/schema_functions_test.go
@@ -21,13 +21,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "test rename query",
-			Raw:  `from(db:"mydb") |> rename(columns:{old:"new"}) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> rename(columns:{old:"new"}) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -53,13 +53,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name: "test drop query",
-			Raw:  `from(db:"mydb") |> drop(columns:["col1", "col2", "col3"]) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> drop(columns:["col1", "col2", "col3"]) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -83,13 +83,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name: "test keep query",
-			Raw:  `from(db:"mydb") |> keep(columns:["col1", "col2", "col3"]) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> keep(columns:["col1", "col2", "col3"]) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -113,13 +113,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name: "test duplicate query",
-			Raw:  `from(db:"mydb") |> duplicate(column: "col1", as: "col1_new") |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> duplicate(column: "col1", as: "col1_new") |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -144,13 +144,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name: "test drop query fn param",
-			Raw:  `from(db:"mydb") |> drop(fn: (col) => col =~ /reg*/) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> drop(fn: (col) => col =~ /reg*/) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -185,13 +185,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name: "test keep query fn param",
-			Raw:  `from(db:"mydb") |> keep(fn: (col) => col =~ /reg*/) |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> keep(fn: (col) => col =~ /reg*/) |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -226,13 +226,13 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name: "test rename query fn param",
-			Raw:  `from(db:"mydb") |> rename(fn: (col) => "new_name") |> sum()`,
+			Raw:  `from(bucket:"mybucket") |> rename(fn: (col) => "new_name") |> sum()`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -261,25 +261,25 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 		},
 		{
 			Name:    "test rename query invalid",
-			Raw:     `from(db:"mydb") |> rename(fn: (col) => "new_name", columns: {a:"b", c:"d"}) |> sum()`,
+			Raw:     `from(bucket:"mybucket") |> rename(fn: (col) => "new_name", columns: {a:"b", c:"d"}) |> sum()`,
 			Want:    nil,
 			WantErr: true,
 		},
 		{
 			Name:    "test drop query invalid",
-			Raw:     `from(db:"mydb") |> drop(fn: (col) => col == target, columns: ["a", "b"]) |> sum()`,
+			Raw:     `from(bucket:"mybucket") |> drop(fn: (col) => col == target, columns: ["a", "b"]) |> sum()`,
 			Want:    nil,
 			WantErr: true,
 		},
 		{
 			Name:    "test keep query invalid",
-			Raw:     `from(db:"mydb") |> keep(fn: (col) => col == target, columns: ["a", "b"]) |> sum()`,
+			Raw:     `from(bucket:"mybucket") |> keep(fn: (col) => col == target, columns: ["a", "b"]) |> sum()`,
 			Want:    nil,
 			WantErr: true,
 		},
 		{
 			Name:    "test duplicate query invalid",
-			Raw:     `from(db:"mydb") |> duplicate(columns: ["a", "b"], n: -1) |> sum()`,
+			Raw:     `from(bucket:"mybucket") |> duplicate(columns: ["a", "b"], n: -1) |> sum()`,
 			Want:    nil,
 			WantErr: true,
 		},

--- a/query/functions/testdata/derivative.flux
+++ b/query/functions/testdata/derivative.flux
@@ -1,3 +1,3 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-23T13:09:22.885021542Z)
   |> derivative(unit:100ms)

--- a/query/functions/testdata/derivative_nonnegative.flux
+++ b/query/functions/testdata/derivative_nonnegative.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> derivative(unit:100ms, nonNegative: true)

--- a/query/functions/testdata/difference.flux
+++ b/query/functions/testdata/difference.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> difference()

--- a/query/functions/testdata/difference_one_value.flux
+++ b/query/functions/testdata/difference_one_value.flux
@@ -1,3 +1,3 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> difference(nonNegative:true)

--- a/query/functions/testdata/difference_panic.flux
+++ b/query/functions/testdata/difference_panic.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> filter(fn: (r) => r._field == "no_exist")
     |> difference()

--- a/query/functions/testdata/drop_after_rename.flux
+++ b/query/functions/testdata/drop_after_rename.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> rename(columns: {old: "new"})
 	|> drop(columns: ["old"])

--- a/query/functions/testdata/drop_before_rename.flux
+++ b/query/functions/testdata/drop_before_rename.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> drop(columns: ["old"])
 	|> rename(columns: {old: "new"})

--- a/query/functions/testdata/drop_newname_after.flux
+++ b/query/functions/testdata/drop_newname_after.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> rename(columns:{old:"new"})
 	|> drop(columns: ["new"])

--- a/query/functions/testdata/drop_newname_before.flux
+++ b/query/functions/testdata/drop_newname_before.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> drop(columns:["new"])
 	|> rename(columns: {old:"new"})

--- a/query/functions/testdata/drop_referenced.flux
+++ b/query/functions/testdata/drop_referenced.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> drop(columns: ["_field"])
 	|> filter(fn: (r) => r._field == "usage_guest")

--- a/query/functions/testdata/drop_unused.flux
+++ b/query/functions/testdata/drop_unused.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> drop(columns: ["_measurement"])
 	|> filter(fn: (r) => r._field == "usage_guest")

--- a/query/functions/testdata/duplicate.flux
+++ b/query/functions/testdata/duplicate.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> duplicate(column: "host", as: "host_new")

--- a/query/functions/testdata/filter_by_regex.flux
+++ b/query/functions/testdata/filter_by_regex.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-20T19:53:26Z)
   |> filter(fn: (r) => r["name"] =~ /.*0/)
   |> group(by: ["_measurement", "_start"])

--- a/query/functions/testdata/filter_by_tags.flux
+++ b/query/functions/testdata/filter_by_tags.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> filter(fn: (r) => r["name"] == "disk0")
   |> group(by: ["_measurement"])

--- a/query/functions/testdata/fromRows.flux
+++ b/query/functions/testdata/fromRows.flux
@@ -1,3 +1,3 @@
-fromRows(db:"testdb")
+fromRows(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z, stop: 2018-05-22T19:54:17Z)
   |> yield(name:"0")

--- a/query/functions/testdata/group.flux
+++ b/query/functions/testdata/group.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> filter(fn: (r) => r._measurement == "diskio" and r._field == "io_time")
   |> group(by: ["_measurement", "_start", "name"])

--- a/query/functions/testdata/group_by_field.flux
+++ b/query/functions/testdata/group_by_field.flux
@@ -1,3 +1,3 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> group(by: ["_value"])

--- a/query/functions/testdata/group_except.flux
+++ b/query/functions/testdata/group_except.flux
@@ -1,4 +1,4 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> group(except:["_measurement", "_time", "_value"])
     |> max() 

--- a/query/functions/testdata/group_ungroup.flux
+++ b/query/functions/testdata/group_ungroup.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> group(by: ["name"])
   |> group()

--- a/query/functions/testdata/increase.flux
+++ b/query/functions/testdata/increase.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> increase()
 

--- a/query/functions/testdata/keep.flux
+++ b/query/functions/testdata/keep.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> keep(columns: ["_time", "_value", "_field"])

--- a/query/functions/testdata/keep_fn.flux
+++ b/query/functions/testdata/keep_fn.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> keep(fn: (col) => col == "_field" or col == "_value")
     |> keep(fn: (col) =>  {return col == "_value"})

--- a/query/functions/testdata/mean.flux
+++ b/query/functions/testdata/mean.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> group(by:["_measurement", "_start"])
     |> mean(timeSrc:"_start")

--- a/query/functions/testdata/meta_query_fields.flux
+++ b/query/functions/testdata/meta_query_fields.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> filter(fn: (r) => r._measurement == "cpu")
     |> group(by: ["_field"])

--- a/query/functions/testdata/meta_query_keys.flux
+++ b/query/functions/testdata/meta_query_keys.flux
@@ -1,10 +1,10 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> filter(fn: (r) => r._measurement == "cpu")
     |> keys() 
     |> yield(name:"0")
 
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> filter(fn: (r) => r._measurement == "cpu")
     |> group(by: ["host"])

--- a/query/functions/testdata/meta_query_measurements.flux
+++ b/query/functions/testdata/meta_query_measurements.flux
@@ -1,4 +1,4 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> group(by: ["_measurement"])
     |> distinct(column: "_measurement")

--- a/query/functions/testdata/multiple_range.flux
+++ b/query/functions/testdata/multiple_range.flux
@@ -1,3 +1,3 @@
-from(db: "db")
+from(bucket: "db")
 	|> range(start: 2018-05-22T19:53:26Z, stop: 2018-05-22T19:54:16Z)
 	|> range(start: 2018-05-22T19:54:06Z)

--- a/query/functions/testdata/null_as_value.flux
+++ b/query/functions/testdata/null_as_value.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
 	|> filter(fn: (r) => r._value == null)

--- a/query/functions/testdata/percentile.flux
+++ b/query/functions/testdata/percentile.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start: 2018-05-22T19:50:26Z)
     |> group(by: ["_measurement", "_start"])
     |> percentile(p:0.75, method:"exact_selector")

--- a/query/functions/testdata/pivot.flux
+++ b/query/functions/testdata/pivot.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> pivot(rowKey: ["_time"], colKey: ["_measurement", "_field"], valueCol: "_value")
   |> yield(name:"0")

--- a/query/functions/testdata/pivot_fields.flux
+++ b/query/functions/testdata/pivot_fields.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> pivot(rowKey: ["_time"], colKey: ["_field"], valueCol: "_value")
   |> yield(name:"0")

--- a/query/functions/testdata/pivot_mean.flux
+++ b/query/functions/testdata/pivot_mean.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> group(by: ["_stop", "_measurement", "_field", "host"])
   |> mean()

--- a/query/functions/testdata/range.flux
+++ b/query/functions/testdata/range.flux
@@ -1,3 +1,3 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:36Z) 
 

--- a/query/functions/testdata/rename.flux
+++ b/query/functions/testdata/rename.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> rename(columns:{host:"server"})
 	|> drop(columns:["_start", "_stop"])

--- a/query/functions/testdata/rename_fn.flux
+++ b/query/functions/testdata/rename_fn.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> rename(fn: (col) => col)
 	|> drop(fn: (col) => col == "_start" or col == "_stop")

--- a/query/functions/testdata/rename_multiple.flux
+++ b/query/functions/testdata/rename_multiple.flux
@@ -1,4 +1,4 @@
-from(db: "test")
+from(bucket: "test")
 	|> range(start:2018-05-22T19:53:26Z)
 	|> rename(columns: {old:"new"})
 	|> rename(columns: {new: "new1"})

--- a/query/functions/testdata/select_measurement.flux
+++ b/query/functions/testdata/select_measurement.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-21T13:09:22.885021542Z)
   |> filter(fn: (r) => r._measurement ==  "swap")
   |> group(by: ["_measurement", "_start"])

--- a/query/functions/testdata/select_measurement_field.flux
+++ b/query/functions/testdata/select_measurement_field.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> filter(fn: (r) => r._measurement ==  "system" AND r._field == "load1")
   |> group(by: ["_measurement", "_start"])

--- a/query/functions/testdata/selector_preserve_time.flux
+++ b/query/functions/testdata/selector_preserve_time.flux
@@ -1,4 +1,4 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
 	|> top(n:3)
 	|> group(by:["host"])

--- a/query/functions/testdata/simple_max.flux
+++ b/query/functions/testdata/simple_max.flux
@@ -1,4 +1,4 @@
-from(db:"test")
+from(bucket:"test")
   |> range(start:2018-04-17T00:00:00Z)
   |> group(by: ["_measurement", "_start"])
   |> max(column: "_value")

--- a/query/functions/testdata/sort.flux
+++ b/query/functions/testdata/sort.flux
@@ -1,3 +1,3 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-22T19:53:26Z)
   |> sort(cols:["_value", "_time"])

--- a/query/functions/testdata/string_interp.flux
+++ b/query/functions/testdata/string_interp.flux
@@ -1,5 +1,5 @@
 n = 1
 fieldSelect = "field{n}"
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:53:26Z)
     |> filter(fn: (r) => r._field == fieldSelect)

--- a/query/functions/testdata/string_max.flux
+++ b/query/functions/testdata/string_max.flux
@@ -1,3 +1,3 @@
-from(db:"test")
+from(bucket:"test")
     |> range(start:2018-05-22T19:54:16Z)
     |> max() 

--- a/query/functions/testdata/string_sort.flux
+++ b/query/functions/testdata/string_sort.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:26Z)
     |> sort()

--- a/query/functions/testdata/window.flux
+++ b/query/functions/testdata/window.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start:2018-05-22T19:53:26Z)
   |> group(by: ["_measurement"])
   |> window(every: 1s, ignoreGlobalBounds: true)

--- a/query/functions/testdata/window_default_start_align.flux
+++ b/query/functions/testdata/window_default_start_align.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:30Z)
     |> window(every:1m)

--- a/query/functions/testdata/window_group_mean_ungroup.flux
+++ b/query/functions/testdata/window_group_mean_ungroup.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start: 2018-05-23T13:09:22.885021542Z)
   |> window(every:1s)
   |> group(by: ["name"])

--- a/query/functions/testdata/window_offset.flux
+++ b/query/functions/testdata/window_offset.flux
@@ -1,4 +1,4 @@
-from(db:"testdb")
+from(bucket:"testdb")
   |> range(start:2018-05-22T19:53:26Z)
   |> group(by: ["_measurement"])
   |> window(every: 1s, start: 2,  ignoreGlobalBounds: true)

--- a/query/functions/testdata/window_start_bound.flux
+++ b/query/functions/testdata/window_start_bound.flux
@@ -1,3 +1,3 @@
-from(db: "test")
+from(bucket: "test")
     |> range(start:2018-05-22T19:53:00Z)
     |> window(start:2018-05-22T19:53:30Z,every: 1m)

--- a/query/functions/to_http_test.go
+++ b/query/functions/to_http_test.go
@@ -19,13 +19,13 @@ func TestToHTTP_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with database with range",
-			Raw:  `from(db:"mydb") |> toHTTP(url: "https://localhost:8081", name:"series1", method:"POST",  timeout: 50s)`,
+			Raw:  `from(bucket:"mybucket") |> toHTTP(url: "https://localhost:8081", name:"series1", method:"POST",  timeout: 50s)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/functions/to_kafka_test.go
+++ b/query/functions/to_kafka_test.go
@@ -21,13 +21,13 @@ func TestToKafka_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with database",
-			Raw:  `from(db:"mydb") |> toKafka(brokers:["brokerurl:8989"], name:"series1", topic:"totallynotfaketopic")`,
+			Raw:  `from(bucket:"mybucket") |> toKafka(brokers:["brokerurl:8989"], name:"series1", topic:"totallynotfaketopic")`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/functions/window_test.go
+++ b/query/functions/window_test.go
@@ -18,13 +18,13 @@ func TestWindow_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with window",
-			Raw:  `from(db:"mydb") |> window(start:-4h, every:1h)`,
+			Raw:  `from(bucket:"mybucket") |> window(start:-4h, every:1h)`,
 			Want: &query.Spec{
 				Operations: []*query.Operation{
 					{
 						ID: "from0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{

--- a/query/plan/logical_test.go
+++ b/query/plan/logical_test.go
@@ -23,7 +23,7 @@ func TestLogicalPlanner_Plan(t *testing.T) {
 					{
 						ID: "0",
 						Spec: &functions.FromOpSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 					},
 					{
@@ -48,7 +48,7 @@ func TestLogicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("0"): {
 						ID: plan.ProcedureIDFromOperationID("0"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("1")},
@@ -89,7 +89,7 @@ func TestLogicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("select0"): {
 						ID: plan.ProcedureIDFromOperationID("select0"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range0")},
@@ -118,7 +118,7 @@ func TestLogicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("select1"): {
 						ID: plan.ProcedureIDFromOperationID("select1"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range1")},
@@ -195,7 +195,7 @@ var benchmarkQuery = &query.Spec{
 		{
 			ID: "select0",
 			Spec: &functions.FromOpSpec{
-				Database: "mydb",
+				Bucket: "mybucket",
 			},
 		},
 		{
@@ -212,7 +212,7 @@ var benchmarkQuery = &query.Spec{
 		{
 			ID: "select1",
 			Spec: &functions.FromOpSpec{
-				Database: "mydb",
+				Bucket: "mybucket",
 			},
 		},
 		{

--- a/query/plan/physical_test.go
+++ b/query/plan/physical_test.go
@@ -29,7 +29,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -76,7 +76,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -114,7 +114,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("last")},
@@ -143,7 +143,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.MinTime,
@@ -177,7 +177,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -235,7 +235,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -293,7 +293,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -360,7 +360,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -432,7 +432,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -486,7 +486,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -546,7 +546,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -602,7 +602,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -662,7 +662,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -718,7 +718,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -776,7 +776,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database: "mydb",
+							Bucket: "mybucket",
 						},
 						Parents:  nil,
 						Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -832,7 +832,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
 						Spec: &functions.FromProcedureSpec{
-							Database:  "mydb",
+							Bucket:    "mybucket",
 							BoundsSet: true,
 							Bounds: plan.BoundsSpec{
 								Start: query.Time{
@@ -1072,7 +1072,7 @@ func TestPhysicalPlanner_Plan_PushDown_Branch(t *testing.T) {
 			plan.ProcedureIDFromOperationID("from"): {
 				ID: plan.ProcedureIDFromOperationID("from"),
 				Spec: &functions.FromProcedureSpec{
-					Database: "mydb",
+					Bucket: "mybucket",
 				},
 				Parents: nil,
 				Children: []plan.ProcedureID{
@@ -1125,7 +1125,7 @@ func TestPhysicalPlanner_Plan_PushDown_Branch(t *testing.T) {
 			fromID: {
 				ID: fromID,
 				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
+					Bucket:    "mybucket",
 					BoundsSet: true,
 					Bounds: plan.BoundsSpec{
 						Start: query.MinTime,
@@ -1145,7 +1145,7 @@ func TestPhysicalPlanner_Plan_PushDown_Branch(t *testing.T) {
 			fromIDDup: {
 				ID: fromIDDup,
 				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
+					Bucket:    "mybucket",
 					BoundsSet: true,
 					Bounds: plan.BoundsSpec{
 						Start: query.MinTime,
@@ -1183,7 +1183,7 @@ func TestPhysicalPlanner_Plan_PushDown_Mixed(t *testing.T) {
 			plan.ProcedureIDFromOperationID("from"): {
 				ID: plan.ProcedureIDFromOperationID("from"),
 				Spec: &functions.FromProcedureSpec{
-					Database: "mydb",
+					Bucket: "mybucket",
 				},
 				Parents:  nil,
 				Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
@@ -1254,7 +1254,7 @@ func TestPhysicalPlanner_Plan_PushDown_Mixed(t *testing.T) {
 			fromIDDup: {
 				ID: fromIDDup,
 				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
+					Bucket:    "mybucket",
 					BoundsSet: true,
 					Bounds: plan.BoundsSpec{
 						Start: query.Time{
@@ -1279,7 +1279,7 @@ func TestPhysicalPlanner_Plan_PushDown_Mixed(t *testing.T) {
 			plan.ProcedureIDFromOperationID("from"): {
 				ID: plan.ProcedureIDFromOperationID("from"),
 				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
+					Bucket:    "mybucket",
 					BoundsSet: true,
 					Bounds: plan.BoundsSpec{
 						Start: query.Time{

--- a/query/promql/query_test.go
+++ b/query/promql/query_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/ast"
 	"github.com/influxdata/platform/query/functions"
-	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/semantic"
 	"github.com/influxdata/platform/query/semantic/semantictest"
 )
@@ -363,7 +363,7 @@ func TestBuild(t *testing.T) {
 				Operations: []*query.Operation{
 					{
 						ID:   query.OperationID("from"),
-						Spec: &functions.FromOpSpec{Database: "prometheus"},
+						Spec: &functions.FromOpSpec{Bucket: "prometheus"},
 					},
 					{
 						ID: "where",
@@ -438,7 +438,7 @@ func TestBuild(t *testing.T) {
 				Operations: []*query.Operation{
 					{
 						ID:   query.OperationID("from"),
-						Spec: &functions.FromOpSpec{Database: "prometheus"},
+						Spec: &functions.FromOpSpec{Bucket: "prometheus"},
 					},
 					{
 						ID: query.OperationID("range"),
@@ -502,7 +502,7 @@ func TestBuild(t *testing.T) {
 				Operations: []*query.Operation{
 					{
 						ID:   query.OperationID("from"),
-						Spec: &functions.FromOpSpec{Database: "prometheus"},
+						Spec: &functions.FromOpSpec{Bucket: "prometheus"},
 					},
 					{
 						ID: query.OperationID("range"),

--- a/query/promql/types.go
+++ b/query/promql/types.go
@@ -146,7 +146,7 @@ func (s *Selector) QuerySpec() (*query.Spec, error) {
 		{
 			ID: "from", // TODO: Change this to a UUID
 			Spec: &functions.FromOpSpec{
-				Database: "prometheus",
+				Bucket: "prometheus",
 			},
 		},
 	}

--- a/query/spec_test.go
+++ b/query/spec_test.go
@@ -33,7 +33,7 @@ func TestSpec_JSON(t *testing.T) {
 			"id": "from",
 			"kind": "from",
 			"spec": {
-				"db":"mydb"
+				"bucket":"mybucket"
 			}
 		},
 		{
@@ -66,7 +66,7 @@ func TestSpec_JSON(t *testing.T) {
 			{
 				ID: "from",
 				Spec: &functions.FromOpSpec{
-					Database: "mydb",
+					Bucket: "mybucket",
 				},
 			},
 			{

--- a/task/backend/coordinator/coordinator_test.go
+++ b/task/backend/coordinator/coordinator_test.go
@@ -32,7 +32,7 @@ func TestCoordinator(t *testing.T) {
 
 	orgID := platform.ID("org")
 	usrID := platform.ID("usr")
-	script := `option task = {name: "a task",cron: "* * * * *"} from(db:"test") |> range(start:-1h)`
+	script := `option task = {name: "a task",cron: "* * * * *"} from(bucket:"test") |> range(start:-1h)`
 	id, err := coord.CreateTask(context.Background(), orgID, usrID, script, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +103,7 @@ func TestCoordinator(t *testing.T) {
 		t.Fatal("task sent to scheduler doesnt match task created")
 	}
 
-	newScript := `option task = {name: "a task",cron: "1 * * * *"} from(db:"test") |> range(start:-2h)`
+	newScript := `option task = {name: "a task",cron: "1 * * * *"} from(bucket:"test") |> range(start:-2h)`
 	err = coord.ModifyTask(context.Background(), id, newScript)
 	if err != nil {
 		t.Fatal(err)

--- a/task/backend/storetest/storetest.go
+++ b/task/backend/storetest/storetest.go
@@ -67,12 +67,12 @@ func testStoreCreate(t *testing.T, create CreateStoreFunc, destroy DestroyStoreF
 		cron: "* * * * *",
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 	const scriptNoName = `option task = {
 	cron: "* * * * *",
 }
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 	s := create(t)
 	defer destroy(t, s)
 
@@ -194,7 +194,7 @@ func testStoreListTasks(t *testing.T, create CreateStoreFunc, destroy DestroySto
 		cron: "* * * * *",
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 	t.Run("happy path", func(t *testing.T) {
 		s := create(t)
 		defer destroy(t, s)
@@ -359,7 +359,7 @@ func testStoreFindTask(t *testing.T, create CreateStoreFunc, destroy DestroyStor
 		cron: "* * * * *",
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 
 	t.Run("happy path", func(t *testing.T) {
 		s := create(t)
@@ -415,7 +415,7 @@ func testStoreFindMeta(t *testing.T, create CreateStoreFunc, destroy DestroyStor
 		delay: 5s,
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 
 	s := create(t)
 	defer destroy(t, s)
@@ -493,7 +493,7 @@ func testStoreTaskEnableDisable(t *testing.T, create CreateStoreFunc, destroy De
 		cron: "* * * * *",
 	}
 
-	from(db:"test") |> range(start:-1h)`
+	from(bucket:"test") |> range(start:-1h)`
 
 	s := create(t)
 	defer destroy(t, s)
@@ -548,7 +548,7 @@ func testStoreDelete(t *testing.T, create CreateStoreFunc, destroy DestroyStoreF
 		cron: "* * * * *",
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 
 	t.Run("happy path", func(t *testing.T) {
 		s := create(t)
@@ -595,7 +595,7 @@ func testStoreCreateNextRun(t *testing.T, create CreateStoreFunc, destroy Destro
 		concurrency: 2,
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 
 	s := create(t)
 	defer destroy(t, s)
@@ -655,7 +655,7 @@ func testStoreFinishRun(t *testing.T, create CreateStoreFunc, destroy DestroySto
 		cron: "* * * * *",
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 	s := create(t)
 	defer destroy(t, s)
 
@@ -732,7 +732,7 @@ func createABunchOFTasks(t *testing.T, s backend.Store, filter func(user, org ui
 		cron: "* * * * *",
 	}
 
-from(db:"test") |> range(start:-1h)`
+from(bucket:"test") |> range(start:-1h)`
 	var id platform.ID
 	var ids []platform.ID
 	var err error

--- a/task/options/options_test.go
+++ b/task/options/options_test.go
@@ -32,7 +32,7 @@ func scriptGenerator(opt options.Options, body string) string {
 		taskData = fmt.Sprintf("%s  retry: %d,\n", taskData, opt.Retry)
 	}
 	if body == "" {
-		body = `from(db: "test")
+		body = `from(bucket: "test")
     |> range(start:-1h)`
 	}
 
@@ -54,9 +54,9 @@ func TestFromScript(t *testing.T) {
 		{script: scriptGenerator(options.Options{Name: "name", Cron: "* * * * *"}, ""), exp: options.Options{Name: "name", Cron: "* * * * *", Concurrency: 1, Retry: 1}},
 		{script: scriptGenerator(options.Options{Name: "name", Every: time.Hour, Cron: "* * * * *"}, ""), shouldErr: true},
 		{script: scriptGenerator(options.Options{Name: "name", Concurrency: 1000, Every: time.Hour}, ""), shouldErr: true},
-		{script: "option task = {\n  name: \"name\",\n  concurrency: 0,\n  every: 1m0s,\n\n}\n\nfrom(db: \"test\")\n    |> range(start:-1h)", shouldErr: true},
+		{script: "option task = {\n  name: \"name\",\n  concurrency: 0,\n  every: 1m0s,\n\n}\n\nfrom(bucket: \"test\")\n    |> range(start:-1h)", shouldErr: true},
 		{script: scriptGenerator(options.Options{Name: "name", Retry: 20, Every: time.Hour}, ""), shouldErr: true},
-		{script: "option task = {\n  name: \"name\",\n  retry: 0,\n  every: 1m0s,\n\n}\n\nfrom(db: \"test\")\n    |> range(start:-1h)", shouldErr: true},
+		{script: "option task = {\n  name: \"name\",\n  retry: 0,\n  every: 1m0s,\n\n}\n\nfrom(bucket: \"test\")\n    |> range(start:-1h)", shouldErr: true},
 		{script: scriptGenerator(options.Options{Name: "name"}, ""), shouldErr: true},
 		{script: scriptGenerator(options.Options{}, ""), shouldErr: true},
 	} {


### PR DESCRIPTION
Removes the `db` parameter and used only bucket and bucketID.
