### PR TITLE
feat(http): add flux AST and Spec endpoints to fluxd

### DIFF
--- a/chronograf/ui/src/flux/apis/index.ts
+++ b/chronograf/ui/src/flux/apis/index.ts
@@ -24,19 +24,19 @@ export const getSuggestions = async (url: string) => {
 
 interface ASTRequest {
   url: string
-  body: string
+  query: string
 }
 
 export const getAST = async (request: ASTRequest) => {
-  const {url, body} = request
+  const {url, query} = request
   try {
     const {data} = await AJAX({
       method: 'POST',
       url,
-      data: {body},
+      data: {query},
     })
 
-    return data
+    return data.ast
   } catch (error) {
     console.error('Could not parse query', error)
     throw error

--- a/chronograf/ui/src/flux/components/FilterArgs.tsx
+++ b/chronograf/ui/src/flux/components/FilterArgs.tsx
@@ -52,7 +52,7 @@ class FilterArgs extends PureComponent<Props, State> {
   public async convertStringToNodes() {
     const {links, value} = this.props
 
-    const ast = await getAST({url: links.ast, body: value})
+    const ast = await getAST({url: links.ast, query: value})
     const nodes = new Walker(ast).inOrderExpression
     this.setState({nodes, ast})
   }

--- a/chronograf/ui/src/flux/components/FilterPreview.tsx
+++ b/chronograf/ui/src/flux/components/FilterPreview.tsx
@@ -41,7 +41,7 @@ export class FilterPreview extends PureComponent<Props, State> {
   public async convertStringToNodes() {
     const {links, filterString} = this.props
 
-    const ast = await getAST({url: links.ast, body: filterString})
+    const ast = await getAST({url: links.ast, query: filterString})
     const nodes = new Walker(ast).inOrderExpression
     this.setState({nodes, ast})
   }

--- a/chronograf/ui/src/flux/containers/FluxPage.tsx
+++ b/chronograf/ui/src/flux/containers/FluxPage.tsx
@@ -599,7 +599,7 @@ export class FluxPage extends PureComponent<Props, State> {
     const {links, notify, script} = this.props
 
     try {
-      const ast = await getAST({url: links.ast, body: script})
+      const ast = await getAST({url: links.ast, query: script})
       const body = bodyNodes(ast, this.state.suggestions)
       const status = {type: 'success', text: ''}
       notify(validateSuccess())
@@ -620,7 +620,7 @@ export class FluxPage extends PureComponent<Props, State> {
     }
 
     try {
-      const ast = await getAST({url: links.ast, body: script})
+      const ast = await getAST({url: links.ast, query: script})
 
       if (update) {
         this.props.updateScript(script)
@@ -643,7 +643,7 @@ export class FluxPage extends PureComponent<Props, State> {
     }
 
     try {
-      await getAST({url: links.ast, body: script})
+      await getAST({url: links.ast, query: script})
     } catch (error) {
       this.setState({status: this.parseError(error)})
       return console.error('Could not parse AST', error)

--- a/http/flux_lang_test.go
+++ b/http/flux_lang_test.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFluxLangHandler_getFlux(t *testing.T) {
+	tests := []struct {
+		name string
+		w    *httptest.ResponseRecorder
+		r    *http.Request
+		want string
+	}{
+		{
+			name: "get links",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest("GET", "/v2/flux", nil),
+			want: `{"links":{"self":"/v2/flux","suggestions":"/v2/flux/suggestions","ast":"/v2/flux/ast"}}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &FluxLangHandler{}
+			h.getFlux(tt.w, tt.r)
+			if got := tt.w.Body.String(); got != tt.want {
+				t.Errorf("http.getFlux = got %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFluxLangHandler_postFluxAST(t *testing.T) {
+	tests := []struct {
+		name   string
+		w      *httptest.ResponseRecorder
+		r      *http.Request
+		want   string
+		status int
+	}{
+		{
+			name: "get ast from()",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest("GET", "/v2/flux/ast", bytes.NewBufferString(`{"query": "from()"}`)),
+			want: `{"ast":{"type":"Program","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"body":[{"type":"ExpressionStatement","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"expression":{"type":"CallExpression","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"callee":{"type":"Identifier","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":5},"source":"from"},"name":"from"}}}]}}
+`,
+			status: http.StatusOK,
+		},
+		{
+			name:   "error from bad json",
+			w:      httptest.NewRecorder(),
+			r:      httptest.NewRequest("GET", "/v2/flux/ast", bytes.NewBufferString(`error!`)),
+			status: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &FluxLangHandler{}
+			h.postFluxAST(tt.w, tt.r)
+			if got := tt.w.Body.String(); got != tt.want {
+				t.Errorf("http.postFluxAST = got\n%vwant\n%v", got, tt.want)
+			}
+			if got := tt.w.Code; got != tt.status {
+				t.Errorf("http.postFluxAST = got %d\nwant %d", got, tt.status)
+			}
+		})
+	}
+}
+
+func TestFluxLangHandler_postFluxSpec(t *testing.T) {
+	tests := []struct {
+		name   string
+		w      *httptest.ResponseRecorder
+		r      *http.Request
+		now    func() time.Time
+		want   string
+		status int
+	}{
+		{
+			name: "get spec from()",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest("GET", "/v2/flux/spec", bytes.NewBufferString(`{"query": "from(bucket: \"telegraf\")"}`)),
+			now:  func() time.Time { return time.Unix(0, 0).UTC() },
+			want: `{"spec":{"operations":[{"kind":"from","id":"from0","spec":{"bucket":"telegraf"}}],"edges":null,"resources":{"priority":"high","concurrency_quota":0,"memory_bytes_quota":0},"now":"1970-01-01T00:00:00Z"}}
+`,
+			status: http.StatusOK,
+		},
+		{
+			name:   "error from bad json",
+			w:      httptest.NewRecorder(),
+			r:      httptest.NewRequest("GET", "/v2/flux/spec", bytes.NewBufferString(`error!`)),
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "error from incomplete spec",
+			w:      httptest.NewRecorder(),
+			r:      httptest.NewRequest("GET", "/v2/flux/spec", bytes.NewBufferString(`{"query": "from()"}`)),
+			now:    func() time.Time { return time.Unix(0, 0).UTC() },
+			status: http.StatusUnprocessableEntity,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &FluxLangHandler{
+				Now: tt.now,
+			}
+			h.postFluxSpec(tt.w, tt.r)
+			if got := tt.w.Body.String(); got != tt.want {
+				t.Errorf("http.postFluxSpec = got %s\nwant %s", got, tt.want)
+			}
+
+			if got := tt.w.Code; got != tt.status {
+				t.Errorf("http.postFluxSpec = got %d\nwant %d", got, tt.status)
+			}
+		})
+	}
+}

--- a/http/query_test.go
+++ b/http/query_test.go
@@ -1,0 +1,476 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/platform/mock"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/query"
+)
+
+func TestQueryRequest_WithDefaults(t *testing.T) {
+	type fields struct {
+		Spec    *flux.Spec
+		AST     *ast.Program
+		Query   string
+		Type    string
+		Dialect QueryDialect
+		org     *platform.Organization
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   QueryRequest
+	}{
+		{
+			name: "empty query has defaults set",
+			want: QueryRequest{
+				Type: "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+					Header:         func(x bool) *bool { return &x }(true),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := QueryRequest{
+				Spec:    tt.fields.Spec,
+				AST:     tt.fields.AST,
+				Query:   tt.fields.Query,
+				Type:    tt.fields.Type,
+				Dialect: tt.fields.Dialect,
+				org:     tt.fields.org,
+			}
+			if got := r.WithDefaults(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("QueryRequest.WithDefaults() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryRequest_Validate(t *testing.T) {
+	type fields struct {
+		Spec    *flux.Spec
+		AST     *ast.Program
+		Query   string
+		Type    string
+		Dialect QueryDialect
+		org     *platform.Organization
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "requires query, spec, or ast",
+			fields: fields{
+				Type: "flux",
+			},
+			wantErr: true,
+		},
+		{
+			name: "requires flux type",
+			fields: fields{
+				Query: "howdy",
+				Type:  "doody",
+			},
+			wantErr: true,
+		},
+		{
+			name: "comment must be a single character",
+			fields: fields{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					CommentPrefix: "error!",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "delimiter must be a single character",
+			fields: fields{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter: "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "characters must be unicode runes",
+			fields: fields{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter: string([]byte{0x80}),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown annotations",
+			fields: fields{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter:   ",",
+					Annotations: []string{"error"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown date time format",
+			fields: fields{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "error",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid query",
+			fields: fields{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := QueryRequest{
+				Spec:    tt.fields.Spec,
+				AST:     tt.fields.AST,
+				Query:   tt.fields.Query,
+				Type:    tt.fields.Type,
+				Dialect: tt.fields.Dialect,
+				org:     tt.fields.org,
+			}
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("QueryRequest.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_toSpec(t *testing.T) {
+	flux.FinalizeBuiltIns()
+	type args struct {
+		p   *ast.Program
+		now func() time.Time
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *flux.Spec
+		wantErr bool
+	}{
+		{
+			name: "ast converts to spec",
+			args: args{
+				p:   &ast.Program{},
+				now: func() time.Time { return time.Unix(0, 0) },
+			},
+			want: &flux.Spec{
+				Now: time.Unix(0, 0).UTC(),
+			},
+		},
+		{
+			name: "bad semantics error",
+			args: args{
+				p: &ast.Program{
+					Body: []ast.Statement{
+						&ast.ReturnStatement{},
+					},
+				},
+				now: func() time.Time { return time.Unix(0, 0) },
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := toSpec(tt.args.p, tt.args.now)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toSpec() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toSpec() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryRequest_proxyRequest(t *testing.T) {
+	type fields struct {
+		Spec    *flux.Spec
+		AST     *ast.Program
+		Query   string
+		Type    string
+		Dialect QueryDialect
+		org     *platform.Organization
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		now     func() time.Time
+		want    *query.ProxyRequest
+		wantErr bool
+	}{
+		{
+			name: "requires query, spec, or ast",
+			fields: fields{
+				Type: "flux",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid query",
+			fields: fields{
+				Query: "howdy",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+				},
+				org: &platform.Organization{},
+			},
+			want: &query.ProxyRequest{
+				Request: query.Request{
+					Compiler: lang.FluxCompiler{
+						Query: "howdy",
+					},
+				},
+				Dialect: csv.Dialect{
+					ResultEncoderConfig: csv.ResultEncoderConfig{
+						NoHeader:  false,
+						Delimiter: ',',
+					},
+				},
+			},
+		},
+		{
+			name: "valid AST",
+			fields: fields{
+				AST:  &ast.Program{},
+				Type: "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+				},
+				org: &platform.Organization{},
+			},
+			now: func() time.Time { return time.Unix(0, 0).UTC() },
+			want: &query.ProxyRequest{
+				Request: query.Request{
+					Compiler: lang.SpecCompiler{
+						Spec: &flux.Spec{
+							Now: time.Unix(0, 0).UTC(),
+						},
+					},
+				},
+				Dialect: csv.Dialect{
+					ResultEncoderConfig: csv.ResultEncoderConfig{
+						NoHeader:  false,
+						Delimiter: ',',
+					},
+				},
+			},
+		},
+		{
+			name: "valid spec",
+			fields: fields{
+				Type: "flux",
+				Spec: &flux.Spec{
+					Now: time.Unix(0, 0).UTC(),
+				},
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+				},
+				org: &platform.Organization{},
+			},
+			want: &query.ProxyRequest{
+				Request: query.Request{
+					Compiler: lang.SpecCompiler{
+						Spec: &flux.Spec{
+							Now: time.Unix(0, 0).UTC(),
+						},
+					},
+				},
+				Dialect: csv.Dialect{
+					ResultEncoderConfig: csv.ResultEncoderConfig{
+						NoHeader:  false,
+						Delimiter: ',',
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := QueryRequest{
+				Spec:    tt.fields.Spec,
+				AST:     tt.fields.AST,
+				Query:   tt.fields.Query,
+				Type:    tt.fields.Type,
+				Dialect: tt.fields.Dialect,
+				org:     tt.fields.org,
+			}
+			got, err := r.proxyRequest(tt.now)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("QueryRequest.ProxyRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("QueryRequest.ProxyRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_decodeQueryRequest(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		r   *http.Request
+		svc platform.OrganizationService
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *QueryRequest
+		wantErr bool
+	}{
+		{
+			name: "valid query request",
+			args: args{
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`)),
+				svc: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+						return &platform.Organization{
+							ID: func() platform.ID { s, _ := platform.IDFromString("deadbeef"); return *s }(),
+						}, nil
+					},
+				},
+			},
+			want: &QueryRequest{
+				Query: "from()",
+				Type:  "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+					Header:         func(x bool) *bool { return &x }(true),
+				},
+				org: &platform.Organization{
+					ID: func() platform.ID { s, _ := platform.IDFromString("deadbeef"); return *s }(),
+				},
+			},
+		},
+		{
+			name: "error decoding json",
+			args: args{
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`error`)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "error validating query",
+			args: args{
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`)),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeQueryRequest(tt.args.ctx, tt.args.r, tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decodeQueryRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("decodeQueryRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_decodeProxyQueryRequest(t *testing.T) {
+	type args struct {
+		ctx  context.Context
+		r    *http.Request
+		auth *platform.Authorization
+		svc  platform.OrganizationService
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *query.ProxyRequest
+		wantErr bool
+	}{
+		{
+			name: "valid query request",
+			args: args{
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`)),
+				svc: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+						return &platform.Organization{
+							ID: func() platform.ID { s, _ := platform.IDFromString("deadbeef"); return *s }(),
+						}, nil
+					},
+				},
+			},
+			want: &query.ProxyRequest{
+				Request: query.Request{
+					OrganizationID: func() platform.ID { s, _ := platform.IDFromString("deadbeef"); return *s }(),
+					Compiler: lang.FluxCompiler{
+						Query: "from()",
+					},
+				},
+				Dialect: csv.Dialect{
+					ResultEncoderConfig: csv.ResultEncoderConfig{
+						NoHeader:  false,
+						Delimiter: ',',
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeProxyQueryRequest(tt.args.ctx, tt.args.r, tt.args.auth, tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decodeProxyQueryRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("decodeProxyQueryRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/mock/org_service.go
+++ b/mock/org_service.go
@@ -1,0 +1,49 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/influxdata/platform"
+)
+
+var _ platform.OrganizationService = &OrganizationService{}
+
+// OrganizationService is a mock organization server.
+type OrganizationService struct {
+	FindOrganizationByIDF func(ctx context.Context, id platform.ID) (*platform.Organization, error)
+	FindOrganizationF     func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error)
+	FindOrganizationsF    func(ctx context.Context, filter platform.OrganizationFilter, opt ...platform.FindOptions) ([]*platform.Organization, int, error)
+	CreateOrganizationF   func(ctx context.Context, b *platform.Organization) error
+	UpdateOrganizationF   func(ctx context.Context, id platform.ID, upd platform.OrganizationUpdate) (*platform.Organization, error)
+	DeleteOrganizationF   func(ctx context.Context, id platform.ID) error
+}
+
+//FindOrganizationByID calls FindOrganizationByIDF.
+func (s *OrganizationService) FindOrganizationByID(ctx context.Context, id platform.ID) (*platform.Organization, error) {
+	return s.FindOrganizationByIDF(ctx, id)
+}
+
+//FindOrganization calls FindOrganizationF.
+func (s *OrganizationService) FindOrganization(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+	return s.FindOrganizationF(ctx, filter)
+}
+
+//FindOrganizations calls FindOrganizationsF.
+func (s *OrganizationService) FindOrganizations(ctx context.Context, filter platform.OrganizationFilter, opt ...platform.FindOptions) ([]*platform.Organization, int, error) {
+	return s.FindOrganizationsF(ctx, filter, opt...)
+}
+
+// CreateOrganization calls CreateOrganizationF.
+func (s *OrganizationService) CreateOrganization(ctx context.Context, b *platform.Organization) error {
+	return s.CreateOrganizationF(ctx, b)
+}
+
+// UpdateOrganization calls UpdateOrganizationF.
+func (s *OrganizationService) UpdateOrganization(ctx context.Context, id platform.ID, upd platform.OrganizationUpdate) (*platform.Organization, error) {
+	return s.UpdateOrganizationF(ctx, id, upd)
+}
+
+// DeleteOrganization calls DeleteOrganizationF.
+func (s *OrganizationService) DeleteOrganization(ctx context.Context, id platform.ID) error {
+	return s.DeleteOrganizationF(ctx, id)
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Add support for AST and Spec generation as well as query support of AST and spec.

### Setup
1. Use influxdb nightly from https://portal.influxdata.com/downloads
2. run `influxd config > influxd.conf`
3. run `influxd -config influxd.conf`
4. __must__ have influxd running before turning on fluxd.
5. Download fluxd nightly from https://portal.influxdata.com/downloads
6. `run fluxd --storage-hosts 127.0.0.1:8082`
7. install and run telegraf to get data into influx



### Convert Query to AST
Produce AST JSON structure of flux by POSTing to the `/v2/flux/ast` endpoint:

```sh
curl -XPOST http://127.0.0.1:8093/v2/flux/ast -d '{"query": "from(bucket: \"telegraf\")"}'
```

### Query using AST

```sh
# redirect the AST to file
curl -XPOST http://127.0.0.1:8093/v2/flux/ast -d '{"query": "from(bucket: \"telegraf\")"}' > ast.json
# send the ast.json to the query endpoint
curl -v -XPOST http://127.0.0.1:8093/query -d@ast.json
```

### Convert Query to Spec
Produce Spec JSON structure of flux by POSTing to the `/v2/flux/spec` endpoint:

```sh
curl -XPOST http://127.0.0.1:8093/v2/flux/spec -d '{"query": "from(bucket: \"telegraf\")"}'
```

### Query using the Spec
```sh
# redirect the AST to file
curl -XPOST http://127.0.0.1:8093/v2/flux/spec -d '{"query": "from(bucket: \"telegraf\")"}' > spec.json
# send the spec.json to the query endpoint
curl -v -XPOST http://127.0.0.1:8093/query -d@spec.json
```