### PR TITLE
fix: remove constraints that were from the query package

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,10 +51,6 @@ required = [
   name = "github.com/influxdata/influxdb"
   branch = "platform"
 
-[[constraint]]
-  name = "github.com/influxdata/tdigest"
-  branch = "master"
-
 # Pigeon hasn't made official releases for a while, we need to use master for now.
 # We plan to replace pigeon with a hand written parser, as such this dependency is short lived.
 [[override]]
@@ -89,10 +85,6 @@ required = [
 [[constraint]]
   branch = "master"
   name = "github.com/andreyvit/diff"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/gonum/stat"
 
 [[constraint]]
   name = "github.com/google/go-github"


### PR DESCRIPTION
The query package has now mostly been moved to influxdata/flux so these
constraints cause dep to print a non-useful message that is confusing.