### PR TITLE
fix(query/influxql): disable the join behavior in the transpiler

### DIFF
--- a/query/influxql/group.go
+++ b/query/influxql/group.go
@@ -183,6 +183,10 @@ func (gr *groupInfo) createCursor(t *transpilerState) (cursor, error) {
 	// TODO(jsternberg): We need to differentiate between various join types and this needs to be
 	// except: ["_field"] rather than joining on the _measurement. This also needs to specify what the time
 	// column should be.
+	if len(cursors) > 1 {
+		return nil, errors.New("unimplemented: joining fields within a cursor")
+	}
+
 	cur := Join(t, cursors, []string{"_measurement"}, nil)
 	if len(tags) > 0 {
 		cur = &tagsCursor{cursor: cur, tags: tags}

--- a/query/influxql/spectests/math.go
+++ b/query/influxql/spectests/math.go
@@ -1,13 +1,15 @@
+//+build todo
+
 package spectests
 
 import (
 	"time"
 
-	"github.com/influxdata/influxql"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/ast"
 	"github.com/influxdata/platform/query/execute"
 	"github.com/influxdata/platform/query/functions"
+	"github.com/influxdata/platform/query/influxql"
 	"github.com/influxdata/platform/query/semantic"
 )
 

--- a/query/influxql/spectests/multiple_aggregates.go
+++ b/query/influxql/spectests/multiple_aggregates.go
@@ -1,3 +1,5 @@
+//+build todo
+
 package spectests
 
 import (

--- a/query/influxql/transpiler.go
+++ b/query/influxql/transpiler.go
@@ -102,6 +102,9 @@ func (t *transpilerState) Transpile(ctx context.Context, id int, stmt *influxql.
 
 	// Join the cursors together on the measurement name.
 	// TODO(jsternberg): This needs to join on all remaining group keys.
+	if len(cursors) > 1 {
+		return errors.New("unimplemented: joining multiple group cursors")
+	}
 	cur := Join(t, cursors, []string{"_measurement"}, nil)
 
 	// Map each of the fields into another cursor. This evaluates any lingering expressions.


### PR DESCRIPTION
The behavior needs to be updated so we are goinig to just disable it
temporarily so bad query specs are not generated.

Related to #707.