### PR TITLE
Add storage engine

### DIFF
--- a/cmd/influxd/extra.go
+++ b/cmd/influxd/extra.go
@@ -31,6 +31,7 @@ import (
 	"github.com/influxdata/platform/bolt"
 	"github.com/influxdata/platform/models"
 	"github.com/influxdata/platform/query"
+	"github.com/influxdata/platform/storage"
 	"github.com/influxdata/platform/tsdb"
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
@@ -110,7 +111,7 @@ func (o *orgLookup) Lookup(ctx context.Context, name string) (platform.ID, bool)
 }
 
 type store struct {
-	shard *tsdb.Shard
+	engine *storage.Engine
 }
 
 func (s *store) WithLogger(*zap.Logger) {}
@@ -144,7 +145,7 @@ func (s *store) Read(ctx context.Context, req *ReadRequest) (ResultSet, error) {
 	}
 
 	var cur SeriesCursor
-	if ic, err := newIndexSeriesCursor(ctx, source, req, s.shard); err != nil {
+	if ic, err := newIndexSeriesCursor(ctx, source, req, s.engine); err != nil {
 		return nil, err
 	} else if ic == nil {
 		return nil, nil
@@ -186,7 +187,7 @@ func (s *store) GroupRead(ctx context.Context, req *ReadRequest) (GroupResultSet
 	}
 
 	newCursor := func() (SeriesCursor, error) {
-		cur, err := newIndexSeriesCursor(ctx, source, req, s.shard)
+		cur, err := newIndexSeriesCursor(ctx, source, req, s.engine)
 		if cur == nil || err != nil {
 			return nil, err
 		}
@@ -214,7 +215,7 @@ var (
 )
 
 type indexSeriesCursor struct {
-	sqry         tsdb.SeriesCursor
+	sqry         storage.SeriesCursor
 	err          error
 	tags         models.Tags
 	cond         influxql.Expr
@@ -223,8 +224,8 @@ type indexSeriesCursor struct {
 	hasValueExpr bool
 }
 
-func newIndexSeriesCursor(ctx context.Context, src *ReadSource, req *ReadRequest, shard *tsdb.Shard) (*indexSeriesCursor, error) {
-	queries, err := shard.CreateCursorIterator(ctx)
+func newIndexSeriesCursor(ctx context.Context, src *ReadSource, req *ReadRequest, engine *storage.Engine) (*indexSeriesCursor, error) {
+	queries, err := engine.CreateCursorIterator(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +267,7 @@ func newIndexSeriesCursor(ctx context.Context, src *ReadSource, req *ReadRequest
 		}
 	}
 
-	p.sqry, err = shard.CreateSeriesCursor(ctx, tsdb.SeriesCursorRequest{Measurements: mi}, opt.Condition)
+	p.sqry, err = engine.CreateSeriesCursor(ctx, storage.SeriesCursorRequest{Measurements: mi}, opt.Condition)
 	if err != nil {
 		p.Close()
 		return nil, err

--- a/cmd/influxd/extra.go
+++ b/cmd/influxd/extra.go
@@ -198,18 +198,12 @@ func (s *store) GroupRead(ctx context.Context, req *ReadRequest) (GroupResultSet
 }
 
 const (
-	fieldTagKey       = "_f"
-	measurementTagKey = "_m"
-
 	fieldKey       = "_field"
 	measurementKey = "_measurement"
 	valueKey       = "_value"
 )
 
 var (
-	fieldTagKeyBytes       = []byte(fieldTagKey)
-	measurementTagKeyBytes = []byte(measurementTagKey)
-
 	fieldKeyBytes       = []byte(fieldKey)
 	measurementKeyBytes = []byte(measurementKey)
 )
@@ -315,7 +309,7 @@ func (c *indexSeriesCursor) Next() *SeriesRow {
 	//TODO(edd): check this.
 	c.row.SeriesTags = copyTags(c.row.SeriesTags, sr.Tags)
 	c.row.Tags = copyTags(c.row.Tags, sr.Tags)
-	c.row.Field = string(c.row.Tags.Get(fieldTagKeyBytes))
+	c.row.Field = string(c.row.Tags.Get(tsdb.FieldKeyTagKeyBytes))
 
 	normalizeTags(c.row.Tags)
 
@@ -10467,14 +10461,14 @@ func toStoragePredicate(n semantic.Expression, objectName string) (*Node, error)
 			return &Node{
 				NodeType: NodeTypeTagRef,
 				Value: &Node_TagRefValue{
-					TagRefValue: fieldTagKey,
+					TagRefValue: tsdb.FieldKeyTagKey,
 				},
 			}, nil
 		case measurementKey:
 			return &Node{
 				NodeType: NodeTypeTagRef,
 				Value: &Node_TagRefValue{
-					TagRefValue: measurementTagKey,
+					TagRefValue: tsdb.MeasurementTagKey,
 				},
 			}, nil
 		case valueKey:

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -36,10 +36,6 @@ import (
 	"github.com/influxdata/platform/tsdb"
 	_ "github.com/influxdata/platform/tsdb/index/tsi1"
 	_ "github.com/influxdata/platform/tsdb/tsm1"
-<<<<<<< HEAD
-=======
-	pzap "github.com/influxdata/platform/zap"
->>>>>>> Add very basic write support
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -36,6 +36,10 @@ import (
 	"github.com/influxdata/platform/tsdb"
 	_ "github.com/influxdata/platform/tsdb/index/tsi1"
 	_ "github.com/influxdata/platform/tsdb/tsm1"
+<<<<<<< HEAD
+=======
+	pzap "github.com/influxdata/platform/zap"
+>>>>>>> Add very basic write support
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/storage/config.go
+++ b/storage/config.go
@@ -12,4 +12,14 @@ const ()
 type Config struct {
 	EngineOptions tsdb.EngineOptions `toml:"-"`
 	Index         tsi1.Config        `toml:"index"`
+	tsdb.Config
+}
+
+// NewConfig initialises a new config for an Engine.
+func NewConfig() Config {
+	return Config{
+		EngineOptions: tsdb.NewEngineOptions(),
+		Index:         tsi1.NewConfig(),
+		Config:        tsdb.NewConfig(),
+	}
 }

--- a/storage/config.go
+++ b/storage/config.go
@@ -1,0 +1,15 @@
+package storage
+
+import (
+	"github.com/influxdata/platform/tsdb"
+	"github.com/influxdata/platform/tsdb/index/tsi1"
+)
+
+// Config defaults
+const ()
+
+// Config holds the configuration for an Engine.
+type Config struct {
+	EngineOptions tsdb.EngineOptions `toml:"-"`
+	Index         tsi1.Config        `toml:"index"`
+}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"path/filepath"
+
+	"github.com/influxdata/platform/tsdb"
+	"github.com/influxdata/platform/tsdb/index/tsi1"
+	"github.com/influxdata/platform/tsdb/tsm1"
+	"go.uber.org/zap"
+)
+
+type Engine struct {
+	config Config
+
+	index  *tsi1.Index
+	sfile  *tsdb.SeriesFile
+	engine *tsm1.Engine
+
+	logger *zap.Logger
+}
+
+func NewEngine(path string, c Config) *Engine {
+	e := &Engine{
+		sfile:  tsdb.NewSeriesFile(filepath.Join(path, tsdb.SeriesFileDirectory)),
+		logger: zap.NewNop(),
+	}
+
+	// Initialise index.
+	index := tsi1.NewIndex(e.sfile, "remove me", c.Index,
+		tsi1.WithPath(filepath.Join(path, tsi1.DefaultIndexDirectoryName)),
+	)
+	e.index = index
+
+	// Initialise Engine
+	engine := tsm1.NewEngine(0, tsdb.Index(e.index), filepath.Join(path, "data"), "remove-me-wal", e.sfile, c.EngineOptions)
+	// TODO(edd): Once the tsdb.Engine abstraction is gone, this won't be needed.
+	e.engine = engine.(*tsm1.Engine)
+
+	return e
+}
+
+// WithLogger sets the logger on the Store. It must be called before Open.
+func (e *Engine) WithLogger(log *zap.Logger) {
+	e.logger = log.With(zap.String("service", "storage"))
+	e.sfile.WithLogger(e.logger)
+	e.index.WithLogger(e.logger)
+	e.engine.WithLogger(e.logger)
+}
+
+// Open opens the store and all underlying resources. It returns an error if
+// any of the underlying systems fail to open.
+func (e *Engine) Open() error {
+	return nil
+}
+
+// Close closes the store and all underlying resources. It returns an error if
+// any of the underlying systems fail to close.
+func (e *Engine) Close() error {
+	return nil
+}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -1,17 +1,27 @@
 package storage
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
+	"sync"
 
+	"github.com/influxdata/influxql"
+	"github.com/influxdata/platform/models"
 	"github.com/influxdata/platform/tsdb"
 	"github.com/influxdata/platform/tsdb/index/tsi1"
 	"github.com/influxdata/platform/tsdb/tsm1"
 	"go.uber.org/zap"
 )
 
+// Static objects to prevent small allocs.
+var timeBytes = []byte("time")
+
 type Engine struct {
 	config Config
+	path   string
 
+	mu     sync.RWMutex
 	index  *tsi1.Index
 	sfile  *tsdb.SeriesFile
 	engine *tsm1.Engine
@@ -19,8 +29,22 @@ type Engine struct {
 	logger *zap.Logger
 }
 
-func NewEngine(path string, c Config) *Engine {
+// Option provides a set
+type Option func(*Engine)
+
+// WithTSMFilenameFormatter sets a function on the underlying tsm1.Engine to specify
+// how TSM files are named.
+var WithTSMFilenameFormatter = func(fn tsm1.FormatFileNameFunc) Option {
+	return func(e *Engine) {
+		e.engine.WithFormatFileNameFunc(fn)
+	}
+}
+
+// NewEngine initialises a new storage engine, including a series file, index and
+// TSM engine.
+func NewEngine(path string, c Config, options ...Option) *Engine {
 	e := &Engine{
+		path:   path,
 		sfile:  tsdb.NewSeriesFile(filepath.Join(path, tsdb.SeriesFileDirectory)),
 		logger: zap.NewNop(),
 	}
@@ -36,12 +60,16 @@ func NewEngine(path string, c Config) *Engine {
 	// TODO(edd): Once the tsdb.Engine abstraction is gone, this won't be needed.
 	e.engine = engine.(*tsm1.Engine)
 
+	// Apply options.
+	for _, option := range options {
+		option(e)
+	}
 	return e
 }
 
 // WithLogger sets the logger on the Store. It must be called before Open.
 func (e *Engine) WithLogger(log *zap.Logger) {
-	e.logger = log.With(zap.String("service", "storage"))
+	e.logger = log.With(zap.String("service", "storage-engine"))
 	e.sfile.WithLogger(e.logger)
 	e.index.WithLogger(e.logger)
 	e.engine.WithLogger(e.logger)
@@ -50,11 +78,136 @@ func (e *Engine) WithLogger(log *zap.Logger) {
 // Open opens the store and all underlying resources. It returns an error if
 // any of the underlying systems fail to open.
 func (e *Engine) Open() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if err := e.sfile.Open(); err != nil {
+		return err
+	}
+
+	if err := e.index.Open(); err != nil {
+		return err
+	}
+
+	if err := e.engine.Open(); err != nil {
+		return err
+	}
+	e.engine.SetCompactionsEnabled(true) // TODO(edd):is this needed?
 	return nil
 }
 
 // Close closes the store and all underlying resources. It returns an error if
 // any of the underlying systems fail to close.
 func (e *Engine) Close() error {
-	return nil
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if err := e.sfile.Close(); err != nil {
+		return err
+	}
+
+	if err := e.index.Close(); err != nil {
+		return err
+	}
+
+	return e.engine.Close()
+}
+
+func (e *Engine) CreateSeriesCursor(ctx context.Context, req SeriesCursorRequest, cond influxql.Expr) (SeriesCursor, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	// TODO(edd): remove IndexSet
+	return newSeriesCursor(req, tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}, cond)
+}
+
+func (e *Engine) CreateCursorIterator(ctx context.Context) (tsdb.CursorIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.engine.CreateCursorIterator(ctx)
+}
+
+// WritePoints writes the provided points to the engine.
+//
+// The Engine expects all points to have been correctly validated by the caller.
+// WritePoints will however determine if there are any field type conflicts, and
+// return an appropriate error in that case.
+func (e *Engine) WritePoints(points []models.Point) error {
+	collection := tsdb.NewSeriesCollection(points)
+
+	j := 0
+	for iter := collection.Iterator(); iter.Next(); {
+		tags := iter.Tags()
+
+		// Filter out any tags with key equal to "time": they are invalid.
+		if tags.Get(timeBytes) != nil {
+			if collection.Reason == "" {
+				collection.Reason = fmt.Sprintf(
+					"invalid tag key: input tag %q on measurement %q is invalid",
+					timeBytes, iter.Name())
+			}
+			collection.Dropped++
+			collection.DroppedKeys = append(collection.DroppedKeys, iter.Key())
+			continue
+		}
+
+		// Drop any series with invalid unicode characters in the key.
+		if e.config.ValidateKeys && !models.ValidKeyTokens(string(iter.Name()), tags) {
+			if collection.Reason == "" {
+				collection.Reason = fmt.Sprintf("key contains invalid unicode: %q", iter.Key())
+			}
+			collection.Dropped++
+			collection.DroppedKeys = append(collection.DroppedKeys, iter.Key())
+			continue
+		}
+
+		collection.Copy(j, iter.Index())
+		j++
+	}
+	collection.Truncate(j)
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// Add new series to the index and series file. Check for partial writes.
+	if err := e.index.CreateSeriesListIfNotExists(collection); err != nil {
+		// ignore PartialWriteErrors. The collection captures it.
+		// TODO(edd/jeff): should we just remove PartialWriteError from the index then?
+		if _, ok := err.(tsdb.PartialWriteError); !ok {
+			return err
+		}
+	}
+
+	// Write the points to the cache and WAL.
+	if err := e.engine.WritePoints(collection.Points); err != nil {
+		return err
+	}
+	return collection.PartialWriteError()
+}
+
+// DeleteSeriesRangeWithPredicate deletes all series data iterated over if fn returns
+// true for that series.
+func (e *Engine) DeleteSeriesRangeWithPredicate(itr tsdb.SeriesIterator, fn func([]byte, models.Tags) (int64, int64, bool)) error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.engine.DeleteSeriesRangeWithPredicate(itr, fn)
+}
+
+// SeriesCardinality returns the number of series in the engine.
+func (e *Engine) SeriesCardinality() int64 {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.index.SeriesN()
+}
+
+// Path returns the path of the engine's base directory.
+func (e *Engine) Path() string {
+	return e.path
+}
+
+// ApplyFnToSeriesIDSet allows the caller to apply fn to the SeriesIDSet held
+// within the engine's index.
+func (e *Engine) ApplyFnToSeriesIDSet(fn func(*tsdb.SeriesIDSet)) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	fn(e.index.SeriesIDSet())
 }

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -54,10 +54,6 @@ const (
 	// DefaultMaxConcurrentCompactions is the maximum number of concurrent full and level compactions
 	// that can run at one time.  A value of 0 results in 50% of runtime.GOMAXPROCS(0) used at runtime.
 	DefaultMaxConcurrentCompactions = 0
-
-	// DefaultMaxIndexLogFileSize is the default threshold, in bytes, when an index
-	// write-ahead log file will compact into an index file.
-	DefaultMaxIndexLogFileSize = 1 * 1024 * 1024 // 1MB
 )
 
 // Config holds the configuration for the tsbd package.
@@ -88,12 +84,6 @@ type Config struct {
 	// not affected by this limit.  A value of 0 limits compactions to runtime.GOMAXPROCS(0).
 	MaxConcurrentCompactions int `toml:"max-concurrent-compactions"`
 
-	// MaxIndexLogFileSize is the threshold, in bytes, when an index write-ahead log file will
-	// compact into an index file. Lower sizes will cause log files to be compacted more quickly
-	// and result in lower heap usage at the expense of write throughput. Higher sizes will
-	// be compacted less frequently, store more series in-memory, and provide higher write throughput.
-	MaxIndexLogFileSize toml.Size `toml:"max-index-log-file-size"`
-
 	TraceLoggingEnabled bool `toml:"trace-logging-enabled"`
 
 	// TSMWillNeed controls whether we hint to the kernel that we intend to
@@ -118,8 +108,6 @@ func NewConfig() Config {
 		CompactThroughput:              toml.Size(DefaultCompactThroughput),
 		CompactThroughputBurst:         toml.Size(DefaultCompactThroughputBurst),
 		MaxConcurrentCompactions:       DefaultMaxConcurrentCompactions,
-
-		MaxIndexLogFileSize: toml.Size(DefaultMaxIndexLogFileSize),
 
 		TraceLoggingEnabled: false,
 		TSMWillNeed:         false,

--- a/tsdb/explode.go
+++ b/tsdb/explode.go
@@ -6,6 +6,17 @@ import (
 	"github.com/influxdata/platform/models"
 )
 
+// Values used to store the field key and measurement name as tags.
+const (
+	FieldKeyTagKey    = "_f"
+	MeasurementTagKey = "_m"
+)
+
+var (
+	FieldKeyTagKeyBytes    = []byte(FieldKeyTagKey)
+	MeasurementTagKeyBytes = []byte(MeasurementTagKey)
+)
+
 // ExplodePoints creates a list of points that only contains one field per point. It also
 // moves the measurement to a tag, and changes the measurement to be the provided argument.
 func ExplodePoints(org, bucket []byte, points []models.Point) ([]models.Point, error) {
@@ -23,8 +34,8 @@ func ExplodePoints(org, bucket []byte, points []models.Point) ([]models.Point, e
 		itr := pt.FieldIterator()
 		for itr.Next() {
 			tags = tags[:0]
-			tags = append(tags, models.NewTag([]byte("_f"), itr.FieldKey()))
-			tags = append(tags, models.NewTag([]byte("_m"), pt.Name()))
+			tags = append(tags, models.NewTag(FieldKeyTagKeyBytes, itr.FieldKey()))
+			tags = append(tags, models.NewTag(MeasurementTagKeyBytes, pt.Name()))
 			pt.ForEachTag(func(k, v []byte) bool {
 				tags = append(tags, models.NewTag(k, v))
 				return true

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -2477,16 +2477,6 @@ func NewIndex(id uint64, database, path string, seriesIDSet *SeriesIDSet, sfile 
 	return fn(id, "remove-me", path, seriesIDSet, sfile, options), nil
 }
 
-func MustOpenIndex(id uint64, database, path string, seriesIDSet *SeriesIDSet, sfile *SeriesFile, options EngineOptions) Index {
-	idx, err := NewIndex(id, database, path, seriesIDSet, sfile, options)
-	if err != nil {
-		panic(err)
-	} else if err := idx.Open(); err != nil {
-		panic(err)
-	}
-	return idx
-}
-
 // assert will panic with a given formatted message if the given condition is false.
 func assert(condition bool, msg string, v ...interface{}) {
 	if !condition {

--- a/tsdb/index/tsi1/config.go
+++ b/tsdb/index/tsi1/config.go
@@ -1,0 +1,27 @@
+package tsi1
+
+import "github.com/influxdata/influxdb/toml"
+
+// DefaultMaxIndexLogFileSize is the default threshold, in bytes, when an index
+// write-ahead log file will compact into an index file.
+const DefaultMaxIndexLogFileSize = 1 * 1024 * 1024 // 1MB
+
+// DefaultIndexDirectoryName is the default name of the directory holding the
+// index data.
+const DefaultIndexDirectoryName = "index"
+
+// Config holds configurable Index options.
+type Config struct {
+	// MaxIndexLogFileSize is the threshold, in bytes, when an index write-ahead log file will
+	// compact into an index file. Lower sizes will cause log files to be compacted more quickly
+	// and result in lower heap usage at the expense of write throughput. Higher sizes will
+	// be compacted less frequently, store more series in-memory, and provide higher write throughput.
+	MaxIndexLogFileSize toml.Size `toml:"max-index-log-file-size"`
+}
+
+// NewConfig returns a new Config.
+func NewConfig() Config {
+	return Config{
+		MaxIndexLogFileSize: toml.Size(DefaultMaxIndexLogFileSize),
+	}
+}

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/influxdata/platform/models"
 	"github.com/influxdata/platform/tsdb"
+	"github.com/influxdata/platform/tsdb/index/tsi1"
 )
 
 // Ensure fileset can return an iterator over all series in the index.
 func TestFileSet_SeriesIDIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(1, tsi1.NewConfig())
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -81,7 +82,7 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all series for one measurement.
 func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(1, tsi1.NewConfig())
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -147,7 +148,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all measurements for the index.
 func TestFileSet_MeasurementIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(1, tsi1.NewConfig())
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -221,7 +222,7 @@ func TestFileSet_MeasurementIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all keys for one measurement.
 func TestFileSet_TagKeyIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(1, tsi1.NewConfig())
 	defer idx.Close()
 
 	// Create initial set of series.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -50,11 +50,6 @@ func init() {
 			panic(err)
 		}
 	}
-
-	// tsdb.RegisterIndex(IndexName, func(_ uint64, db, path string, _ *tsdb.SeriesIDSet, sfile *tsdb.SeriesFile, ) tsdb.Index {
-	// 	idx := NewIndex(sfile, db, WithPath(path), WithMaximumLogFileSize(int64(opt.Config.MaxIndexLogFileSize)))
-	// 	return idx
-	// })
 }
 
 // DefaultPartitionN determines how many shards the index will be partitioned into.

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -92,7 +92,7 @@ func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 		sfile:       sfile,
 		seriesIDSet: tsdb.NewSeriesIDSet(),
 
-		MaxLogFileSize: tsdb.DefaultMaxIndexLogFileSize,
+		MaxLogFileSize: DefaultMaxIndexLogFileSize,
 
 		// compactionEnabled: true,
 		compactionInterrupt: make(chan struct{}),

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -48,6 +48,11 @@ func NewSeriesFile(path string) *SeriesFile {
 	}
 }
 
+// WithLogger sets the logger on the SeriesFile and all underlying partitions. It must be called before Open.
+func (f *SeriesFile) WithLogger(log *zap.Logger) {
+	f.Logger = log.With(zap.String("service", "series-file"))
+}
+
 // Open memory maps the data file at the file's path.
 func (f *SeriesFile) Open() error {
 	// Wait for all references to be released and prevent new ones from being acquired.
@@ -62,6 +67,7 @@ func (f *SeriesFile) Open() error {
 	// Open partitions.
 	f.partitions = make([]*SeriesPartition, 0, SeriesFilePartitionN)
 	for i := 0; i < SeriesFilePartitionN; i++ {
+		// TODO(edd): These partition initialisation should be moved up to NewSeriesFile.
 		p := NewSeriesPartition(i, f.SeriesPartitionPath(i))
 		p.Logger = f.Logger.With(zap.Int("partition", p.ID()))
 		if err := p.Open(); err != nil {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -225,6 +225,11 @@ func (s *Shard) Index() (Index, error) {
 
 // WritePoints will write the raw data points and any new metadata to the index in the shard.
 func (s *Shard) WritePoints(points []models.Point) error {
+	points, err := explodePoints([]byte("insert-org-bucket"), points)
+	if err != nil {
+		return err
+	}
+
 	collection := NewSeriesCollection(points)
 
 	j := 0

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -224,11 +224,6 @@ func (s *Shard) Index() (Index, error) {
 
 // WritePoints will write the raw data points and any new metadata to the index in the shard.
 func (s *Shard) WritePoints(points []models.Point) error {
-	points, err := explodePoints([]byte("insert-org-bucket"), points)
-	if err != nil {
-		return err
-	}
-
 	collection := NewSeriesCollection(points)
 
 	j := 0

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/influxdata/influxql"
 	"github.com/influxdata/platform/models"
 	"go.uber.org/zap"
 )
@@ -307,15 +306,6 @@ func (s *Shard) SeriesN() int64 {
 		return 0
 	}
 	return engine.SeriesN()
-}
-
-// CreateSeriesCursor creates a SeriesCursor for the shard.
-func (s *Shard) CreateSeriesCursor(ctx context.Context, req SeriesCursorRequest, cond influxql.Expr) (SeriesCursor, error) {
-	index, err := s.Index()
-	if err != nil {
-		return nil, err
-	}
-	return newSeriesCursor(req, IndexSet{Indexes: []Index{index}, SeriesFile: s.sfile}, cond)
 }
 
 // CreateCursorIterator creates a CursorIterator for the shard.

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
+	t.Skip("Move to the new engine")
 	tmpDir, _ := ioutil.TempDir("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
@@ -83,6 +84,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 }
 
 func TestWriteTimeTag(t *testing.T) {
+	t.Skip("Move to the new engine")
 	tmpDir, _ := ioutil.TempDir("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
@@ -123,6 +125,7 @@ func TestWriteTimeTag(t *testing.T) {
 }
 
 func TestWriteTimeField(t *testing.T) {
+	t.Skip("Move to the new engine")
 	tmpDir, _ := ioutil.TempDir("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
@@ -152,6 +155,7 @@ func TestWriteTimeField(t *testing.T) {
 }
 
 func TestShardWriteAddNewField(t *testing.T) {
+	t.Skip("Move to the new engine")
 	tmpDir, _ := ioutil.TempDir("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
@@ -199,6 +203,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 // Ensures that when a shard is closed, it removes any series meta-data
 // from the index.
 func TestShard_Close_RemoveIndex(t *testing.T) {
+	t.Skip("Move to the new engine")
 	tmpDir, _ := ioutil.TempDir("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")


### PR DESCRIPTION
Closes #884

_Briefly describe your proposed changes:_

This PR adds an initial storage engine, which comprises: a TSM engine, a SeriesFile and a TSI index.

_What was the problem?_

We didn't have a storage engine

_What was the solution?_

Write a storage engine.

There is still a huge amount of work I need to do, but this should give us a working storage engine that snapshots on every write. It should be enough for the Chronograf team to use as a backend for their development.