### PR TITLE
feat(http/view): add storing LogView config

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3355,6 +3355,98 @@ components:
         visible:
           description: Indicates whether this field should be visible on the table
           type: boolean
+    LogViewProperties:
+      description: Contains the configuration for the log viewer
+      type: object
+      required:
+      - columns
+      - shape
+      - type
+      properties:
+        shape:
+            type: string
+            enum: ["chronograf-v2"]
+        type:
+            type: string
+            enum: ["log-viewer"]
+        columns:
+          description: Defines the order, names, and visibility of columns in the log
+            viewer table
+          type: array
+          items:
+            "$ref": "#/components/schemas/LogViewerColumn"
+      example:
+        columns:
+        - name: severity
+          position: 0
+          settings:
+          - type: label
+            value: icon
+          - type: label
+            value: text
+          - type: visibility
+            value: visible
+          - type: color
+            name: ruby
+            value: emergency
+          - type: color
+            name: rainforest
+            value: info
+          - type: displayName
+            value: Log Severity!
+        - name: messages
+          position: 1
+          settings:
+          - type: visibility
+            value: hidden
+    LogViewerColumn:
+      description: Contains a specific column's settings.
+      type: object
+      required:
+      - name
+      - position
+      - settings
+      properties:
+        name:
+          description: Unique identifier name of the column
+          type: string
+        position:
+          type: integer
+          format: int32
+        settings:
+          description: Composable settings options for the column
+          type: array
+          items:
+            description: Type and value and optional name of a setting.
+            type: object
+            required:
+            - type
+            - value
+            properties:
+              type:
+                type: string
+              value:
+                type: string
+              name:
+                type: string
+      example:
+        name: severity
+        position: 0
+        settings:
+        - type: label
+          value: icon
+        - type: label
+          value: text
+        - type: visibility
+          value: visible
+        - type: color
+          name: ruby
+          value: emergency
+        - type: color
+          name: rainforest
+          value: info
+        - type: displayName
+          value: Log Severity!
     V1ViewProperties:
       properties:
         type:
@@ -3564,6 +3656,7 @@ components:
           oneOf:
             - $ref: "#/components/schemas/V1ViewProperties"
             - $ref: "#/components/schemas/EmptyViewProperties"
+            - $ref: "#/components/schemas/LogViewProperties"
     Views:
       type: object
       properties:


### PR DESCRIPTION
Closes #918

_Briefly describe your proposed changes:_
Add LogView configuration as a new view type.

_What was the problem?_
Previously in the last episode of chronograf, our adventurers used `/chronograf/v1/org_config/logviewer` to store the view state of log viewer.  Now we have a generic `/views` endpoint to handle such things.

(see https://github.com/influxdata/chronograf/blob/master/chronograf.go#L876-L893 for previous impl)

_What was the solution?_

We ported the org_config struct from chronograf with minor changes ('encodings` is now `settings`).

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)