### PR TITLE
try to restore the test

### DIFF
--- a/mock/nats.go
+++ b/mock/nats.go
@@ -1,0 +1,122 @@
+package mock
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/influxdata/platform/nats"
+)
+
+// NatsServer is the mocked nats server based buffered channel.
+type NatsServer struct {
+	sync.RWMutex
+	queue map[string]chan io.Reader
+}
+
+type natsJob struct {
+	subject string
+	r       io.Reader
+}
+
+// create an empty channel for a subject
+func (s *NatsServer) initSubject(subject string) (chan io.Reader, error) {
+	s.Lock()
+	defer s.Unlock()
+	if _, ok := s.queue[subject]; !ok {
+		s.queue[subject] = make(chan io.Reader)
+	}
+	return s.queue[subject], nil
+}
+
+// NewNats returns a mocked version of publisher, subscriber
+func NewNats() (nats.Publisher, nats.Subscriber) {
+	server := &NatsServer{
+		queue: make(map[string]chan io.Reader),
+	}
+
+	publisher := &NatsPublisher{
+		server: server,
+	}
+
+	subcriber := &NatsSubscriber{
+		server: server,
+	}
+
+	return publisher, subcriber
+}
+
+// NatsPublisher is a mocked nats publisher.
+type NatsPublisher struct {
+	server *NatsServer
+}
+
+// Publish add subject and msg to server.
+func (p *NatsPublisher) Publish(subject string, r io.Reader) error {
+	_, err := p.server.initSubject(subject)
+	p.server.queue[subject] <- r
+	return err
+}
+
+// NatsSubscriber is mocked nats subscriber.
+type NatsSubscriber struct {
+	server *NatsServer
+}
+
+// Subscribe implements nats.Subscriber inteferface.
+func (s *NatsSubscriber) Subscribe(subject, group string, handler nats.Handler) error {
+	ch, err := s.server.initSubject(subject)
+	if err != nil {
+		return err
+	}
+
+	go func(s *NatsSubscriber, subject string, handler nats.Handler) {
+		for {
+			select {
+			case r := <-ch:
+				handler.Process(&natsSubscription{subject: subject},
+					&natsMessage{
+						r: r,
+					})
+			}
+		}
+	}(s, subject, handler)
+	return nil
+}
+
+type natsMessage struct {
+	r     io.Reader
+	read  bool
+	bytes []byte
+}
+
+func (m *natsMessage) Data() []byte {
+	if m.read {
+		return m.bytes
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(m.r)
+	m.bytes = buf.Bytes()
+	m.read = true
+	return m.bytes
+}
+
+func (m *natsMessage) Ack() error {
+	return nil
+}
+
+type natsSubscription struct {
+	subject string
+}
+
+func (s *natsSubscription) Pending() (int64, int64, error) {
+	return 0, 0, nil
+}
+
+func (s *natsSubscription) Delivered() (int64, error) {
+	return 0, nil
+}
+
+func (s *natsSubscription) Close() error {
+	return nil
+}

--- a/mock/nats_test.go
+++ b/mock/nats_test.go
@@ -1,0 +1,62 @@
+package mock
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/influxdata/platform/nats"
+)
+
+// TestNats use the mocked nats publisher and subscriber
+// try to collect 0~total integers
+func TestNats(t *testing.T) {
+	total := 30
+	workers := 3
+	publisher, subscriber := NewNats()
+	subject := "default"
+	h := &fakeNatsHandler{
+		collector: make([]int, 0),
+		totalJobs: make(chan struct{}, total),
+	}
+	for i := 0; i < workers; i++ {
+		subscriber.Subscribe(subject, "", h)
+	}
+
+	for i := 0; i < total; i++ {
+		buf := new(bytes.Buffer)
+		buf.Write([]byte{uint8(i)})
+		go publisher.Publish(subject, buf)
+	}
+
+	// make sure all done
+	for i := 0; i < total; i++ {
+		<-h.totalJobs
+	}
+
+	sort.Slice(h.collector, func(i, j int) bool {
+		return h.collector[i] < h.collector[j]
+	})
+
+	for i := 0; i < total; i++ {
+		if h.collector[i] != i {
+			t.Fatalf("nats mocking got incorrect result, want %d, got %d", i, h.collector[i])
+		}
+	}
+}
+
+type fakeNatsHandler struct {
+	sync.Mutex
+	collector []int
+	totalJobs chan struct{}
+}
+
+func (h *fakeNatsHandler) Process(s nats.Subscription, m nats.Message) {
+	h.Lock()
+	defer h.Unlock()
+	defer m.Ack()
+	i := m.Data()
+	h.collector = append(h.collector, int(i[0]))
+	h.totalJobs <- struct{}{}
+}


### PR DESCRIPTION
Closes #
https://github.com/influxdata/platform/issues/851

Previously, we use real nats server for testing, assuming it will work. This fix will use a mocked Nats Server, which is a simple map of go channels. So we won't rely on nats processing speed.