### PR TITLE
ci(goreleaser): override goreleaser build flags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,10 @@ builds:
     main: ./cmd/fluxd/
     ldflags: -s -w -X main.commit={{.Commit}}
     binary: fluxd
+    flags:
+      - -tags=assets
+    env:
+      - GO111MODULE=on
   - goos:
     - linux
     - darwin
@@ -38,6 +42,8 @@ builds:
       - goos: windows
         goarch: 386
     main: ./cmd/influx/
+    env:
+      - GO111MODULE=on
     ldflags: -s -w -X main.commit={{.Commit}}
     binary: influx
   - goos:
@@ -58,6 +64,10 @@ builds:
       - goos: windows
         goarch: 386
     main: ./cmd/influxd/
+    flags:
+      - -tags=assets
+    env:
+      - GO111MODULE=on
     ldflags: -s -w -X main.commit={{.Commit}}
     binary: influxd
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ UTILS := \
 # This target sets up the dependencies to correctly build all go commands.
 # Other targets must depend on this target to correctly builds CMDS.
 all: GO_ARGS=-tags 'assets $(GO_TAGS)'
-all: node_modules $(UTILS) subdirs generate $(CMDS)
+all: node_modules $(UTILS) subdirs chronograf/ui generate $(CMDS)
 
 # Target to build subdirs.
 # Each subdirs must support the `all` target.
@@ -134,7 +134,7 @@ bench:
 	$(GO_TEST) -bench=. -run=^$$ ./...
 
 nightly: bin/$(GOOS)/goreleaser all
-	GO_TEST=env GO111MODULE=on PATH=./bin/$(GOOS):${PATH} goreleaser --snapshot --rm-dist --publish-snapshots
+	PATH=./bin/$(GOOS):${PATH} goreleaser --snapshot --rm-dist --publish-snapshots
 
 # Recursively clean all subdirs
 clean: $(SUBDIRS)
@@ -162,4 +162,4 @@ run: chronogiraffe
 
 
 # .PHONY targets represent actions that do not create an actual file.
-.PHONY: all subdirs $(SUBDIRS) run fmt test test-go test-js test-go-race bench clean node_modules vet nightly chronogiraffe
+.PHONY: all subdirs $(SUBDIRS) chronograf/ui run fmt test test-go test-js test-go-race bench clean node_modules vet nightly chronogiraffe

--- a/http/assets.go
+++ b/http/assets.go
@@ -10,9 +10,9 @@ import (
 
 const (
 	// Dir is prefix of the assets in the bindata
-	Dir = "../chronograf/ui/build"
+	Dir = "../ui/build"
 	// Default is the default item to load if 404
-	Default = "../chronograf/ui/build/index.html"
+	Default = "../ui/build/index.html"
 	// DebugDir is the prefix of the assets in development mode
 	DebugDir = "chronograf/ui/build"
 	// DebugDefault is the default item to load if 404


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
To override goreleaser build tags properly, one must pass the flags option in the releaser yaml.

_What was the problem?_
The release binaries did not have the static assets compiled in.

_What was the solution?_
Rather than the makefile passing go modules environment to goreleaser, update goreleaser.yaml to cinclude

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)