### PR TITLE
Add authentication middleware

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -2,7 +2,6 @@ package platform
 
 import (
 	"context"
-	"fmt"
 )
 
 // Authorization is a authorization. 🎉
@@ -15,24 +14,19 @@ type Authorization struct {
 	Permissions []Permission `json:"permissions,omitempty"`
 }
 
-// Allowed returns true if the authorization is active and requested permission level
+// Allowed returns true if the authorization is active and request permission
 // exists in the authorization's list of permissions.
-func Allowed(req Permission, auth *Authorization) bool {
-	if !IsActive(auth) {
+func (a *Authorization) Allowed(p Permission) bool {
+	if !a.IsActive() {
 		return false
 	}
 
-	for _, p := range auth.Permissions {
-		if p.Action == req.Action && p.Resource == req.Resource {
-			return true
-		}
-	}
-	return false
+	return allowed(p, a.Permissions)
 }
 
 // IsActive returns true if the authorization active.
-func IsActive(auth *Authorization) bool {
-	return auth.Status == Active
+func (a *Authorization) IsActive() bool {
+	return a.Status == Active
 }
 
 // AuthorizationService represents a service for managing authorization data.
@@ -65,75 +59,4 @@ type AuthorizationFilter struct {
 
 	UserID *ID
 	User   *string
-}
-
-type action string
-
-const (
-	// ReadAction is the action for reading.
-	ReadAction action = "read"
-	// WriteAction is the action for writing.
-	WriteAction action = "write"
-	// CreateAction is the action for creating new resources.
-	CreateAction action = "create"
-	// DeleteAction is the action for deleting an existing resource.
-	DeleteAction action = "delete"
-)
-
-type resource string
-
-const (
-	// UserResource represents the user resource actions can apply to.
-	UserResource = resource("user")
-	// OrganizationResource represents the org resource actions can apply to.
-	OrganizationResource = resource("org")
-)
-
-// TaskResource represents the task resource scoped to an organization.
-func TaskResource(orgID ID) resource {
-	return resource(fmt.Sprintf("org/%s/task", orgID))
-}
-
-// BucketResource constructs a bucket resource.
-func BucketResource(id ID) resource {
-	return resource(fmt.Sprintf("bucket/%s", id))
-}
-
-// Permission defines an action and a resource.
-type Permission struct {
-	Action   action   `json:"action"`
-	Resource resource `json:"resource"`
-}
-
-func (p Permission) String() string {
-	return fmt.Sprintf("%s:%s", p.Action, p.Resource)
-}
-
-var (
-	// CreateUserPermission is a permission for creating users.
-	CreateUserPermission = Permission{
-		Action:   CreateAction,
-		Resource: UserResource,
-	}
-	// DeleteUserPermission is a permission for deleting users.
-	DeleteUserPermission = Permission{
-		Action:   DeleteAction,
-		Resource: UserResource,
-	}
-)
-
-// ReadBucketPermission constructs a permission for reading a bucket.
-func ReadBucketPermission(id ID) Permission {
-	return Permission{
-		Action:   ReadAction,
-		Resource: BucketResource(id),
-	}
-}
-
-// WriteBucketPermission constructs a permission for writing to a bucket.
-func WriteBucketPermission(id ID) Permission {
-	return Permission{
-		Action:   WriteAction,
-		Resource: BucketResource(id),
-	}
 }

--- a/auth.go
+++ b/auth.go
@@ -24,6 +24,11 @@ func (a *Authorization) Allowed(p Permission) bool {
 	return allowed(p, a.Permissions)
 }
 
+// IsActive is a stub for idpe.
+func IsActive(a *Authorization) bool {
+	return a.IsActive()
+}
+
 // IsActive returns true if the authorization active.
 func (a *Authorization) IsActive() bool {
 	return a.Status == Active

--- a/auth.go
+++ b/auth.go
@@ -32,7 +32,7 @@ func (a *Authorization) IsActive() bool {
 // Kind returns session and is used for auditing.
 func (a *Authorization) Kind() string { return "authorization" }
 
-// ID returns the authorizations ID and is used for auditing.
+// Identifier returns the authorizations ID and is used for auditing.
 func (a *Authorization) Identifier() ID { return a.ID }
 
 // AuthorizationService represents a service for managing authorization data.

--- a/auth.go
+++ b/auth.go
@@ -29,6 +29,12 @@ func (a *Authorization) IsActive() bool {
 	return a.Status == Active
 }
 
+// Kind returns session and is used for auditing.
+func (a *Authorization) Kind() string { return "authorization" }
+
+// ID returns the authorizations ID and is used for auditing.
+func (a *Authorization) Identifier() ID { return a.ID }
+
 // AuthorizationService represents a service for managing authorization data.
 type AuthorizationService interface {
 	// Returns a single authorization by ID.

--- a/authz.go
+++ b/authz.go
@@ -1,0 +1,88 @@
+package platform
+
+import "fmt"
+
+// Authorizer will authorize a permission.
+type Authorizer interface {
+	Allowed(p Permission) bool
+}
+
+func allowed(p Permission, ps []Permission) bool {
+	for _, perm := range ps {
+		if perm.Action == p.Action && perm.Resource == p.Resource {
+			return true
+		}
+	}
+	return false
+}
+
+type action string
+
+const (
+	// ReadAction is the action for reading.
+	ReadAction action = "read"
+	// WriteAction is the action for writing.
+	WriteAction action = "write"
+	// CreateAction is the action for creating new resources.
+	CreateAction action = "create"
+	// DeleteAction is the action for deleting an existing resource.
+	DeleteAction action = "delete"
+)
+
+type resource string
+
+const (
+	// UserResource represents the user resource actions can apply to.
+	UserResource = resource("user")
+	// OrganizationResource represents the org resource actions can apply to.
+	OrganizationResource = resource("org")
+)
+
+// TaskResource represents the task resource scoped to an organization.
+func TaskResource(orgID ID) resource {
+	return resource(fmt.Sprintf("org/%s/task", orgID))
+}
+
+// BucketResource constructs a bucket resource.
+func BucketResource(id ID) resource {
+	return resource(fmt.Sprintf("bucket/%s", id))
+}
+
+// Permission defines an action and a resource.
+type Permission struct {
+	Action   action   `json:"action"`
+	Resource resource `json:"resource"`
+}
+
+func (p Permission) String() string {
+	return fmt.Sprintf("%s:%s", p.Action, p.Resource)
+}
+
+var (
+	// CreateUserPermission is a permission for creating users.
+	CreateUserPermission = Permission{
+		Action:   CreateAction,
+		Resource: UserResource,
+	}
+	// DeleteUserPermission is a permission for deleting users.
+	DeleteUserPermission = Permission{
+		Action:   DeleteAction,
+		Resource: UserResource,
+	}
+)
+
+// ReadBucketPermission constructs a permission for reading a bucket.
+func ReadBucketPermission(id ID) Permission {
+	return Permission{
+		Action:   ReadAction,
+		Resource: BucketResource(id),
+	}
+}
+
+// WriteBucketPermission constructs a permission for writing to a bucket.
+func WriteBucketPermission(id ID) Permission {
+	return Permission{
+		Action:   WriteAction,
+		Resource: BucketResource(id),
+	}
+}

--- a/authz.go
+++ b/authz.go
@@ -4,7 +4,14 @@ import "fmt"
 
 // Authorizer will authorize a permission.
 type Authorizer interface {
+	// Allowed returns true is the associated permission is allowed by the authorizer
 	Allowed(p Permission) bool
+
+	// ID returns an identifier used for auditing.
+	Identifier() ID
+
+	// Kind metadata for auditing.
+	Kind() string
 }
 
 func allowed(p Permission, ps []Permission) bool {

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -189,6 +189,16 @@ func platformF(cmd *cobra.Command, args []string) {
 		macroSvc = c
 	}
 
+	var basicAuthSvc platform.BasicAuthService
+	{
+		basicAuthSvc = c
+	}
+
+	var sessionSvc platform.SessionService
+	{
+		sessionSvc = c
+	}
+
 	var onboardingSvc platform.OnboardingService = c
 
 	var queryService query.QueryService
@@ -278,6 +288,10 @@ func platformF(cmd *cobra.Command, args []string) {
 
 	// HTTP server
 	go func() {
+		sessionHandler := http.NewSessionHandler()
+		sessionHandler.BasicAuthService = basicAuthSvc
+		sessionHandler.SessionService = sessionSvc
+
 		bucketHandler := http.NewBucketHandler()
 		bucketHandler.BucketService = bucketSvc
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -35,7 +35,6 @@ import (
 	taskbolt "github.com/influxdata/platform/task/backend/bolt"
 	"github.com/influxdata/platform/task/backend/coordinator"
 	taskexecutor "github.com/influxdata/platform/task/backend/executor"
-	pzap "github.com/influxdata/platform/zap"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -174,9 +173,9 @@ func platformF(cmd *cobra.Command, args []string) {
 		dashboardSvc = c
 	}
 
-	var cellSvc platform.ViewService
+	var viewSvc platform.ViewService
 	{
-		cellSvc = c
+		viewSvc = c
 	}
 
 	var sourceSvc platform.SourceService
@@ -286,87 +285,34 @@ func platformF(cmd *cobra.Command, args []string) {
 		Addr: httpBindAddress,
 	}
 
+	handlerConfig := &http.APIBackend{
+		Logger:           logger,
+		NewBucketService: source.NewBucketService,
+		NewQueryService:  source.NewQueryService,
+		PublisherFn: func(r io.Reader) error {
+			return publisher.Publish(IngressSubject, r)
+		},
+		AuthorizationService:       authSvc,
+		BucketService:              bucketSvc,
+		SessionService:             sessionSvc,
+		UserService:                userSvc,
+		OrganizationService:        orgSvc,
+		UserResourceMappingService: userResourceSvc,
+		DashboardService:           dashboardSvc,
+		ViewService:                viewSvc,
+		SourceService:              sourceSvc,
+		MacroService:               macroSvc,
+		BasicAuthService:           basicAuthSvc,
+		OnboardingService:          onboardingSvc,
+		QueryService:               queryService,
+		TaskService:                taskSvc,
+		ScraperTargetStoreService:  scraperTargetSvc,
+		ChronografService:          chronografSvc,
+	}
+
 	// HTTP server
 	go func() {
-		sessionHandler := http.NewSessionHandler()
-		sessionHandler.BasicAuthService = basicAuthSvc
-		sessionHandler.SessionService = sessionSvc
-
-		bucketHandler := http.NewBucketHandler()
-		bucketHandler.BucketService = bucketSvc
-
-		orgHandler := http.NewOrgHandler()
-		orgHandler.OrganizationService = orgSvc
-		orgHandler.BucketService = bucketSvc
-		orgHandler.UserResourceMappingService = userResourceSvc
-
-		userHandler := http.NewUserHandler()
-		userHandler.UserService = userSvc
-
-		dashboardHandler := http.NewDashboardHandler()
-		dashboardHandler.DashboardService = dashboardSvc
-
-		cellHandler := http.NewViewHandler()
-		cellHandler.ViewService = cellSvc
-
-		macroHandler := http.NewMacroHandler()
-		macroHandler.MacroService = macroSvc
-
-		authHandler := http.NewAuthorizationHandler()
-		authHandler.AuthorizationService = authSvc
-		authHandler.Logger = logger.With(zap.String("handler", "auth"))
-
-		assetHandler := http.NewAssetHandler()
-		assetHandler.Develop = developerMode
-		fluxLangHandler := http.NewFluxLangHandler()
-
-		sourceHandler := http.NewSourceHandler()
-		sourceHandler.SourceService = sourceSvc
-		sourceHandler.NewBucketService = source.NewBucketService
-		sourceHandler.NewQueryService = source.NewQueryService
-
-		setupHandler := http.NewSetupHandler()
-		setupHandler.OnboardingService = onboardingSvc
-
-		taskHandler := http.NewTaskHandler(logger)
-		taskHandler.TaskService = taskSvc
-
-		publishFn := func(r io.Reader) error {
-			return publisher.Publish(IngressSubject, r)
-		}
-
-		writeHandler := http.NewWriteHandler(publishFn)
-		writeHandler.AuthorizationService = authSvc
-		writeHandler.OrganizationService = orgSvc
-		writeHandler.BucketService = bucketSvc
-		writeHandler.Logger = logger.With(zap.String("handler", "write"))
-
-		queryHandler := http.NewFluxHandler()
-		queryHandler.AuthorizationService = authSvc
-		queryHandler.OrganizationService = orgSvc
-		queryHandler.Logger = logger.With(zap.String("handler", "query"))
-		queryHandler.ProxyQueryService = pzap.NewProxyQueryService(queryHandler.Logger)
-
-		// TODO(desa): what to do about idpe.
-		chronografHandler := http.NewChronografHandler(chronografSvc)
-
-		platformHandler := &http.PlatformHandler{
-			BucketHandler:        bucketHandler,
-			OrgHandler:           orgHandler,
-			UserHandler:          userHandler,
-			AuthorizationHandler: authHandler,
-			DashboardHandler:     dashboardHandler,
-			AssetHandler:         assetHandler,
-			FluxLangHandler:      fluxLangHandler,
-			ChronografHandler:    chronografHandler,
-			SourceHandler:        sourceHandler,
-			TaskHandler:          taskHandler,
-			ViewHandler:          cellHandler,
-			MacroHandler:         macroHandler,
-			QueryHandler:         queryHandler,
-			WriteHandler:         writeHandler,
-			SetupHandler:         setupHandler,
-		}
+		platformHandler := http.NewPlatformHandler(handlerConfig)
 		reg.MustRegister(platformHandler.PrometheusCollectors()...)
 
 		h := http.NewHandlerFromRegistry("platform", reg)

--- a/context/token.go
+++ b/context/token.go
@@ -10,8 +10,9 @@ import (
 type contextKey string
 
 const (
-	authorizerCtxKey = contextKey("influx/authorizer/v1")
-	tokenCtxKey      = contextKey("influx/token/v1")
+	authorizationCtxKey = contextKey("influx/authorization/v1")
+	authorizerCtxKey    = contextKey("influx/authorizer/v1")
+	tokenCtxKey         = contextKey("influx/token/v1")
 )
 
 // SetAuthorizer sets an authorizer on context.
@@ -42,4 +43,19 @@ func GetToken(ctx context.Context) (string, error) {
 	}
 
 	return t, nil
+}
+
+// SetAuthorization sets an authorization on context.
+func SetAuthorization(ctx context.Context, a *platform.Authorization) context.Context {
+	return context.WithValue(ctx, authorizationCtxKey, a)
+}
+
+// GetAuthorization retrieves an authorization from context.
+func GetAuthorization(ctx context.Context) (*platform.Authorization, error) {
+	a, ok := ctx.Value(authorizationCtxKey).(*platform.Authorization)
+	if !ok {
+		return nil, errors.InternalErrorf("authorization not found on context")
+	}
+
+	return a, nil
 }

--- a/context/token.go
+++ b/context/token.go
@@ -10,31 +10,31 @@ import (
 type contextKey string
 
 const (
-	authorizationCtxKey = contextKey("influx/authorization/v1")
-	tokenCtxKey         = contextKey("influx/token/v1")
+	authorizerCtxKey = contextKey("influx/authorizer/v1")
+	tokenCtxKey      = contextKey("influx/token/v1")
 )
 
-// SetAuthorization sets an authorization on context.
-func SetAuthorization(ctx context.Context, a *platform.Authorization) context.Context {
-	return context.WithValue(ctx, authorizationCtxKey, a)
+// SetAuthorizer sets an authorizer on context.
+func SetAuthorizer(ctx context.Context, a platform.Authorizer) context.Context {
+	return context.WithValue(ctx, authorizerCtxKey, a)
 }
 
-// GetAuthorization retrieves an authorization from context.
-func GetAuthorization(ctx context.Context) (*platform.Authorization, error) {
-	a, ok := ctx.Value(authorizationCtxKey).(*platform.Authorization)
+// GetAuthorizer retrieves an authorizer from context.
+func GetAuthorizer(ctx context.Context) (platform.Authorizer, error) {
+	a, ok := ctx.Value(authorizerCtxKey).(platform.Authorizer)
 	if !ok {
-		return nil, errors.InternalErrorf("authorization not found on context")
+		return nil, errors.InternalErrorf("authorizer not found on context")
 	}
 
 	return a, nil
 }
 
-// SetToken sets an authorization on context.
+// SetToken sets an token on context.
 func SetToken(ctx context.Context, t string) context.Context {
 	return context.WithValue(ctx, tokenCtxKey, t)
 }
 
-// GeToken retrieves an authorization from context.
+// GeToken retrieves an token from context.
 func GetToken(ctx context.Context) (string, error) {
 	t, ok := ctx.Value(tokenCtxKey).(string)
 	if !ok {

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -1,0 +1,249 @@
+package http
+
+import (
+	"io"
+	http "net/http"
+	"strings"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/chronograf/server"
+	"github.com/influxdata/platform/query"
+	pzap "github.com/influxdata/platform/zap"
+	"go.uber.org/zap"
+)
+
+// APIHandler is a collection of all the service handlers.
+type APIHandler struct {
+	BucketHandler        *BucketHandler
+	UserHandler          *UserHandler
+	OrgHandler           *OrgHandler
+	AuthorizationHandler *AuthorizationHandler
+	DashboardHandler     *DashboardHandler
+	AssetHandler         *AssetHandler
+	ChronografHandler    *ChronografHandler
+	ViewHandler          *ViewHandler
+	SourceHandler        *SourceHandler
+	MacroHandler         *MacroHandler
+	TaskHandler          *TaskHandler
+	FluxLangHandler      *FluxLangHandler
+	QueryHandler         *FluxHandler
+	WriteHandler         *WriteHandler
+	SetupHandler         *SetupHandler
+	SessionHandler       *SessionHandler
+}
+
+// APIBackend is all services and associated parameters required to construct
+// an APIHandler.
+type APIBackend struct {
+	Logger *zap.Logger
+
+	NewBucketService func(*platform.Source) (platform.BucketService, error)
+	NewQueryService  func(*platform.Source) (query.ProxyQueryService, error)
+
+	PublisherFn func(r io.Reader) error
+
+	AuthorizationService       platform.AuthorizationService
+	BucketService              platform.BucketService
+	SessionService             platform.SessionService
+	UserService                platform.UserService
+	OrganizationService        platform.OrganizationService
+	UserResourceMappingService platform.UserResourceMappingService
+	DashboardService           platform.DashboardService
+	ViewService                platform.ViewService
+	SourceService              platform.SourceService
+	MacroService               platform.MacroService
+	BasicAuthService           platform.BasicAuthService
+	OnboardingService          platform.OnboardingService
+	QueryService               query.QueryService
+	TaskService                platform.TaskService
+	ScraperTargetStoreService  platform.ScraperTargetStoreService
+	ChronografService          *server.Service
+}
+
+// NewAPIHandler constructs all api handlers beneath it and returns an APIHandler
+func NewAPIHandler(b *APIBackend) *APIHandler {
+	h := &APIHandler{}
+	h.SessionHandler = NewSessionHandler()
+	h.SessionHandler.BasicAuthService = b.BasicAuthService
+	h.SessionHandler.SessionService = b.SessionService
+
+	h.BucketHandler = NewBucketHandler()
+	h.BucketHandler.BucketService = b.BucketService
+
+	h.OrgHandler = NewOrgHandler()
+	h.OrgHandler.OrganizationService = b.OrganizationService
+	h.OrgHandler.BucketService = b.BucketService
+	h.OrgHandler.UserResourceMappingService = b.UserResourceMappingService
+
+	h.UserHandler = NewUserHandler()
+	h.UserHandler.UserService = b.UserService
+
+	h.DashboardHandler = NewDashboardHandler()
+	h.DashboardHandler.DashboardService = b.DashboardService
+
+	h.ViewHandler = NewViewHandler()
+	h.ViewHandler.ViewService = b.ViewService
+
+	h.MacroHandler = NewMacroHandler()
+	h.MacroHandler.MacroService = b.MacroService
+
+	h.AuthorizationHandler = NewAuthorizationHandler()
+	h.AuthorizationHandler.AuthorizationService = b.AuthorizationService
+	h.AuthorizationHandler.Logger = b.Logger.With(zap.String("handler", "auth"))
+
+	h.FluxLangHandler = NewFluxLangHandler()
+
+	h.SourceHandler = NewSourceHandler()
+	h.SourceHandler.SourceService = b.SourceService
+	h.SourceHandler.NewBucketService = b.NewBucketService
+	h.SourceHandler.NewQueryService = b.NewQueryService
+
+	h.SetupHandler = NewSetupHandler()
+	h.SetupHandler.OnboardingService = b.OnboardingService
+
+	h.TaskHandler = NewTaskHandler(b.Logger)
+	h.TaskHandler.TaskService = b.TaskService
+
+	h.WriteHandler = NewWriteHandler(b.PublisherFn)
+	h.WriteHandler.AuthorizationService = b.AuthorizationService
+	h.WriteHandler.OrganizationService = b.OrganizationService
+	h.WriteHandler.BucketService = b.BucketService
+	h.WriteHandler.Logger = b.Logger.With(zap.String("handler", "write"))
+
+	h.QueryHandler = NewFluxHandler()
+	h.QueryHandler.AuthorizationService = b.AuthorizationService
+	h.QueryHandler.OrganizationService = b.OrganizationService
+	h.QueryHandler.Logger = b.Logger.With(zap.String("handler", "query"))
+	h.QueryHandler.ProxyQueryService = pzap.NewProxyQueryService(h.QueryHandler.Logger)
+
+	h.ChronografHandler = NewChronografHandler(b.ChronografService)
+
+	return h
+}
+
+var apiLinks = map[string]interface{}{
+	"signin":     "/api/v2/signin",
+	"signout":    "/api/v2/singout",
+	"setup":      "/api/v2/setup",
+	"sources":    "/api/v2/sources",
+	"dashboards": "/api/v2/dashboards",
+	"query":      "/api/v2/query",
+	"write":      "/api/v2/write",
+	"orgs":       "/api/v2/orgs",
+	"auths":      "/api/v2/authorizations",
+	"buckets":    "/api/v2/buckets",
+	"users":      "/api/v2/users",
+	"tasks":      "/api/v2/tasks",
+	"flux": map[string]string{
+		"self":        "/api/v2/flux",
+		"ast":         "/api/v2/flux/ast",
+		"suggestions": "/api/v2/flux/suggestions",
+	},
+	"external": map[string]string{
+		"statusFeed": "https://www.influxdata.com/feed/json",
+	},
+	"system": map[string]string{
+		"metrics": "/metrics",
+		"debug":   "/debug/pprof",
+		"health":  "/healthz",
+	},
+}
+
+func (h *APIHandler) serveLinks(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if err := encodeResponse(ctx, w, http.StatusOK, apiLinks); err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+}
+
+// ServeHTTP delegates a request to the appropriate subhandler.
+func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	setCORSResponseHeaders(w, r)
+	if r.Method == "OPTIONS" {
+		return
+	}
+
+	// Serve the links base links for the API.
+	if r.URL.Path == "/api/v2/" || r.URL.Path == "/api/v2" {
+		h.serveLinks(w, r)
+		return
+	}
+
+	if r.URL.Path == "/api/v2/signin" || r.URL.Path == "/api/v2/signout" {
+		h.SessionHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/setup") {
+		h.SetupHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/write") {
+		h.WriteHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/query") {
+		h.QueryHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/buckets") {
+		h.BucketHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/users") {
+		h.UserHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/orgs") {
+		h.OrgHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/authorizations") {
+		h.AuthorizationHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/dashboards") {
+		h.DashboardHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/sources") {
+		h.SourceHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/tasks") {
+		h.TaskHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/views") {
+		h.ViewHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/macros") {
+		h.MacroHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/flux") {
+		h.FluxLangHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/chronograf/") {
+		h.ChronografHandler.ServeHTTP(w, r)
+		return
+	}
+
+	http.NotFound(w, r)
+}

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/influxdata/platform"
+	platcontext "github.com/influxdata/platform/context"
+	"go.uber.org/zap"
+)
+
+// AuthenticationHandler is a middleware for authenticating incoming requests.
+type AuthenticationHandler struct {
+	Logger *zap.Logger
+
+	AuthorizationService platform.AuthorizationService
+	SessionService       platform.SessionService
+
+	Handler http.Handler
+}
+
+// NewAuthenticationHandler creates an authentication handler.
+func NewAuthenicationHandler() *AuthenticationHandler {
+	return &AuthenticationHandler{
+		Logger:  zap.NewNop(),
+		Handler: http.DefaultServeMux,
+	}
+}
+
+func probeAuthScheme(r *http.Request) (string, error) {
+	_, tokenErr := GetToken(r)
+	_, sessErr := decodeCookieSession(r.Context(), r)
+
+	if tokenErr != nil && sessErr != nil {
+		return "", fmt.Errorf("unknown authenitcation scheme")
+	}
+
+	if tokenErr != nil {
+		return "token", nil
+	}
+
+	return "session", nil
+}
+
+// ServeHTTP extracts the session or token from the http request and places the resulting authorizer on the request context.
+func (h *AuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	scheme, err := probeAuthScheme(r)
+	if err != nil {
+		ForbiddenError(ctx, err, w)
+		return
+	}
+
+	switch scheme {
+	case "token":
+		ctx, err = h.extractAuthorization(ctx, r)
+		if err != nil {
+			break
+		}
+		r = r.WithContext(ctx)
+		h.Handler.ServeHTTP(w, r)
+		return
+	case "session":
+		ctx, err = h.extractSession(ctx, r)
+		if err != nil {
+			break
+		}
+		r = r.WithContext(ctx)
+		h.Handler.ServeHTTP(w, r)
+		return
+	}
+
+	ForbiddenError(ctx, fmt.Errorf("unauthorized"), w)
+	return
+}
+
+func (h *AuthenticationHandler) extractAuthorization(ctx context.Context, r *http.Request) (context.Context, error) {
+	t, err := GetToken(r)
+	if err != nil {
+		return ctx, err
+	}
+
+	a, err := h.AuthorizationService.FindAuthorizationByToken(ctx, t)
+	if err != nil {
+		return ctx, err
+	}
+
+	return platcontext.SetAuthorizer(ctx, a), nil
+}
+
+func (h *AuthenticationHandler) extractSession(ctx context.Context, r *http.Request) (context.Context, error) {
+	k, err := decodeCookieSession(ctx, r)
+	if err != nil {
+		return ctx, err
+	}
+
+	s, err := h.SessionService.FindSession(ctx, k)
+	if err != nil {
+		return ctx, err
+	}
+
+	return platcontext.SetAuthorizer(ctx, s), nil
+}

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -26,7 +26,7 @@ type AuthenticationHandler struct {
 }
 
 // NewAuthenticationHandler creates an authentication handler.
-func NewAuthenicationHandler() *AuthenticationHandler {
+func NewAuthenticationHandler() *AuthenticationHandler {
 	return &AuthenticationHandler{
 		Logger:       zap.NewNop(),
 		Handler:      http.DefaultServeMux,

--- a/http/authentication_test.go
+++ b/http/authentication_test.go
@@ -1,0 +1,211 @@
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/influxdata/platform"
+	platformhttp "github.com/influxdata/platform/http"
+	"github.com/influxdata/platform/mock"
+)
+
+func TestAuthenticationHandler(t *testing.T) {
+	type fields struct {
+		AuthorizationService platform.AuthorizationService
+		SessionService       platform.SessionService
+	}
+	type args struct {
+		token   string
+		session string
+	}
+	type wants struct {
+		code int
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "session provided",
+			fields: fields{
+				AuthorizationService: mock.NewAuthorizationService(),
+				SessionService: &mock.SessionService{
+					FindSessionFn: func(ctx context.Context, key string) (*platform.Session, error) {
+						return &platform.Session{}, nil
+					},
+				},
+			},
+			args: args{
+				session: "abc123",
+			},
+			wants: wants{
+				code: http.StatusOK,
+			},
+		},
+		{
+			name: "session does not exist",
+			fields: fields{
+				AuthorizationService: mock.NewAuthorizationService(),
+				SessionService: &mock.SessionService{
+					FindSessionFn: func(ctx context.Context, key string) (*platform.Session, error) {
+						return nil, fmt.Errorf("session not found")
+					},
+				},
+			},
+			args: args{
+				session: "abc123",
+			},
+			wants: wants{
+				code: http.StatusForbidden,
+			},
+		},
+		{
+			name: "token provided",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					FindAuthorizationByTokenFn: func(ctx context.Context, token string) (*platform.Authorization, error) {
+						return &platform.Authorization{}, nil
+					},
+				},
+				SessionService: mock.NewSessionService(),
+			},
+			args: args{
+				token: "abc123",
+			},
+			wants: wants{
+				code: http.StatusOK,
+			},
+		},
+		{
+			name: "token does not exist",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					FindAuthorizationByTokenFn: func(ctx context.Context, token string) (*platform.Authorization, error) {
+						return nil, fmt.Errorf("authorization not found")
+					},
+				},
+				SessionService: mock.NewSessionService(),
+			},
+			args: args{
+				token: "abc123",
+			},
+			wants: wants{
+				code: http.StatusForbidden,
+			},
+		},
+		{
+			name: "no auth provided",
+			fields: fields{
+				AuthorizationService: mock.NewAuthorizationService(),
+				SessionService:       mock.NewSessionService(),
+			},
+			args: args{},
+			wants: wants{
+				code: http.StatusForbidden,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			h := platformhttp.NewAuthenicationHandler()
+			h.AuthorizationService = tt.fields.AuthorizationService
+			h.SessionService = tt.fields.SessionService
+			h.Handler = handler
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "http://any.url", nil)
+
+			if tt.args.session != "" {
+				platformhttp.SetCookieSession(tt.args.session, r)
+			}
+
+			if tt.args.token != "" {
+				platformhttp.SetToken(tt.args.token, r)
+			}
+
+			h.ServeHTTP(w, r)
+
+			if got, want := w.Code, tt.wants.code; got != want {
+				t.Errorf("expected status code to be %d got %d", want, got)
+			}
+		})
+	}
+}
+
+func TestProbeAuthScheme(t *testing.T) {
+	type args struct {
+		token   string
+		session string
+	}
+	type wants struct {
+		scheme string
+		err    error
+	}
+
+	tests := []struct {
+		name  string
+		args  args
+		wants wants
+	}{
+		{
+			name: "session provided",
+			args: args{
+				session: "abc123",
+			},
+			wants: wants{
+				scheme: "session",
+			},
+		},
+		{
+			name: "token provided",
+			args: args{
+				token: "abc123",
+			},
+			wants: wants{
+				scheme: "token",
+			},
+		},
+		{
+			name: "no auth provided",
+			args: args{},
+			wants: wants{
+				err: fmt.Errorf("unknown authentication scheme"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("POST", "http://any.url", nil)
+
+			if tt.args.session != "" {
+				platformhttp.SetCookieSession(tt.args.session, r)
+			}
+
+			if tt.args.token != "" {
+				platformhttp.SetToken(tt.args.token, r)
+			}
+
+			scheme, err := platformhttp.ProbeAuthScheme(r)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Errorf("unexpected error got %v want %v", err, tt.wants.err)
+				return
+			}
+
+			if got, want := scheme, tt.wants.scheme; got != want {
+				t.Errorf("expected scheme to be %s got %s", want, got)
+			}
+		})
+	}
+}

--- a/http/authentication_test.go
+++ b/http/authentication_test.go
@@ -118,7 +118,7 @@ func TestAuthenticationHandler(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			h := platformhttp.NewAuthenicationHandler()
+			h := platformhttp.NewAuthenticationHandler()
 			h.AuthorizationService = tt.fields.AuthorizationService
 			h.SessionService = tt.fields.SessionService
 			h.Handler = handler
@@ -271,7 +271,7 @@ func TestAuthenticationHandler_NoAuthRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			h := platformhttp.NewAuthenicationHandler()
+			h := platformhttp.NewAuthenticationHandler()
 			h.AuthorizationService = mock.NewAuthorizationService()
 			h.SessionService = mock.NewSessionService()
 			h.Handler = handler

--- a/http/errors.go
+++ b/http/errors.go
@@ -100,6 +100,11 @@ func EncodeError(ctx context.Context, err error, w http.ResponseWriter) {
 	w.WriteHeader(code)
 }
 
+// ForbiddenError encodes error with a forbidden status code.
+func ForbiddenError(ctx context.Context, err error, w http.ResponseWriter) {
+	EncodeError(ctx, kerrors.Forbiddenf(err.Error()), w)
+}
+
 // statusCode returns the http status code for an error.
 func statusCode(e kerrors.Error) int {
 	if e.Code > 0 {

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -26,6 +26,10 @@ func NewPlatformHandler(b *APIBackend) *PlatformHandler {
 	h := NewAuthenticationHandler()
 	h.Handler = NewAPIHandler(b)
 	h.RegisterNoAuthRoute("GET", "/api/v2")
+	h.RegisterNoAuthRoute("POST", "/api/v2/signin")
+	h.RegisterNoAuthRoute("POST", "/api/v2/signout")
+	h.RegisterNoAuthRoute("POST", "/api/v2/setup")
+	h.RegisterNoAuthRoute("GET", "/api/v2/setup")
 
 	return &PlatformHandler{
 		AssetHandler: NewAssetHandler(),

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -1,35 +1,19 @@
 package http
 
 import (
-	"context"
-	nethttp "net/http"
+	"net/http"
 	"strings"
 
-	idpctx "github.com/influxdata/platform/context"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // PlatformHandler is a collection of all the service handlers.
 type PlatformHandler struct {
-	BucketHandler        *BucketHandler
-	UserHandler          *UserHandler
-	OrgHandler           *OrgHandler
-	AuthorizationHandler *AuthorizationHandler
-	DashboardHandler     *DashboardHandler
-	AssetHandler         *AssetHandler
-	ChronografHandler    *ChronografHandler
-	ViewHandler          *ViewHandler
-	SourceHandler        *SourceHandler
-	MacroHandler         *MacroHandler
-	TaskHandler          *TaskHandler
-	FluxLangHandler      *FluxLangHandler
-	QueryHandler         *FluxHandler
-	WriteHandler         *WriteHandler
-	SetupHandler         *SetupHandler
-	SessionHandler       *SessionHandler
+	AssetHandler *AssetHandler
+	APIHandler   http.Handler
 }
 
-func setCORSResponseHeaders(w nethttp.ResponseWriter, r *nethttp.Request) {
+func setCORSResponseHeaders(w http.ResponseWriter, r *http.Request) {
 	if origin := r.Header.Get("Origin"); origin != "" {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
@@ -37,44 +21,20 @@ func setCORSResponseHeaders(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 }
 
-var platformLinks = map[string]interface{}{
-	"signin":     "/api/v2/signin",
-	"signout":    "/api/v2/singout",
-	"setup":      "/api/v2/setup",
-	"sources":    "/api/v2/sources",
-	"dashboards": "/api/v2/dashboards",
-	"query":      "/api/v2/query",
-	"write":      "/api/v2/write",
-	"orgs":       "/api/v2/orgs",
-	"auths":      "/api/v2/authorizations",
-	"buckets":    "/api/v2/buckets",
-	"users":      "/api/v2/users",
-	"tasks":      "/api/v2/tasks",
-	"flux": map[string]string{
-		"self":        "/api/v2/flux",
-		"ast":         "/api/v2/flux/ast",
-		"suggestions": "/api/v2/flux/suggestions",
-	},
-	"external": map[string]string{
-		"statusFeed": "https://www.influxdata.com/feed/json",
-	},
-	"system": map[string]string{
-		"metrics": "/metrics",
-		"debug":   "/debug/pprof",
-		"health":  "/healthz",
-	},
-}
+// NewPlatformHandler returns a platform handler that serves the API and associated assets.
+func NewPlatformHandler(b *APIBackend) *PlatformHandler {
+	h := NewAuthenticationHandler()
+	h.Handler = NewAPIHandler(b)
+	h.RegisterNoAuthRoute("GET", "/api/v2")
 
-func (h *PlatformHandler) serveLinks(w nethttp.ResponseWriter, r *nethttp.Request) {
-	ctx := r.Context()
-	if err := encodeResponse(ctx, w, nethttp.StatusOK, platformLinks); err != nil {
-		EncodeError(ctx, err, w)
-		return
+	return &PlatformHandler{
+		AssetHandler: NewAssetHandler(),
+		APIHandler:   h,
 	}
 }
 
 // ServeHTTP delegates a request to the appropriate subhandler.
-func (h *PlatformHandler) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request) {
+func (h *PlatformHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	setCORSResponseHeaders(w, r)
 	if r.Method == "OPTIONS" {
 		return
@@ -89,107 +49,11 @@ func (h *PlatformHandler) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 		return
 	}
 
-	// Serve the links base links for the API.
-	if r.URL.Path == "/api/v2/" || r.URL.Path == "/api/v2" {
-		h.serveLinks(w, r)
-		return
-	}
-
-	if r.URL.Path == "/api/v2/signin" || r.URL.Path == "/api/v2/signout" {
-		h.SessionHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/setup") {
-		h.SetupHandler.ServeHTTP(w, r)
-		return
-	}
-
-	ctx := r.Context()
-	var err error
-	if ctx, err = extractAuthorization(ctx, r); err != nil {
-		// TODO(desa): remove this when the authentication middleware is added.
-	}
-	r = r.WithContext(ctx)
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/write") {
-		h.WriteHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/query") {
-		h.QueryHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/buckets") {
-		h.BucketHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/users") {
-		h.UserHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/orgs") {
-		h.OrgHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/authorizations") {
-		h.AuthorizationHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/dashboards") {
-		h.DashboardHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/sources") {
-		h.SourceHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/tasks") {
-		h.TaskHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/views") {
-		h.ViewHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/macros") {
-		h.MacroHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/api/v2/flux") {
-		h.FluxLangHandler.ServeHTTP(w, r)
-		return
-	}
-
-	if strings.HasPrefix(r.URL.Path, "/chronograf/") {
-		h.ChronografHandler.ServeHTTP(w, r)
-		return
-	}
-
-	nethttp.NotFound(w, r)
+	h.APIHandler.ServeHTTP(w, r)
 }
 
 // PrometheusCollectors satisfies the prom.PrometheusCollector interface.
 func (h *PlatformHandler) PrometheusCollectors() []prometheus.Collector {
 	// TODO: collect and return relevant metrics.
 	return nil
-}
-
-func extractAuthorization(ctx context.Context, r *nethttp.Request) (context.Context, error) {
-	t, err := GetToken(r)
-	if err != nil {
-		return ctx, err
-	}
-	return idpctx.SetToken(ctx, t), nil
 }

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -60,8 +60,8 @@ func (h *FluxHandler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !platform.IsActive(auth) {
-		EncodeError(ctx, errors.Forbiddenf("insufficient permissions for write"), w)
+	if !auth.IsActive() {
+		EncodeError(ctx, errors.Forbiddenf("insufficient permissions for query"), w)
 		return
 	}
 

--- a/http/session_handler.go
+++ b/http/session_handler.go
@@ -125,3 +125,13 @@ func decodeCookieSession(ctx context.Context, r *http.Request) (string, error) {
 	}
 	return c.Value, nil
 }
+
+// SetCookieSession adds a cookie for the session to an http request
+func SetCookieSession(key string, r *http.Request) {
+	c := &http.Cookie{
+		Name:  cookieSessionName,
+		Value: key,
+	}
+
+	r.AddCookie(c)
+}

--- a/http/session_handler.go
+++ b/http/session_handler.go
@@ -25,8 +25,8 @@ func NewSessionHandler() *SessionHandler {
 		Router: httprouter.New(),
 	}
 
-	h.HandlerFunc("POST", "/signin", h.handleSignin)
-	h.HandlerFunc("POST", "/signout", h.handleSignout)
+	h.HandlerFunc("POST", "/api/v2/signin", h.handleSignin)
+	h.HandlerFunc("POST", "/api/v2/signout", h.handleSignout)
 	return h
 }
 

--- a/http/session_test.go
+++ b/http/session_test.go
@@ -71,7 +71,7 @@ func TestBasicAuthHandler_handleSignin(t *testing.T) {
 			h.SessionService = tt.fields.SessionService
 
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest("POST", "http://localhost:9999/signin", nil)
+			r := httptest.NewRequest("POST", "http://localhost:9999/api/v2/signin", nil)
 			r.SetBasicAuth(tt.args.user, tt.args.password)
 			h.ServeHTTP(w, r)
 

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -125,7 +125,7 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		bucket = b
 	}
 
-	if !platform.Allowed(platform.WriteBucketPermission(bucket.ID), auth) {
+	if !auth.Allowed(platform.WriteBucketPermission(bucket.ID)) {
 		EncodeError(ctx, errors.Forbiddenf("insufficient permissions for write"), w)
 		return
 	}

--- a/query/preauthorizer.go
+++ b/query/preauthorizer.go
@@ -44,7 +44,7 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 		}
 
 		reqPerm := platform.ReadBucketPermission(bucket.ID)
-		if !platform.Allowed(reqPerm, auth) {
+		if !auth.Allowed(reqPerm) {
 			return errors.New("No read permission for bucket: \"" + bucket.Name + "\"")
 		}
 	}
@@ -56,7 +56,7 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 		}
 
 		reqPerm := platform.WriteBucketPermission(bucket.ID)
-		if !platform.Allowed(reqPerm, auth) {
+		if !auth.Allowed(reqPerm) {
 			return errors.New("No write permission for bucket: \"" + bucket.Name + "\"")
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -36,6 +36,12 @@ func (s *Session) Allowed(p Permission) bool {
 	return allowed(p, s.Permissions)
 }
 
+// Kind returns session and is used for auditing.
+func (s *Session) Kind() string { return "session" }
+
+// Identifier returns the sessions ID and is used for auditing.
+func (s *Session) Identifier() ID { return s.ID }
+
 // SessionService represents a service for managing user sessions.
 type SessionService interface {
 	FindSession(ctx context.Context, key string) (*Session, error)

--- a/session.go
+++ b/session.go
@@ -26,6 +26,16 @@ func (s *Session) Expired() error {
 	return nil
 }
 
+// Allowed returns true if the authorization is unexpired and request permission
+// exists in the sessions list of permissions.
+func (s *Session) Allowed(p Permission) bool {
+	if err := s.Expired(); err != nil {
+		return false
+	}
+
+	return allowed(p, s.Permissions)
+}
+
 // SessionService represents a service for managing user sessions.
 type SessionService interface {
 	FindSession(ctx context.Context, key string) (*Session, error)

--- a/task/validator.go
+++ b/task/validator.go
@@ -47,7 +47,7 @@ func validatePermission(ctx context.Context, perm platform.Permission) error {
 		return err
 	}
 
-	if !platform.Allowed(perm, auth) {
+	if !auth.Allowed(perm) {
 		return authError{error: ErrFailedPermission, perm: perm, auth: auth}
 	}
 

--- a/task/validator.go
+++ b/task/validator.go
@@ -12,11 +12,11 @@ import (
 type authError struct {
 	error
 	perm platform.Permission
-	auth *platform.Authorization
+	auth platform.Authorizer
 }
 
 func (ae *authError) AuthzError() error {
-	return fmt.Errorf("permission failed for auth (%s): %s", ae.auth.ID.String(), ae.perm.String())
+	return fmt.Errorf("permission failed for auth (%s): %s", ae.auth.Identifier().String(), ae.perm.String())
 }
 
 var ErrFailedPermission = errors.New("unauthorized")
@@ -42,7 +42,7 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t *platform.Task
 // TODO(lh): add permission checking for the all the platform.TaskService functions.
 
 func validatePermission(ctx context.Context, perm platform.Permission) error {
-	auth, err := platcontext.GetAuthorization(ctx)
+	auth, err := platcontext.GetAuthorizer(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Note: this will enforce authentication for all routes except for the following

* `/metrics`
* `/healthz`
* `/debug/pprof/*`
* `GET - /api/v2`
* `POST - /api/v2/setup`
* `POST - /api/v2/signin`
* `POST - /api/v2/signout`

Closes #926

_Briefly describe your proposed changes:_
This PR adds support for authenticating requests that provide either a token or a valid session.

Additionally it provides a refactor that allows wrapping the API related parts of the platform handler.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass

  - [x] Add list of routes that do not require authentication