### PR TITLE
fix(flux/api): ensure ast default

### DIFF
--- a/chronograf/ui/src/flux/apis/index.ts
+++ b/chronograf/ui/src/flux/apis/index.ts
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import AJAX from 'src/utils/ajax'
 import {Service, FluxTable} from 'src/types'
 import {updateService} from 'src/shared/apis'
+import {getDeep} from 'src/utils/wrappers'
 import {
   parseResponse,
   parseResponseError,
@@ -36,7 +37,7 @@ export const getAST = async (request: ASTRequest) => {
       data: {query},
     })
 
-    return data.ast
+    return getDeep<ASTRequest>(data, 'ast', {url: '', query: ''})
   } catch (error) {
     console.error('Could not parse query', error)
     throw error


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Add defaults for AST response.

_What was the problem?_
If there was no `ast` in the returned object, it would thrown an error.

_What was the solution?_
Using getDeep (lodash wrapper)

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)