### PR TITLE
ci(Makefile): update PATH to have go-bindata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ export GO_BUILD=go build $(GO_ARGS)
 export GO_TEST=go test $(GO_ARGS)
 export GO_GENERATE=go generate $(GO_ARGS)
 export GO_VET= go vet $(GO_ARGS)
+export PATH := $(PWD)/bin/$(GOOS):$(PATH)
 
 
 # All go source files


### PR DESCRIPTION

_Briefly describe your proposed changes:_
Add path to the makefile

_What was the problem?_
go-bindata is not found

_What was the solution?_
Use export extension of GNU Make
