### PR TITLE
Convert everything to /api/v2 on the FE

### DIFF
--- a/chronograf/ui/src/dashboards/apis/v2/index.ts
+++ b/chronograf/ui/src/dashboards/apis/v2/index.ts
@@ -27,7 +27,7 @@ export const getDashboards = async (url: string): Promise<Dashboard[]> => {
 export const getDashboard = async (id: string): Promise<Dashboard> => {
   try {
     const {data} = await AJAX({
-      url: `/v2/dashboards/${id}`,
+      url: `/api/v2/dashboards/${id}`,
     })
 
     return data

--- a/chronograf/ui/src/shared/apis/links.ts
+++ b/chronograf/ui/src/shared/apis/links.ts
@@ -1,7 +1,7 @@
 import {getAJAX} from 'src/utils/ajax'
 import {Links} from 'src/types/v2/links'
 
-const linksURI = '/v2'
+const linksURI = '/api/v2'
 
 export const getLinks = async (): Promise<Links> => {
   try {

--- a/chronograf/ui/src/sources/apis/v2/index.ts
+++ b/chronograf/ui/src/sources/apis/v2/index.ts
@@ -4,7 +4,7 @@ import {Source} from 'src/types/v2'
 export const getSources = async (): Promise<Source[]> => {
   try {
     const {data} = await AJAX({
-      url: '/v2/sources',
+      url: '/api/v2/sources',
     })
 
     return data.sources


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
_What was the problem?_
API routes were changed to `/api/v2` from `/v2`
_What was the solution?_
Make changes on the FE to get links and sources from `api/v2` instead of `/v2`

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)