### PR TITLE
ci(goreleaser): add new go env vars to goreleaser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ bench:
 	$(GO_TEST) -bench=. -run=^$$ ./...
 
 nightly: bin/$(GOOS)/goreleaser all
-	PATH=./bin/$(GOOS):${PATH} goreleaser --snapshot --rm-dist --publish-snapshots
+	GO_TEST=env GO111MODULE=on PATH=./bin/$(GOOS):${PATH} goreleaser --snapshot --rm-dist --publish-snapshots
 
 # Recursively clean all subdirs
 clean: $(SUBDIRS)


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
With go modules the go build system takes a few environment variables.  Goreleaser uses those variables to configure the go build.

_What was the problem?_
`goreleaser` needs the various go environment variables to run properly.

_What was the solution?_
Added the variables and tested it in circle's ssh.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)