### PR TITLE
Add basic authentication service

### DIFF
--- a/bolt/bbolt_test.go
+++ b/bolt/bbolt_test.go
@@ -7,10 +7,12 @@ import (
 	"os"
 
 	"github.com/influxdata/platform/bolt"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func NewTestClient() (*bolt.Client, func(), error) {
 	c := bolt.NewClient()
+	bolt.HashCost = bcrypt.MinCost
 
 	f, err := ioutil.TempFile("", "influxdata-platform-bolt-")
 	if err != nil {

--- a/bolt/user_test.go
+++ b/bolt/user_test.go
@@ -2,6 +2,7 @@ package bolt_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/influxdata/platform"
@@ -14,7 +15,7 @@ func initUserService(f platformtesting.UserFields, t *testing.T) (platform.UserS
 		t.Fatalf("failed to create new bolt client: %v", err)
 	}
 	c.IDGenerator = f.IDGenerator
-	ctx := context.TODO()
+	ctx := context.Background()
 	for _, u := range f.Users {
 		if err := c.PutUser(ctx, u); err != nil {
 			t.Fatalf("failed to populate users")
@@ -52,4 +53,187 @@ func TestUserService_FindUser(t *testing.T) {
 
 func TestUserService_UpdateUser(t *testing.T) {
 	platformtesting.UpdateUser(initUserService, t)
+}
+
+func TestBasicAuth(t *testing.T) {
+	type fields struct {
+		users []*platform.User
+	}
+	type args struct {
+		name            string
+		user            string
+		setPassword     string
+		comparePassword string
+	}
+	type wants struct {
+		setErr     error
+		compareErr error
+	}
+	tests := []struct {
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			fields: fields{
+				users: []*platform.User{
+					{
+						Name: "user1",
+						ID:   platform.ID("0"),
+					},
+				},
+			},
+			args: args{
+				name:            "happy path",
+				user:            "user1",
+				setPassword:     "hello",
+				comparePassword: "hello",
+			},
+			wants: wants{},
+		},
+		{
+			fields: fields{
+				users: []*platform.User{
+					{
+						Name: "user1",
+						ID:   platform.ID("0"),
+					},
+				},
+			},
+			args: args{
+				name:            "happy path dont match",
+				user:            "user1",
+				setPassword:     "hello",
+				comparePassword: "world",
+			},
+			wants: wants{
+				compareErr: fmt.Errorf("crypto/bcrypt: hashedPassword is not the hash of the given password"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.args.name, func(t *testing.T) {
+			c, closeFn, err := NewTestClient()
+			if err != nil {
+				t.Fatalf("failed to create new bolt client: %v", err)
+			}
+			defer closeFn()
+			ctx := context.Background()
+
+			for _, user := range tt.fields.users {
+				if err := c.PutUser(ctx, user); err != nil {
+					t.Fatal(err)
+					return
+				}
+			}
+
+			err = c.SetPassword(ctx, tt.args.user, tt.args.setPassword)
+
+			if (err != nil && tt.wants.setErr == nil) || (err == nil && tt.wants.setErr != nil) {
+				t.Fatalf("expected SetPassword error %v got %v", tt.wants.setErr, err)
+				return
+			}
+
+			if err != nil {
+				if want, got := tt.wants.setErr.Error(), err.Error(); want != got {
+					t.Fatalf("expected SetPassword error %v got %v", want, got)
+				}
+				return
+			}
+
+			err = c.ComparePassword(ctx, tt.args.user, tt.args.comparePassword)
+
+			if (err != nil && tt.wants.compareErr == nil) || (err == nil && tt.wants.compareErr != nil) {
+				t.Fatalf("expected ComparePassword error %v got %v", tt.wants.compareErr, err)
+				return
+			}
+
+			if err != nil {
+				if want, got := tt.wants.compareErr.Error(), err.Error(); want != got {
+					t.Fatalf("expected ComparePassword error %v got %v", tt.wants.compareErr, err)
+				}
+				return
+			}
+
+		})
+	}
+
+}
+
+func TestBasicAuth_CompareAndSet(t *testing.T) {
+	type fields struct {
+		users []*platform.User
+	}
+	type args struct {
+		name string
+		user string
+		old  string
+		new  string
+	}
+	type wants struct {
+		err error
+	}
+	tests := []struct {
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			fields: fields{
+				users: []*platform.User{
+					{
+						Name: "user1",
+						ID:   platform.ID("0"),
+					},
+				},
+			},
+			args: args{
+				name: "happy path",
+				user: "user1",
+				old:  "hello",
+				new:  "hello",
+			},
+			wants: wants{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.args.name, func(t *testing.T) {
+			c, closeFn, err := NewTestClient()
+			if err != nil {
+				t.Fatalf("failed to create new bolt client: %v", err)
+			}
+			defer closeFn()
+			ctx := context.Background()
+
+			for _, user := range tt.fields.users {
+				if err := c.PutUser(ctx, user); err != nil {
+					t.Fatal(err)
+					return
+				}
+			}
+
+			if err := c.SetPassword(ctx, tt.args.user, tt.args.old); err != nil {
+				t.Fatalf("unexpected error %v", err)
+				return
+			}
+
+			err = c.CompareAndSetPassword(ctx, tt.args.user, tt.args.old, tt.args.new)
+
+			if (err != nil && tt.wants.err == nil) || (err == nil && tt.wants.err != nil) {
+				t.Fatalf("expected CompareAndSetPassword error %v got %v", tt.wants.err, err)
+				return
+			}
+
+			if err != nil {
+				if want, got := tt.wants.err.Error(), err.Error(); want != got {
+					t.Fatalf("expected CompareAndSetPassword error %v got %v", tt.wants.err, err)
+				}
+				return
+			}
+
+		})
+	}
+
 }

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/willf/bitset v1.1.9 // indirect
 	github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6 // indirect
 	go.uber.org/zap v1.9.1
-	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb // indirect
+	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
 	golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3
 	golang.org/x/oauth2 v0.0.0-20180521191639-dd5f5d8e78ce
 	golang.org/x/sys v0.0.0-20180920110915-d641721ec2de // indirect

--- a/user.go
+++ b/user.go
@@ -31,6 +31,13 @@ type UserService interface {
 	DeleteUser(ctx context.Context, id ID) error
 }
 
+// BasicAuthService is the service for managing basic auth.
+type BasicAuthService interface {
+	SetPassword(ctx context.Context, name string, password string) error
+	ComparePassword(ctx context.Context, name string, password string) error
+	CompareAndSetPassword(ctx context.Context, name string, old string, new string) error
+}
+
 // UserUpdate represents updates to a user.
 // Only fields which are set are updated.
 type UserUpdate struct {


### PR DESCRIPTION
Closes #856

_Briefly describe your proposed changes:_
This PR introduces a service that can store users passwords securely (with bcrypt). It does implement any authentication or authorization.

  - [x] Rebased/mergeable
  - [x] Tests pass