### PR TITLE
Signin after setup

### DIFF
--- a/chronograf/ui/mocks/dummy.ts
+++ b/chronograf/ui/mocks/dummy.ts
@@ -14,6 +14,8 @@ export const links: Links = {
   auths: '/api/v2/authorizations',
   buckets: '/api/v2/buckets',
   dashboards: '/api/v2/dashboards',
+  signin: '/api/v2/signin',
+  signout: '/api/v2/signout',
   external: {
     statusFeed: 'https://www.influxdata.com/feed/json',
   },

--- a/chronograf/ui/src/Signin.tsx
+++ b/chronograf/ui/src/Signin.tsx
@@ -3,60 +3,55 @@ import React, {ReactElement, PureComponent} from 'react'
 import {connect} from 'react-redux'
 
 // APIs
-import {getSetupStatus} from 'src/onboarding/apis'
-
-// Actions
-import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {trySources} from 'src/onboarding/apis'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import OnboardingWizard from 'src/onboarding/containers/OnboardingWizard'
+import SigninPage from 'src/onboarding/containers/SigninPage'
 import Notifications from 'src/shared/components/notifications/Notifications'
 
 // Types
-import {Notification, NotificationFunc, RemoteDataState} from 'src/types'
+import {RemoteDataState} from 'src/types'
 import {Links} from 'src/types/v2/links'
 
 interface State {
   loading: RemoteDataState
-  isSetupAllowed: boolean
+  isSourcesAllowed: boolean
 }
 
 interface Props {
   links: Links
-  isSetupComplete: boolean
   children: ReactElement<any>
-  notify: (message: Notification | NotificationFunc) => void
 }
 
 @ErrorHandling
-export class Setup extends PureComponent<Props, State> {
+export class Signin extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 
     this.state = {
       loading: RemoteDataState.NotStarted,
-      isSetupAllowed: false,
+      isSourcesAllowed: false,
     }
   }
 
   public async componentDidMount() {
     const {links} = this.props
-    const isSetupAllowed = await getSetupStatus(links.setup)
-    this.setState({loading: RemoteDataState.Done, isSetupAllowed})
+    const isSourcesAllowed = await trySources(links.sources)
+    this.setState({loading: RemoteDataState.Done, isSourcesAllowed})
   }
 
   public render() {
-    const {isSetupComplete} = this.props
-    const {isSetupAllowed} = this.state
+    const {isSourcesAllowed} = this.state
+
     if (this.isLoading) {
       return <div className="page-spinner" />
     }
-    if (isSetupAllowed && !isSetupComplete) {
+    if (!isSourcesAllowed) {
       return (
         <div className="chronograf-root">
           <Notifications inPresentationMode={true} />
-          <OnboardingWizard />
+          <SigninPage />
         </div>
       )
     } else {
@@ -73,13 +68,8 @@ export class Setup extends PureComponent<Props, State> {
   }
 }
 
-const mstp = ({links, isSetupComplete}) => ({
+const mstp = ({links}) => ({
   links,
-  isSetupComplete,
 })
 
-const mdtp = {
-  notify: notifyAction,
-}
-
-export default connect(mstp, mdtp)(Setup)
+export default connect(mstp)(Signin)

--- a/chronograf/ui/src/index.tsx
+++ b/chronograf/ui/src/index.tsx
@@ -18,6 +18,7 @@ import {getBasepath} from 'src/utils/basepath'
 import App from 'src/App'
 import CheckSources from 'src/CheckSources'
 import Setup from 'src/Setup'
+import Signin from 'src/Signin'
 import {DashboardsPage, DashboardPage} from 'src/dashboards'
 import {SourcePage, ManageSources} from 'src/sources'
 import {FluxPage} from 'src/flux'
@@ -100,19 +101,24 @@ class Root extends PureComponent<{}, State> {
       <Provider store={store}>
         <Router history={history}>
           <Route component={Setup}>
-            <Route component={App}>
-              <Route path="/" component={CheckSources}>
-                <Route
-                  path="dashboards/:dashboardID"
-                  component={DashboardPage}
-                />
-                <Route path="sources/new" component={SourcePage} />
-                <Route path="dashboards" component={DashboardsPage} />
-                <Route path="manage-sources" component={ManageSources} />
-                <Route path="manage-sources/new" component={SourcePage} />
-                <Route path="manage-sources/:id/edit" component={SourcePage} />
-                <Route path="delorean" component={FluxPage} />
-                <Route path="user/:tab" component={UserPage} />
+            <Route component={Signin}>
+              <Route component={App}>
+                <Route path="/" component={CheckSources}>
+                  <Route
+                    path="dashboards/:dashboardID"
+                    component={DashboardPage}
+                  />
+                  <Route path="sources/new" component={SourcePage} />
+                  <Route path="dashboards" component={DashboardsPage} />
+                  <Route path="manage-sources" component={ManageSources} />
+                  <Route path="manage-sources/new" component={SourcePage} />
+                  <Route
+                    path="manage-sources/:id/edit"
+                    component={SourcePage}
+                  />
+                  <Route path="delorean" component={FluxPage} />
+                  <Route path="user/:tab" component={UserPage} />
+                </Route>
               </Route>
             </Route>
           </Route>

--- a/chronograf/ui/src/onboarding/apis/index.ts
+++ b/chronograf/ui/src/onboarding/apis/index.ts
@@ -2,17 +2,14 @@ import _ from 'lodash'
 
 import AJAX from 'src/utils/ajax'
 
-export const getSetupStatus = async (
-  url: string
-): Promise<{isAllowed: boolean}> => {
+export const getSetupStatus = async (url: string): Promise<boolean> => {
   try {
     const {data} = await AJAX({
       method: 'GET',
       url,
     })
-    const {isAllowed} = data
-
-    return {isAllowed}
+    const {allowed} = data
+    return allowed
   } catch (error) {
     console.error("Can't get setup status", error)
     throw error
@@ -29,16 +26,48 @@ export interface SetupParams {
 export const setSetupParams = async (
   url: string,
   setupParams: SetupParams
-): Promise<{data: object}> => {
+): Promise<void> => {
   try {
-    const {data} = await AJAX({
+    await AJAX({
       method: 'POST',
       url,
       data: setupParams,
     })
-    return {data}
   } catch (error) {
     console.error("Can't set setup parameters", error)
     throw error
+  }
+}
+
+export const signin = async (
+  url: string,
+  params: {username: string; password: string}
+): Promise<void> => {
+  const {username, password} = params
+  try {
+    await AJAX({
+      method: 'POST',
+      url,
+      auth: {
+        username,
+        password,
+      },
+    })
+  } catch (error) {
+    console.error('Sign in has failed', error)
+    throw error
+  }
+}
+
+export const trySources = async (url: string): Promise<boolean> => {
+  try {
+    await AJAX({
+      method: 'GET',
+      url,
+    })
+    return true
+  } catch (error) {
+    console.error('Sign in has failed', error)
+    return false
   }
 }

--- a/chronograf/ui/src/onboarding/components/AdminStep.tsx
+++ b/chronograf/ui/src/onboarding/components/AdminStep.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/clockface'
 
 // APIS
-import {setSetupParams, SetupParams} from 'src/onboarding/apis'
+import {setSetupParams, SetupParams, signin} from 'src/onboarding/apis'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -202,6 +202,7 @@ class AdminStep extends PureComponent<OnboardingStepProps, State> {
 
     try {
       await setSetupParams(links.setup, setupParams)
+      await signin(links.signin, {username, password})
       notify(copy.SetupSuccess)
       handleSetSetupParams(setupParams)
       handleSetStepStatus(currentStepIndex, StepStatus.Complete)

--- a/chronograf/ui/src/onboarding/containers/SigninPage.tsx
+++ b/chronograf/ui/src/onboarding/containers/SigninPage.tsx
@@ -1,0 +1,127 @@
+// Libraries
+import React, {PureComponent, ChangeEvent} from 'react'
+import {connect} from 'react-redux'
+import _ from 'lodash'
+
+// Components
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {
+  Button,
+  ComponentColor,
+  ComponentSize,
+  Input,
+  Form,
+  Columns,
+  WizardFullScreen,
+} from 'src/clockface'
+
+// APIs
+import {signin} from 'src/onboarding/apis'
+
+// Actions
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+
+// Constants
+import * as copy from 'src/shared/copy/notifications'
+
+// Types
+import {Links} from 'src/types/v2/links'
+import {Notification, NotificationFunc} from 'src/types'
+
+export interface Props {
+  links: Links
+  notify: (message: Notification | NotificationFunc) => void
+}
+
+interface State {
+  username: string
+  password: string
+}
+
+@ErrorHandling
+class SigninPage extends PureComponent<Props, State> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      username: '',
+      password: '',
+    }
+  }
+
+  public render() {
+    const {username, password} = this.state
+    return (
+      <WizardFullScreen>
+        <div className="wizard-step--container">
+          <div className="onboarding-step">
+            <h3 className="wizard-step-title">Please sign in</h3>
+            <p>(and remember that you are awesome)</p>
+            <Form>
+              <Form.Element
+                label="Username"
+                colsXS={Columns.Six}
+                offsetXS={Columns.Three}
+                errorMessage={''}
+              >
+                <Input
+                  value={username}
+                  onChange={this.handleUsername}
+                  size={ComponentSize.Medium}
+                />
+              </Form.Element>
+              <Form.Element
+                label="Password"
+                colsXS={Columns.Six}
+                offsetXS={Columns.Three}
+                errorMessage={''}
+              >
+                <Input
+                  value={password}
+                  onChange={this.handlePassword}
+                  size={ComponentSize.Medium}
+                />
+              </Form.Element>
+            </Form>
+            <Button
+              color={ComponentColor.Primary}
+              text="Sign In"
+              size={ComponentSize.Medium}
+              onClick={this.handleSignIn}
+            />
+          </div>
+        </div>
+      </WizardFullScreen>
+    )
+  }
+
+  private handleUsername = (e: ChangeEvent<HTMLInputElement>): void => {
+    const username = e.target.value
+    this.setState({username})
+  }
+  private handlePassword = (e: ChangeEvent<HTMLInputElement>): void => {
+    const password = e.target.value
+    this.setState({password})
+  }
+
+  private handleSignIn = async (): Promise<void> => {
+    const {links, notify} = this.props
+    const {username, password} = this.state
+    try {
+      await signin(links.signin, {username, password})
+
+      notify(copy.SigninSuccessful)
+    } catch (error) {
+      notify(copy.SigninError)
+    }
+  }
+}
+
+const mstp = ({links}) => ({
+  links,
+})
+
+const mdtp = {
+  notify: notifyAction,
+}
+
+export default connect(mstp, mdtp)(SigninPage)

--- a/chronograf/ui/src/shared/copy/notifications.ts
+++ b/chronograf/ui/src/shared/copy/notifications.ts
@@ -93,7 +93,7 @@ export const csvUploadFailed = (): Notification => ({
   message: 'Please upload a .csv file',
 })
 
-// Onboarding wizard notifications
+// Onboarding notifications
 export const SetupSuccess: Notification = {
   ...defaultSuccessNotification,
   message: 'Admin User details have been successfully set',
@@ -107,6 +107,15 @@ export const SetupError: Notification = {
 export const SetupNotAllowed: Notification = {
   ...defaultErrorNotification,
   message: `Defaults have already been set on this account.`,
+}
+
+export const SigninSuccessful: Notification = {
+  ...defaultSuccessNotification,
+  message: `YAY! You're good to go, RELOAD to continue`,
+}
+export const SigninError: Notification = {
+  ...defaultErrorNotification,
+  message: `OH Noes! Sign In did not work. :(`,
 }
 
 //  Hosts Page Notifications

--- a/chronograf/ui/src/shared/reducers/links.test.ts
+++ b/chronograf/ui/src/shared/reducers/links.test.ts
@@ -2,11 +2,14 @@ import _ from 'lodash'
 
 import linksReducer from 'src/shared/reducers/links'
 import {linksGetCompleted, setDefaultDashboard} from 'src/shared/actions/links'
+import {Links} from 'src/types/v2/links'
 
-const links = {
+const links: Links = {
   auths: '/api/v2/authorizations',
   buckets: '/api/v2/buckets',
   dashboards: '/api/v2/dashboards',
+  signin: '/api/v2/signin',
+  signout: '/api/v2/signout',
   external: {
     statusFeed: 'https://www.influxdata.com/feed/json',
   },

--- a/chronograf/ui/src/shared/reducers/links.ts
+++ b/chronograf/ui/src/shared/reducers/links.ts
@@ -4,6 +4,8 @@ import {Links} from 'src/types/v2/links'
 const initialState: Links = {
   auths: '',
   buckets: '',
+  signin: '',
+  signout: '',
   dashboards: '',
   external: {
     statusFeed: '',

--- a/chronograf/ui/src/types/v2/links.ts
+++ b/chronograf/ui/src/types/v2/links.ts
@@ -1,6 +1,8 @@
 export interface Links {
   auths: string
   buckets: string
+  signin: string
+  signout: string
   dashboards: string
   external: {
     statusFeed: string

--- a/chronograf/ui/src/utils/ajax.ts
+++ b/chronograf/ui/src/utils/ajax.ts
@@ -15,10 +15,18 @@ interface RequestParams {
   data?: object | string
   params?: object
   headers?: object
+  auth?: {username: string; password: string}
 }
 
 async function AJAX<T = any>(
-  {url, method = 'GET', data = {}, params = {}, headers = {}}: RequestParams,
+  {
+    url,
+    method = 'GET',
+    data = {},
+    params = {},
+    headers = {},
+    auth = null,
+  }: RequestParams,
   excludeBasepath = false
 ): Promise<(T) | AxiosResponse<T>> {
   try {
@@ -30,6 +38,7 @@ async function AJAX<T = any>(
       data,
       params,
       headers,
+      auth,
     })
 
     return response


### PR DESCRIPTION
Closes #[110](https://github.com/influxdata/applications-team-issues/issues/110)

Onboarding wizard retrieves cookie session token from /signin after completing setup

After setup has been completed, user is prompted for username&password, and signin flow retrieves cookie session. 

ATTN: THis is a hacky solution to get us able to work on platform, will refactor this flow later with more time