### PR TITLE
Add routes that allow the user to exchange basic auth credentials for a session

### DIFF
--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -128,6 +128,11 @@ func (c *Client) initialize(ctx context.Context) error {
 			return err
 		}
 
+		// Always create Session bucket.
+		if err := c.initializeSessions(ctx, tx); err != nil {
+			return err
+		}
+
 		return nil
 	}); err != nil {
 		return err

--- a/bolt/session.go
+++ b/bolt/session.go
@@ -1,0 +1,133 @@
+package bolt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	bolt "github.com/coreos/bbolt"
+	"github.com/influxdata/platform"
+)
+
+var (
+	sessionBucket = []byte("sessionsv1")
+)
+
+var _ platform.SessionService = (*Client)(nil)
+
+func (c *Client) initializeSessions(ctx context.Context, tx *bolt.Tx) error {
+	if _, err := tx.CreateBucketIfNotExists([]byte(sessionBucket)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FindSession retrieves the session found at the provided key.
+func (c *Client) FindSession(ctx context.Context, key string) (*platform.Session, error) {
+	var sess *platform.Session
+	err := c.db.View(func(tx *bolt.Tx) error {
+		s, err := c.findSession(ctx, tx, key)
+		if err != nil {
+			return err
+		}
+
+		sess = s
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sess, sess.Expired()
+}
+
+func (c *Client) findSession(ctx context.Context, tx *bolt.Tx, key string) (*platform.Session, error) {
+	v := tx.Bucket(sessionBucket).Get([]byte(key))
+
+	if len(v) == 0 {
+		return nil, fmt.Errorf("session not found")
+	}
+
+	s := &platform.Session{}
+	if err := json.Unmarshal(v, s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (c *Client) putSession(ctx context.Context, tx *bolt.Tx, key string, s *platform.Session) error {
+	v, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	if err := tx.Bucket(sessionBucket).Put([]byte(key), v); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ExpireSession expires the session at the provided key.
+func (c *Client) ExpireSession(ctx context.Context, key string) error {
+	return c.db.Update(func(tx *bolt.Tx) error {
+		s, err := c.findSession(ctx, tx, key)
+		if err != nil {
+			return err
+		}
+
+		s.ExpiresAt = time.Now()
+
+		return c.putSession(ctx, tx, key, s)
+	})
+}
+
+// CreateSession creates a session for a user with the users maximal privileges.
+func (c *Client) CreateSession(ctx context.Context, user string) (*platform.Session, error) {
+	var sess *platform.Session
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		s, err := c.createSession(ctx, tx, user)
+		if err != nil {
+			return err
+		}
+
+		sess = s
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sess, nil
+}
+
+func (c *Client) createSession(ctx context.Context, tx *bolt.Tx, user string) (*platform.Session, error) {
+	u, err := c.findUserByName(ctx, tx, user)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &platform.Session{}
+	s.ID = c.IDGenerator.ID()
+	k, err := c.TokenGenerator.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.Key = k
+	s.UserID = u.ID
+	s.CreatedAt = time.Now()
+	// TODO(desa): make this configurable
+	s.ExpiresAt = s.CreatedAt.Add(time.Hour)
+	// TODO(desa): not totally sure what to do here. Possibly we should have a maximal privilege permission.
+	s.Permissions = []platform.Permission{}
+
+	if err := c.putSession(ctx, tx, s.Key, s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/bolt/session_test.go
+++ b/bolt/session_test.go
@@ -1,0 +1,41 @@
+package bolt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/platform"
+	platformtesting "github.com/influxdata/platform/testing"
+)
+
+func initSessionService(f platformtesting.SessionFields, t *testing.T) (platform.SessionService, func()) {
+	c, closeFn, err := NewTestClient()
+	if err != nil {
+		t.Fatalf("failed to create new bolt client: %v", err)
+	}
+	c.IDGenerator = f.IDGenerator
+	c.TokenGenerator = f.TokenGenerator
+	ctx := context.Background()
+	for _, u := range f.Users {
+		if err := c.PutUser(ctx, u); err != nil {
+			t.Fatalf("failed to populate users")
+		}
+	}
+	for _, s := range f.Sessions {
+		if err := c.PutSession(ctx, s); err != nil {
+			t.Fatalf("failed to populate sessions")
+		}
+	}
+	return c, func() {
+		defer closeFn()
+		for _, u := range f.Users {
+			if err := c.DeleteUser(ctx, u.ID); err != nil {
+				t.Logf("failed to remove users: %v", err)
+			}
+		}
+	}
+}
+
+func TestSessionService(t *testing.T) {
+	platformtesting.SessionService(initSessionService, t)
+}

--- a/http/session_handler.go
+++ b/http/session_handler.go
@@ -1,0 +1,127 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/influxdata/platform"
+	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
+)
+
+// BasicAuthHandler represents an HTTP API handler for authorizations.
+type BasicAuthHandler struct {
+	*httprouter.Router
+	Logger *zap.Logger
+
+	BasicAuthService platform.BasicAuthService
+	SessionService   platform.SessionService
+}
+
+// NewBasicAuthHandler returns a new instance of BasicAuthHandler.
+func NewBasicAuthHandler() *BasicAuthHandler {
+	h := &BasicAuthHandler{
+		Router: httprouter.New(),
+	}
+
+	h.HandlerFunc("POST", "/signin", h.handleSignin)
+	h.HandlerFunc("POST", "/signout", h.handleSignout)
+	return h
+}
+
+// handleSignin is the HTTP handler for the POST /signin route.
+func (h *BasicAuthHandler) handleSignin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := decodeSigninRequest(ctx, r)
+	if err != nil {
+		h.Logger.Info("failed to decode request", zap.String("handler", "basicAuth"), zap.Error(err))
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	if err := h.BasicAuthService.ComparePassword(ctx, req.Username, req.Password); err != nil {
+		// Don't log here, it should already be handled by the service
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	s, err := h.SessionService.CreateSession(ctx, req.Username)
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	encodeCookieSession(w, s)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type signinRequest struct {
+	Username string
+	Password string
+}
+
+func decodeSigninRequest(ctx context.Context, r *http.Request) (*signinRequest, error) {
+	u, p, ok := r.BasicAuth()
+	if !ok {
+		return nil, fmt.Errorf("invalid basic auth")
+	}
+
+	return &signinRequest{
+		Username: u,
+		Password: p,
+	}, nil
+}
+
+// handleSignout is the HTTP handler for the POST /signout route.
+func (h *BasicAuthHandler) handleSignout(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := decodeSignoutRequest(ctx, r)
+	if err != nil {
+		h.Logger.Info("failed to decode request", zap.String("handler", "basicAuth"), zap.Error(err))
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	if err := h.SessionService.ExpireSession(ctx, req.Key); err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	// TODO(desa): not sure what to do here maybe redirect?
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type signoutRequest struct {
+	Key string
+}
+
+func decodeSignoutRequest(ctx context.Context, r *http.Request) (*signoutRequest, error) {
+	key, err := decodeCookieSession(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return &signoutRequest{
+		Key: key,
+	}, nil
+}
+
+const cookieSessionName = "session"
+
+func encodeCookieSession(w http.ResponseWriter, s *platform.Session) {
+	c := &http.Cookie{
+		Name:  cookieSessionName,
+		Value: s.Key,
+	}
+
+	http.SetCookie(w, c)
+}
+func decodeCookieSession(ctx context.Context, r *http.Request) (string, error) {
+	c, err := r.Cookie(cookieSessionName)
+	if err != nil {
+		return "", err
+	}
+	return c.Value, nil
+}

--- a/http/session_handler.go
+++ b/http/session_handler.go
@@ -10,8 +10,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// BasicAuthHandler represents an HTTP API handler for authorizations.
-type BasicAuthHandler struct {
+// SessionHandler represents an HTTP API handler for authorizations.
+type SessionHandler struct {
 	*httprouter.Router
 	Logger *zap.Logger
 
@@ -19,9 +19,9 @@ type BasicAuthHandler struct {
 	SessionService   platform.SessionService
 }
 
-// NewBasicAuthHandler returns a new instance of BasicAuthHandler.
-func NewBasicAuthHandler() *BasicAuthHandler {
-	h := &BasicAuthHandler{
+// NewSessionHandler returns a new instance of SessionHandler.
+func NewSessionHandler() *SessionHandler {
+	h := &SessionHandler{
 		Router: httprouter.New(),
 	}
 
@@ -31,7 +31,7 @@ func NewBasicAuthHandler() *BasicAuthHandler {
 }
 
 // handleSignin is the HTTP handler for the POST /signin route.
-func (h *BasicAuthHandler) handleSignin(w http.ResponseWriter, r *http.Request) {
+func (h *SessionHandler) handleSignin(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	req, err := decodeSigninRequest(ctx, r)
@@ -75,7 +75,7 @@ func decodeSigninRequest(ctx context.Context, r *http.Request) (*signinRequest, 
 }
 
 // handleSignout is the HTTP handler for the POST /signout route.
-func (h *BasicAuthHandler) handleSignout(w http.ResponseWriter, r *http.Request) {
+func (h *SessionHandler) handleSignout(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	req, err := decodeSignoutRequest(ctx, r)

--- a/http/session_test.go
+++ b/http/session_test.go
@@ -1,0 +1,90 @@
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/influxdata/platform"
+	platformhttp "github.com/influxdata/platform/http"
+	"github.com/influxdata/platform/mock"
+)
+
+func TestBasicAuthHandler_handleSignin(t *testing.T) {
+	type fields struct {
+		BasicAuthService platform.BasicAuthService
+		SessionService   platform.SessionService
+	}
+	type args struct {
+		user     string
+		password string
+	}
+	type wants struct {
+		cookie string
+		err    error
+		code   int
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "successful compare password",
+			fields: fields{
+				SessionService: &mock.SessionService{
+					CreateSessionFn: func(context.Context, string) (*platform.Session, error) {
+						return &platform.Session{
+							ID:        platform.ID("0"),
+							Key:       "abc123xyz",
+							CreatedAt: time.Date(2018, 9, 26, 0, 0, 0, 0, time.UTC),
+							ExpiresAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
+							UserID:    platform.ID("1"),
+						}, nil
+					},
+				},
+				BasicAuthService: &mock.BasicAuthService{
+					ComparePasswordFn: func(context.Context, string, string) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				user:     "user1",
+				password: "supersecret",
+			},
+			wants: wants{
+				cookie: "session=abc123xyz",
+				code:   http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := platformhttp.NewSessionHandler()
+			h.BasicAuthService = tt.fields.BasicAuthService
+			h.SessionService = tt.fields.SessionService
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "http://localhost:9999/signin", nil)
+			r.SetBasicAuth(tt.args.user, tt.args.password)
+			h.ServeHTTP(w, r)
+
+			if got, want := w.Code, tt.wants.code; got != want {
+				t.Errorf("bad status code: got %d want %d", got, want)
+			}
+
+			headers := w.Header()
+			cookie := headers.Get("Set-Cookie")
+			if got, want := cookie, tt.wants.cookie; got != want {
+				t.Errorf("expected session cookie to be set: got %q want %q", got, want)
+			}
+
+		})
+	}
+}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5,6 +5,36 @@ info:
 servers:
   - url: /api/v2
 paths:
+  /signin:
+    servers:
+      - url: /
+    post:
+      summary: Exchange basic auth credentials for session
+      security:
+        - basicAuth: []
+      responses:
+        '204':
+          description: succesfully authenticated
+        default:
+          description: unsuccessful authentication
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /signout:
+    servers:
+      - url: /
+    post:
+      summary: Expire the current session
+      responses:
+        '204':
+          description: session successfully expired
+        default:
+          description: unsuccessful session exipry
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /:
     get:
       summary: Map of all top level routes available

--- a/mock/basic_auth.go
+++ b/mock/basic_auth.go
@@ -1,0 +1,39 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+)
+
+// BasicAuthService is a mock implementation of a retention.BasicAuthService, which
+// also makes it a suitable mock to use wherever an platform.BasicAuthService is required.
+type BasicAuthService struct {
+	SetPasswordFn           func(context.Context, string, string) error
+	ComparePasswordFn       func(context.Context, string, string) error
+	CompareAndSetPasswordFn func(context.Context, string, string, string) error
+}
+
+// NewBasicAuthService returns a mock BasicAuthService where its methods will return
+// zero values.
+func NewBasicAuthService(user, password string) *BasicAuthService {
+	return &BasicAuthService{
+		SetPasswordFn:           func(context.Context, string, string) error { return fmt.Errorf("mock error") },
+		ComparePasswordFn:       func(context.Context, string, string) error { return fmt.Errorf("mock error") },
+		CompareAndSetPasswordFn: func(context.Context, string, string, string) error { return fmt.Errorf("mock error") },
+	}
+}
+
+// SetPassword sets the users current password to be the provided password.
+func (s *BasicAuthService) SetPassword(ctx context.Context, name string, password string) error {
+	return s.SetPasswordFn(ctx, name, password)
+}
+
+// ComparePassword password compares the provided password.
+func (s *BasicAuthService) ComparePassword(ctx context.Context, name string, password string) error {
+	return s.ComparePasswordFn(ctx, name, password)
+}
+
+// CompareAndSetPassword compares the provided password and sets it to the new password.
+func (s *BasicAuthService) CompareAndSetPassword(ctx context.Context, name string, old string, new string) error {
+	return s.CompareAndSetPasswordFn(ctx, name, old, new)
+}

--- a/mock/session_service.go
+++ b/mock/session_service.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/platform"
+)
+
+// SessionService is a mock implementation of a retention.SessionService, which
+// also makes it a suitable mock to use wherever an platform.SessionService is required.
+type SessionService struct {
+	FindSessionFn   func(context.Context, string) (*platform.Session, error)
+	ExpireSessionFn func(context.Context, string) error
+	CreateSessionFn func(context.Context, string) (*platform.Session, error)
+}
+
+// NewSessionService returns a mock SessionService where its methods will return
+// zero values.
+func NewSessionService() *SessionService {
+	return &SessionService{
+		FindSessionFn:   func(context.Context, string) (*platform.Session, error) { return nil, fmt.Errorf("mock session") },
+		CreateSessionFn: func(context.Context, string) (*platform.Session, error) { return nil, fmt.Errorf("mock session") },
+		ExpireSessionFn: func(context.Context, string) error { return fmt.Errorf("mock session") },
+	}
+}
+
+// FindSession returns the session found at the provided key.
+func (s *SessionService) FindSession(ctx context.Context, key string) (*platform.Session, error) {
+	return s.FindSessionFn(ctx, key)
+}
+
+// CreateSession creates a sesion for a user with the users maximal privileges.
+func (s *SessionService) CreateSession(ctx context.Context, user string) (*platform.Session, error) {
+	return s.CreateSessionFn(ctx, user)
+}
+
+// ExpireSession exires the session provided at key.
+func (s *SessionService) ExpireSession(ctx context.Context, key string) error {
+	return s.ExpireSessionFn(ctx, key)
+}

--- a/session.go
+++ b/session.go
@@ -17,6 +17,7 @@ type Session struct {
 	Permissions []Permission `json:"permissions,omitempty"`
 }
 
+// Expired returns an error if the session is expired.
 func (s *Session) Expired() error {
 	if time.Now().After(s.ExpiresAt) {
 		return fmt.Errorf("session has expired")

--- a/session.go
+++ b/session.go
@@ -7,6 +7,7 @@ import (
 
 // Session is a user session.
 type Session struct {
+	// ID is only required for auditing purposes.
 	ID          ID           `json:"id"`
 	Key         string       `json:"key"`
 	CreatedAt   time.Time    `json:"createdAt"`

--- a/session.go
+++ b/session.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -14,6 +15,14 @@ type Session struct {
 	ExpiresAt   time.Time    `json:"expiresAt"`
 	UserID      ID           `json:"userID,omitempty"`
 	Permissions []Permission `json:"permissions,omitempty"`
+}
+
+func (s *Session) Expired() error {
+	if time.Now().After(s.ExpiresAt) {
+		return fmt.Errorf("session has expired")
+	}
+
+	return nil
 }
 
 // SessionService represents a service for managing user sessions.

--- a/session.go
+++ b/session.go
@@ -1,0 +1,23 @@
+package platform
+
+import (
+	"context"
+	"time"
+)
+
+// Session is a user session.
+type Session struct {
+	ID          ID           `json:"id"`
+	Key         string       `json:"key"`
+	CreatedAt   time.Time    `json:"createdAt"`
+	ExpiresAt   time.Time    `json:"expiresAt"`
+	UserID      ID           `json:"userID,omitempty"`
+	Permissions []Permission `json:"permissions,omitempty"`
+}
+
+// SessionService represents a service for managing user sessions.
+type SessionService interface {
+	FindSession(ctx context.Context, key string) (*Session, error)
+	ExpireSession(ctx context.Context, key string) error
+	CreateSession(ctx context.Context, user string) (*Session, error)
+}

--- a/testing/session.go
+++ b/testing/session.go
@@ -1,0 +1,286 @@
+package testing
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/mock"
+)
+
+const (
+	sessionOneID   = "020f755c3c082000"
+	sessionTwoID   = "020f755c3c082001"
+	sessionThreeID = "020f755c3c082002"
+)
+
+var sessionCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*platform.Session) []*platform.Session {
+		out := append([]*platform.Session(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+	cmpopts.IgnoreFields(platform.Session{}, "CreatedAt", "ExpiresAt"),
+	cmpopts.EquateEmpty(),
+}
+
+// SessionFields will include the IDGenerator, TokenGenerator, Sessions, and Users
+type SessionFields struct {
+	IDGenerator    platform.IDGenerator
+	TokenGenerator platform.TokenGenerator
+	Sessions       []*platform.Session
+	Users          []*platform.User
+}
+
+// SessionService tests all the service functions.
+func SessionService(
+	init func(SessionFields, *testing.T) (platform.SessionService, func()), t *testing.T,
+) {
+	tests := []struct {
+		name string
+		fn   func(init func(SessionFields, *testing.T) (platform.SessionService, func()),
+			t *testing.T)
+	}{
+		{
+			name: "CreateSession",
+			fn:   CreateSession,
+		},
+		{
+			name: "FindSession",
+			fn:   FindSession,
+		},
+		{
+			name: "ExpireSession",
+			fn:   ExpireSession,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fn(init, t)
+		})
+	}
+}
+
+// CreateSession testing
+func CreateSession(
+	init func(SessionFields, *testing.T) (platform.SessionService, func()),
+	t *testing.T,
+) {
+	type args struct {
+		user string
+	}
+	type wants struct {
+		err     error
+		session *platform.Session
+	}
+
+	tests := []struct {
+		name   string
+		fields SessionFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "create sessions with empty set",
+			fields: SessionFields{
+				IDGenerator:    mock.NewIDGenerator(sessionTwoID, t),
+				TokenGenerator: mock.NewTokenGenerator("abc123xyz", nil),
+				Users: []*platform.User{
+					{
+						ID:   idFromString(t, sessionOneID),
+						Name: "user1",
+					},
+				},
+			},
+			args: args{
+				user: "user1",
+			},
+			wants: wants{
+				session: &platform.Session{
+					ID:     idFromString(t, sessionTwoID),
+					UserID: idFromString(t, sessionOneID),
+					Key:    "abc123xyz",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+			session, err := s.CreateSession(ctx, tt.args.user)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error messages to match '%v' got '%v'", tt.wants.err, err.Error())
+				}
+			}
+
+			if diff := cmp.Diff(session, tt.wants.session, sessionCmpOptions...); diff != "" {
+				t.Errorf("sessions are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// FindSession testing
+func FindSession(
+	init func(SessionFields, *testing.T) (platform.SessionService, func()),
+	t *testing.T,
+) {
+	type args struct {
+		key string
+	}
+	type wants struct {
+		err     error
+		session *platform.Session
+	}
+
+	tests := []struct {
+		name   string
+		fields SessionFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "basic find session",
+			fields: SessionFields{
+				IDGenerator:    mock.NewIDGenerator(sessionTwoID, t),
+				TokenGenerator: mock.NewTokenGenerator("abc123xyz", nil),
+				Sessions: []*platform.Session{
+					{
+						ID:        idFromString(t, sessionOneID),
+						UserID:    idFromString(t, sessionTwoID),
+						Key:       "abc123xyz",
+						ExpiresAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: "abc123xyz",
+			},
+			wants: wants{
+				session: &platform.Session{
+					ID:        idFromString(t, sessionOneID),
+					UserID:    idFromString(t, sessionTwoID),
+					Key:       "abc123xyz",
+					ExpiresAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+
+			session, err := s.FindSession(ctx, tt.args.key)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected errors to be equal '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+				}
+			}
+
+			if diff := cmp.Diff(session, tt.wants.session, sessionCmpOptions...); diff != "" {
+				t.Errorf("session is different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// ExpireSession testing
+func ExpireSession(
+	init func(SessionFields, *testing.T) (platform.SessionService, func()),
+	t *testing.T,
+) {
+	type args struct {
+		key string
+	}
+	type wants struct {
+		err     error
+		session *platform.Session
+	}
+
+	tests := []struct {
+		name   string
+		fields SessionFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "basic find session",
+			fields: SessionFields{
+				IDGenerator:    mock.NewIDGenerator(sessionTwoID, t),
+				TokenGenerator: mock.NewTokenGenerator("abc123xyz", nil),
+				Sessions: []*platform.Session{
+					{
+						ID:        idFromString(t, sessionOneID),
+						UserID:    idFromString(t, sessionTwoID),
+						Key:       "abc123xyz",
+						ExpiresAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: "abc123xyz",
+			},
+			wants: wants{
+				session: &platform.Session{
+					ID:        idFromString(t, sessionOneID),
+					UserID:    idFromString(t, sessionTwoID),
+					Key:       "abc123xyz",
+					ExpiresAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+
+			err := s.ExpireSession(ctx, tt.args.key)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected errors to be equal '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+				}
+			}
+
+			session, err := s.FindSession(ctx, tt.args.key)
+			if err == nil {
+				t.Errorf("expected session to be expired got %v", err)
+			}
+
+			if diff := cmp.Diff(session, tt.wants.session, sessionCmpOptions...); diff != "" {
+				t.Errorf("session is different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #890

_Briefly describe your proposed changes:_
This PR adds a session service that is intended to be used after a user has authenticated. A session should represent a users maximal privileges, although this has yet to be fully worked out. It contains an ID so that it will be auditable.

This PR adds `/signin` and `/signout` routes that allow the user to exchange basic auth credentials for a session.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)