### PR TITLE
ci(Makefile): add asset generation to nightly

### DIFF
--- a/chronograf/ui/Makefile
+++ b/chronograf/ui/Makefile
@@ -1,0 +1,35 @@
+YARN := $(shell command -v yarn 2> /dev/null)
+UISOURCES := $(shell find . -type f -not \( -path ./build/\* -o -path ./node_modules/\* -o -path ./.cache/\* -o -name Makefile -prune \) )
+
+all: build
+
+node_modules: yarn.lock
+ifndef YARN
+	$(error Please install yarn 0.19.1+)
+else
+	yarn --no-progress --no-emoji
+endif
+
+build: node_modules $(UISOURCES)
+ifndef YARN
+	$(error Please install yarn 0.19.1+)
+else
+	yarn run build
+endif
+
+test:
+ifndef YARN
+	$(error Please install yarn 0.19.1+)
+else
+	yarn test --runInBand
+endif
+
+clean:
+ifndef YARN
+	$(error Please install yarn 0.19.1+)
+else
+	yarn run clean
+endif
+
+
+.PHONY: all clean test

--- a/chronograf/ui/package.json
+++ b/chronograf/ui/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "parcel watch -d build src/index.html",
     "build": "parcel build -d build --no-source-maps src/index.html",
-    "clean": "rm -rf ./build/* && rm -rf ./.cache",
+    "clean": "rm -rf ./build && rm -rf ./.cache",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",


### PR DESCRIPTION


_Briefly describe your proposed changes:_
Move asset generation into ui directory

_What was the problem?_
dist_gen.go was running before the assets had been created

_What was the solution?_
Created a makefile in the ui directory that is called by the top-level makefile

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)