### PR TITLE
Change how the write and query handlers look at auth

### DIFF
--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -48,15 +48,15 @@ func NewFluxHandler() *FluxHandler {
 
 func (h *FluxHandler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	tok, err := pcontext.GetToken(ctx)
+	a, err := pcontext.GetAuthorizer(ctx)
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return
 	}
 
-	auth, err := h.AuthorizationService.FindAuthorizationByToken(ctx, tok)
+	auth, err := h.AuthorizationService.FindAuthorizationByID(ctx, a.Identifier())
 	if err != nil {
-		EncodeError(ctx, errors.Wrap(err, "invalid token", errors.InvalidData), w)
+		EncodeError(ctx, err, w)
 		return
 	}
 

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -54,15 +54,15 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		defer in.Close()
 	}
 
-	tok, err := pcontext.GetToken(ctx)
+	a, err := pcontext.GetAuthorizer(ctx)
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return
 	}
 
-	auth, err := h.AuthorizationService.FindAuthorizationByToken(ctx, tok)
+	auth, err := h.AuthorizationService.FindAuthorizationByID(ctx, a.Identifier())
 	if err != nil {
-		EncodeError(ctx, errors.Wrap(err, "invalid token", errors.InvalidData), w)
+		EncodeError(ctx, err, w)
 		return
 	}
 


### PR DESCRIPTION
The authorization changes made it so that we no longer call `SetToken`, so these handlers that called `GetToken` were failing. Change them to call `GetAuthorizer` and pass the id to the `AuthorizationService` instead of the token.