### PR TITLE
docs(http): add disabled boolean for authorization tokens

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -781,6 +781,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    patch:
+      tags:
+        - Authorizations
+      summary: enable/disable authorization
+      requestBody:
+        description: authorization to update to apply
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Authorization"
+      parameters:
+        - in: path
+          name: authId
+          schema:
+            type: string
+          required: true
+          description: ID of authorization to update
+      responses:
+        '200':
+          description: the enabled or disabled authorization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Authorization"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
     delete:
       tags:
         - Authorizations
@@ -1775,6 +1806,9 @@ components:
         id:
           readOnly: true
           type: string
+        disabled:
+          description: if true the token has been disabled and requests will be rejected.
+          type: boolean
         token:
           readOnly: true
           type: string


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Token permissions are immutable, but, it would be nice to enable/disable tokens rather than just DELETE them.

_What is the problem?_
Administrators should have the ability to temporarily disable a token (perhaps the writes using a token are hurting the system).

Once the issue has been resolved the token can be enabled.  This way the token doesn't need to be DELETED, but, just disabled.

_What was the solution?_

My first boolean!! I feel like it is legit in this case that a token only has 2 states.


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)