### PR TITLE
fix: Update internal HTTP paths for query service

### DIFF
--- a/http/proxy_query_service.go
+++ b/http/proxy_query_service.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	proxyQueryPath = "/v1/query"
+	proxyQueryPath = "/v2/queryproxysvc"
 )
 
 type ProxyQueryHandler struct {

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -41,7 +41,7 @@ func NewFluxHandler() *FluxHandler {
 		Logger: zap.NewNop(),
 	}
 
-	h.HandlerFunc("POST", "/v2/query", h.handlePostQuery)
+	h.HandlerFunc("POST", fluxPath, h.handlePostQuery)
 	return h
 }
 

--- a/http/query_service.go
+++ b/http/query_service.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	queryPath = "/v1/query"
+	queryPath = "/v2/querysvc"
 
 	statsTrailer = "Influx-Query-Statistics"
 )


### PR DESCRIPTION
Since all paths for the various query services were the same even though
the API are different it was confusing to work with and debug.
Now all internal paths have a unique name.
