### PR TITLE
Redesign Panels to conform to 2.0 UI Patterns

### DIFF
--- a/chronograf/ui/src/clockface/components/component_spacer/ComponentSpacer.scss
+++ b/chronograf/ui/src/clockface/components/component_spacer/ComponentSpacer.scss
@@ -6,6 +6,7 @@
 .component-spacer {
   display: flex;
   flex-wrap: nowrap;
+  align-items: center;
 }
 
 .component-spacer--left {

--- a/chronograf/ui/src/clockface/components/panel/Panel.scss
+++ b/chronograf/ui/src/clockface/components/panel/Panel.scss
@@ -3,7 +3,7 @@
    -----------------------------------------------------------------------------
 */
 
-$panel-gutter: 30px;
+$panel-gutter: $ix-marg-b * 2;
 $panel-background: $g3-castle;
 
 .panel {
@@ -11,18 +11,22 @@ $panel-background: $g3-castle;
   flex-direction: column;
   align-items: stretch;
   margin-bottom: $panel-gutter;
+  background-color: $panel-background;
+  border-radius: $radius;
+  margin-bottom: $ix-marg-a;
 }
 
 .panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: $panel-gutter 0;
+  padding: $panel-gutter;
+  padding-bottom: 0;
 }
 
 .panel-title {
-  font-weight: 400;
-  font-size: 19px;
+  font-weight: 500;
+  font-size: 17px;
   color: $g12-forge;
   letter-spacing: 0.015em;
   margin: 0;
@@ -33,83 +37,17 @@ $panel-background: $g3-castle;
 .panel-controls {
   display: flex;
   align-items: center;
-
-  &:nth-child(1) {
-    justify-content: flex-start;
-    > * {
-      margin-right: $ix-marg-b;
-    }
-  }
-
-  &:nth-child(2) {
-    justify-content: flex-end;
-    > * {
-      margin-left: $ix-marg-b;
-    }
-  }
 }
 
 .panel-body {
-  background-color: $panel-background;
   padding: $panel-gutter;
-
-  .panel-header + &,
-  &:first-child {
-    border-top-left-radius: $ix-radius;
-    border-top-right-radius: $ix-radius;
-  }
-  &:last-child {
-    border-bottom-left-radius: $ix-radius;
-    border-bottom-right-radius: $ix-radius;
-  }
-
-  > *:first-child {
-    margin-top: 0;
-  }
-  > *:last-child {
-    margin-bottom: 0;
-  }
 }
 
 .panel-footer {
-  padding: $ix-marg-c $panel-gutter;
+  padding: $ix-marg-b $panel-gutter;
   border-radius: 0 0 $ix-radius $ix-radius;
-  @include gradient-v($g2-kevlar, $panel-background);
+  background-color: mix($panel-background, $g2-kevlar, 50%);
   color: $g9-mountain;
-}
-
-//  Tables directly inside Panels
-//  ----------------------------------------------------------------------------
-.panel > .table {
-  border-top: $ix-border;
-  * {
-    border-color: $g19-ghost;
-  }
-}
-.panel-header + .table {
-  border: none;
-}
-.panel > .table td:first-child,
-.panel > .table th:first-child {
-  padding-left: $panel-gutter;
-}
-.panel > .table td:last-child,
-.panel > .table th:last-child {
-  padding-right: $panel-gutter;
-}
-
-//  Solid Panels
-//  ----------------------------------------------------------------------------
-.panel.panel-solid {
-  background-color: $panel-background;
-  border-radius: $ix-radius;
-
-  .panel-header {
-    padding: $panel-gutter;
-  }
-  .panel-body {
-    background-color: transparent;
-  }
 }
 
 //  Horizontal Rules directly inside Panels

--- a/chronograf/ui/src/clockface/components/panel/Panel.tsx
+++ b/chronograf/ui/src/clockface/components/panel/Panel.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {Component, ComponentClass} from 'react'
-import classnames from 'classnames'
 import _ from 'lodash'
 
 // Components
@@ -10,22 +9,12 @@ import PanelFooter from 'src/clockface/components/panel/PanelFooter'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-export enum PanelType {
-  Default = '',
-  Solid = 'solid',
-}
-
 interface Props {
-  children: JSX.Element[]
-  type?: PanelType
+  children: JSX.Element[] | JSX.Element
 }
 
 @ErrorHandling
 class Panel extends Component<Props> {
-  public static defaultProps: Partial<Props> = {
-    type: PanelType.Default,
-  }
-
   public static Header = PanelHeader
   public static Body = PanelBody
   public static Footer = PanelFooter
@@ -50,13 +39,7 @@ class Panel extends Component<Props> {
 
     this.validateChildren()
 
-    return <div className={this.className}>{children}</div>
-  }
-
-  private get className(): string {
-    const {type} = this.props
-
-    return classnames('panel', {'panel-solid': type === PanelType.Solid})
+    return <div className="panel">{children}</div>
   }
 
   private validateChildren = (): void => {

--- a/chronograf/ui/src/clockface/components/panel/PanelFooter.tsx
+++ b/chronograf/ui/src/clockface/components/panel/PanelFooter.tsx
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
-  children: JSX.Element[]
+  children: JSX.Element[] | JSX.Element | string | number
 }
 
 @ErrorHandling

--- a/chronograf/ui/src/clockface/components/panel/PanelHeader.tsx
+++ b/chronograf/ui/src/clockface/components/panel/PanelHeader.tsx
@@ -1,6 +1,10 @@
 // Libraries
 import React, {Component} from 'react'
 
+// Components
+import {ComponentSpacer, Alignment} from 'src/clockface'
+
+// Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
@@ -16,7 +20,9 @@ class PanelHeader extends Component<Props> {
     return (
       <div className="panel-header">
         <div className="panel-title">{title}</div>
-        <div className="panel-controls">{children}</div>
+        <div className="panel-controls">
+          <ComponentSpacer align={Alignment.Right}>{children}</ComponentSpacer>
+        </div>
       </div>
     )
   }

--- a/chronograf/ui/src/clockface/index.ts
+++ b/chronograf/ui/src/clockface/index.ts
@@ -8,7 +8,7 @@ import OverlayTechnology from './components/overlays/OverlayTechnology'
 import OverlayContainer from './components/overlays/OverlayContainer'
 import OverlayHeading from './components/overlays/OverlayHeading'
 import OverlayBody from './components/overlays/OverlayBody'
-import Panel, {PanelType} from './components/panel/Panel'
+import Panel from './components/panel/Panel'
 import Radio from './components/radio_buttons/RadioButtons'
 import SlideToggle from './components/slide_toggle/SlideToggle'
 import WizardFullScreen from './components/wizard/WizardFullScreen'
@@ -46,7 +46,6 @@ export {
   OverlayHeading,
   OverlayBody,
   Panel,
-  PanelType,
   Radio,
   SlideToggle,
   ComponentColor,


### PR DESCRIPTION
Simplify design and associated components of `Panels` Clockface component.
No longer has a `type` prop and appears much more compact. Deleted a bunch of styles that don't need to exist.

  - [x] Rebased/mergeable
  - [x] Tests pass