### PR TITLE
fix: restore the generate task in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ UTILS := \
 # This target sets up the dependencies to correctly build all go commands.
 # Other targets must depend on this target to correctly builds CMDS.
 all: GO_ARGS=-tags 'assets $(GO_TAGS)'
-all: node_modules $(UTILS) subdirs $(CMDS)
+all: node_modules $(UTILS) subdirs generate $(CMDS)
 
 # Target to build subdirs.
 # Each subdirs must support the `all` target.


### PR DESCRIPTION
This was mistakenly deleted when I deleted vendor. I have no idea why it
was deleted so it was probably a mistake or something left over from
testing.

Fixes #858.