### PR TITLE
test(task): fix two flaky tests

### DIFF
--- a/task/backend/inmem_logreaderwriter.go
+++ b/task/backend/inmem_logreaderwriter.go
@@ -109,7 +109,6 @@ func (r *runReaderWriter) ListRuns(ctx context.Context, runFilter platform.RunFi
 				break
 			}
 		}
-
 	}
 
 	if runFilter.Limit != 0 && beforeIndex-afterIndex > runFilter.Limit {


### PR DESCRIPTION
In TestScheduler_RunLog, the run log gets updated asynchronously so we
need to poll to ensure we don't read a stale value.

In TestScheduler_CreateNextRunOnTick, we were previously reading the
one entry out of two from a map, so it was often the entry we weren't
interested in.