### PR TITLE
feat(http): buckets now use influxql duration strings

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -6,9 +6,11 @@ import (
 	"time"
 )
 
+// BucketType defines known system-buckets.
 type BucketType int
 
 const (
+	// BucketTypeLogs defines the bucket ID of the system logs.
 	BucketTypeLogs = BucketType(iota + 10)
 )
 

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -23,7 +23,7 @@ func bucketF(cmd *cobra.Command, args []string) {
 	cmd.Usage()
 }
 
-// Create Command
+// BucketCreateFlags define the Create Command
 type BucketCreateFlags struct {
 	name      string
 	org       string
@@ -41,7 +41,7 @@ func init() {
 	}
 
 	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.name, "name", "n", "", "name of bucket that will be created")
-	bucketCreateCmd.Flags().DurationVarP(&bucketCreateFlags.retention, "retention", "r", 0, "duration data will live in bucket")
+	bucketCreateCmd.Flags().DurationVarP(&bucketCreateFlags.retention, "retention", "r", 0, "duration in nanoseconds data will live in bucket")
 	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.org, "org", "o", "", "name of the organization that owns the bucket")
 	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.orgID, "org-id", "", "", "id of the organization that owns the bucket")
 	bucketCreateCmd.MarkFlagRequired("name")
@@ -102,7 +102,7 @@ func bucketCreateF(cmd *cobra.Command, args []string) {
 	w.Flush()
 }
 
-// Find Command
+// BucketFindFlags define the Find Command
 type BucketFindFlags struct {
 	name  string
 	id    string
@@ -192,7 +192,7 @@ func bucketFindF(cmd *cobra.Command, args []string) {
 	w.Flush()
 }
 
-// Update Command
+// BucketUpdateFlags define the Update Command
 type BucketUpdateFlags struct {
 	id        string
 	name      string
@@ -260,7 +260,7 @@ func bucketUpdateF(cmd *cobra.Command, args []string) {
 	w.Flush()
 }
 
-// Delete command
+// BucketDeleteFlags define the Delete command
 type BucketDeleteFlags struct {
 	id string
 }

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -516,7 +516,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",
   "name": "example",
-  "retentionPeriod": "1u"
+  "retentionPeriod": "1234ns"
 }
 `,
 			},

--- a/http/duration.go
+++ b/http/duration.go
@@ -1,0 +1,133 @@
+package http
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/platform/kit/errors"
+)
+
+// ErrInvalidDuration is returned when parsing a malformatted duration.
+var ErrInvalidDuration = errors.New("invalid duration", errors.MalformedData)
+
+// ParseDuration parses a time duration from a string.
+// This is needed instead of time.ParseDuration because this will support
+// the full syntax that InfluxQL supports for specifying durations
+// including weeks and days.
+func ParseDuration(s string) (time.Duration, error) {
+	// Return an error if the string is blank or one character
+	if len(s) < 2 {
+		return 0, ErrInvalidDuration
+	}
+
+	// Split string into individual runes.
+	a := split(s)
+
+	// Start with a zero duration.
+	var d time.Duration
+	i := 0
+
+	// Check for a negative.
+	isNegative := false
+	if a[i] == '-' {
+		isNegative = true
+		i++
+	}
+
+	var measure int64
+	var unit string
+
+	// Parsing loop.
+	for i < len(a) {
+		// Find the number portion.
+		start := i
+		for ; i < len(a) && isDigit(a[i]); i++ {
+			// Scan for the digits.
+		}
+
+		// Check if we reached the end of the string prematurely.
+		if i >= len(a) || i == start {
+			return 0, ErrInvalidDuration
+		}
+
+		// Parse the numeric part.
+		n, err := strconv.ParseInt(string(a[start:i]), 10, 64)
+		if err != nil {
+			return 0, ErrInvalidDuration
+		}
+		measure = n
+
+		// Extract the unit of measure.
+		// If the last two characters are "ms" then parse as milliseconds.
+		// Otherwise just use the last character as the unit of measure.
+		unit = string(a[i])
+		switch a[i] {
+		case 'u', 'µ':
+			d += time.Duration(n) * time.Microsecond
+		case 'm':
+			if i+1 < len(a) && a[i+1] == 's' {
+				unit = string(a[i : i+2])
+				d += time.Duration(n) * time.Millisecond
+				i += 2
+				continue
+			}
+			d += time.Duration(n) * time.Minute
+		case 's':
+			d += time.Duration(n) * time.Second
+		case 'h':
+			d += time.Duration(n) * time.Hour
+		case 'd':
+			d += time.Duration(n) * 24 * time.Hour
+		case 'w':
+			d += time.Duration(n) * 7 * 24 * time.Hour
+		default:
+			return 0, ErrInvalidDuration
+		}
+		i++
+	}
+
+	// Check to see if we overflowed a duration
+	if d < 0 && !isNegative {
+		return 0, fmt.Errorf("overflowed duration %d%s: choose a smaller duration or INF", measure, unit)
+	}
+
+	if isNegative {
+		d = -d
+	}
+	return d, nil
+}
+
+// FormatDuration formats a duration to a string.
+func FormatDuration(d time.Duration) string {
+	if d == 0 {
+		return "0s"
+	} else if d%(7*24*time.Hour) == 0 {
+		return fmt.Sprintf("%dw", d/(7*24*time.Hour))
+	} else if d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", d/(24*time.Hour))
+	} else if d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", d/time.Hour)
+	} else if d%time.Minute == 0 {
+		return fmt.Sprintf("%dm", d/time.Minute)
+	} else if d%time.Second == 0 {
+		return fmt.Sprintf("%ds", d/time.Second)
+	} else if d%time.Millisecond == 0 {
+		return fmt.Sprintf("%dms", d/time.Millisecond)
+	}
+	// Although we accept both "u" and "µ" when reading microsecond durations,
+	// we output with "u", which can be represented in 1 byte,
+	// instead of "µ", which requires 2 bytes.
+	return fmt.Sprintf("%du", d/time.Microsecond)
+}
+
+// split splits a string into a slice of runes.
+func split(s string) (a []rune) {
+	for _, ch := range s {
+		a = append(a, ch)
+	}
+	return
+}
+
+// isDigit returns true if the rune is a digit.
+func isDigit(ch rune) bool { return (ch >= '0' && ch <= '9') }

--- a/http/duration.go
+++ b/http/duration.go
@@ -85,6 +85,8 @@ func ParseDuration(s string) (time.Duration, error) {
 					i += 2
 					continue
 				case 'o': // mo == month
+					// TODO(goller): use real duration values:
+					// https://github.com/influxdata/platform/issues/657
 					unit = string(a[i : i+2])
 					d += time.Duration(n) * 30 * 24 * time.Hour
 					i += 2
@@ -99,8 +101,12 @@ func ParseDuration(s string) (time.Duration, error) {
 		case 'd':
 			d += time.Duration(n) * 24 * time.Hour
 		case 'w':
+			// TODO(goller): use real duration values:
+			// https://github.com/influxdata/platform/issues/657
 			d += time.Duration(n) * 7 * 24 * time.Hour
 		case 'y':
+			// TODO(goller): use real duration values:
+			// https://github.com/influxdata/platform/issues/657
 			d += time.Duration(n) * 365 * 24 * time.Hour
 		default:
 			return 0, ErrInvalidDuration

--- a/http/duration.go
+++ b/http/duration.go
@@ -61,6 +61,13 @@ func ParseDuration(s string) (time.Duration, error) {
 		// Extract the unit of measure.
 		unit = string(a[i])
 		switch a[i] {
+		case 'n':
+			d += time.Duration(n) * time.Nanosecond
+			if i+1 < len(a) && a[i+1] == 's' {
+				unit = string(a[i : i+2])
+				i += 2
+				continue
+			}
 		case 'u', 'µ':
 			d += time.Duration(n) * time.Microsecond
 			if i+1 < len(a) && a[i+1] == 's' {
@@ -118,6 +125,8 @@ func FormatDuration(d time.Duration) string {
 		return "0s"
 	} else if d%(365*24*time.Hour) == 0 {
 		return fmt.Sprintf("%dy", d/(365*24*time.Hour))
+	} else if d%(30*24*time.Hour) == 0 {
+		return fmt.Sprintf("%dmo", d/(30*24*time.Hour))
 	} else if d%(7*24*time.Hour) == 0 {
 		return fmt.Sprintf("%dw", d/(7*24*time.Hour))
 	} else if d%(24*time.Hour) == 0 {
@@ -130,11 +139,10 @@ func FormatDuration(d time.Duration) string {
 		return fmt.Sprintf("%ds", d/time.Second)
 	} else if d%time.Millisecond == 0 {
 		return fmt.Sprintf("%dms", d/time.Millisecond)
+	} else if d%time.Microsecond == 0 {
+		return fmt.Sprintf("%dus", d/time.Microsecond)
 	}
-	// Although we accept both "u" and "µ" when reading microsecond durations,
-	// we output with "u", which can be represented in 1 byte,
-	// instead of "µ", which requires 2 bytes.
-	return fmt.Sprintf("%du", d/time.Microsecond)
+	return fmt.Sprintf("%dns", d/time.Nanosecond)
 }
 
 // split splits a string into a slice of runes.

--- a/http/duration_test.go
+++ b/http/duration_test.go
@@ -15,19 +15,23 @@ func TestParseDuration(t *testing.T) {
 	}{
 		{s: `10u`, want: 10 * time.Microsecond},
 		{s: `10µ`, want: 10 * time.Microsecond},
+		{s: `10us`, want: 10 * time.Microsecond},
+		{s: `10µs`, want: 10 * time.Microsecond},
 		{s: `15ms`, want: 15 * time.Millisecond},
 		{s: `100s`, want: 100 * time.Second},
 		{s: `2m`, want: 2 * time.Minute},
+		{s: `2mo`, want: 2 * 30 * 24 * time.Hour},
 		{s: `2h`, want: 2 * time.Hour},
 		{s: `2d`, want: 2 * 24 * time.Hour},
 		{s: `2w`, want: 2 * 7 * 24 * time.Hour},
+		{s: `2y`, want: 2 * 365 * 24 * time.Hour},
 		{s: `1h30m`, want: time.Hour + 30*time.Minute},
 		{s: `30ms3000u`, want: 30*time.Millisecond + 3000*time.Microsecond},
 		{s: `-5s`, want: -5 * time.Second},
 		{s: `-5m30s`, want: -5*time.Minute - 30*time.Second},
-
 		{s: ``, wantErr: true},
 		{s: `3`, wantErr: true},
+		{s: `3mm`, wantErr: true},
 		{s: `1000`, wantErr: true},
 		{s: `w`, wantErr: true},
 		{s: `ms`, wantErr: true},
@@ -64,6 +68,7 @@ func TestFormatDuration(t *testing.T) {
 		{d: 2 * time.Hour, want: `2h`},
 		{d: 2 * 24 * time.Hour, want: `2d`},
 		{d: 2 * 7 * 24 * time.Hour, want: `2w`},
+		{d: 2 * 365 * 24 * time.Hour, want: `2y`},
 	}
 
 	for i, tt := range tests {

--- a/http/duration_test.go
+++ b/http/duration_test.go
@@ -13,6 +13,8 @@ func TestParseDuration(t *testing.T) {
 		want    time.Duration
 		wantErr bool
 	}{
+		{s: `10n`, want: 10 * time.Nanosecond},
+		{s: `10ns`, want: 10 * time.Nanosecond},
 		{s: `10u`, want: 10 * time.Microsecond},
 		{s: `10µ`, want: 10 * time.Microsecond},
 		{s: `10us`, want: 10 * time.Microsecond},
@@ -32,6 +34,7 @@ func TestParseDuration(t *testing.T) {
 		{s: ``, wantErr: true},
 		{s: `3`, wantErr: true},
 		{s: `3mm`, wantErr: true},
+		{s: `3nm`, wantErr: true},
 		{s: `1000`, wantErr: true},
 		{s: `w`, wantErr: true},
 		{s: `ms`, wantErr: true},
@@ -60,14 +63,16 @@ func TestFormatDuration(t *testing.T) {
 		d    time.Duration
 		want string
 	}{
-		{d: 3 * time.Microsecond, want: `3u`},
-		{d: 1001 * time.Microsecond, want: `1001u`},
+		{d: 3 * time.Nanosecond, want: `3ns`},
+		{d: 3 * time.Microsecond, want: `3us`},
+		{d: 1001 * time.Microsecond, want: `1001us`},
 		{d: 15 * time.Millisecond, want: `15ms`},
 		{d: 100 * time.Second, want: `100s`},
 		{d: 2 * time.Minute, want: `2m`},
 		{d: 2 * time.Hour, want: `2h`},
 		{d: 2 * 24 * time.Hour, want: `2d`},
 		{d: 2 * 7 * 24 * time.Hour, want: `2w`},
+		{d: 2 * 30 * 24 * time.Hour, want: `2mo`},
 		{d: 2 * 365 * 24 * time.Hour, want: `2y`},
 	}
 

--- a/http/duration_test.go
+++ b/http/duration_test.go
@@ -1,0 +1,77 @@
+package http
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Ensure a time duration can be parsed.
+func TestParseDuration(t *testing.T) {
+	var tests = []struct {
+		s       string
+		want    time.Duration
+		wantErr bool
+	}{
+		{s: `10u`, want: 10 * time.Microsecond},
+		{s: `10µ`, want: 10 * time.Microsecond},
+		{s: `15ms`, want: 15 * time.Millisecond},
+		{s: `100s`, want: 100 * time.Second},
+		{s: `2m`, want: 2 * time.Minute},
+		{s: `2h`, want: 2 * time.Hour},
+		{s: `2d`, want: 2 * 24 * time.Hour},
+		{s: `2w`, want: 2 * 7 * 24 * time.Hour},
+		{s: `1h30m`, want: time.Hour + 30*time.Minute},
+		{s: `30ms3000u`, want: 30*time.Millisecond + 3000*time.Microsecond},
+		{s: `-5s`, want: -5 * time.Second},
+		{s: `-5m30s`, want: -5*time.Minute - 30*time.Second},
+
+		{s: ``, wantErr: true},
+		{s: `3`, wantErr: true},
+		{s: `1000`, wantErr: true},
+		{s: `w`, wantErr: true},
+		{s: `ms`, wantErr: true},
+		{s: `1.2w`, wantErr: true},
+		{s: `10x`, wantErr: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got, err := ParseDuration(tt.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("ParseDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Ensure a time duration can be formatted.
+func TestFormatDuration(t *testing.T) {
+	var tests = []struct {
+		d    time.Duration
+		want string
+	}{
+		{d: 3 * time.Microsecond, want: `3u`},
+		{d: 1001 * time.Microsecond, want: `1001u`},
+		{d: 15 * time.Millisecond, want: `15ms`},
+		{d: 100 * time.Second, want: `100s`},
+		{d: 2 * time.Minute, want: `2m`},
+		{d: 2 * time.Hour, want: `2h`},
+		{d: 2 * 24 * time.Hour, want: `2d`},
+		{d: 2 * 7 * 24 * time.Hour, want: `2w`},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got := FormatDuration(tt.d)
+			if got != tt.want {
+				t.Errorf("FormatDuration() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Note: I'll create a follow-on PR for changing the external format of the time duration from a string to an object.  I think this set of changes should be reviewed first before I plunge into an entirely different structure.

Closes #796

_Briefly describe your proposed changes:_
Change bucket retention periods from nanoseconds to influxql-style duration strings.

_What was the problem?_
Nanoseconds are difficult to use and a bit unpleasant to view.

_What was the solution?_
retention period is now a string in the influxql duration format.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

/cc @gshif 