### PR TITLE
Filter dashboards by owner

### DIFF
--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -93,10 +93,10 @@ func filterDashboardsFn(filter platform.DashboardFilter) func(d *platform.Dashbo
 	if len(filter.IDs) > 0 {
 		var sm sync.Map
 		for _, id := range filter.IDs {
-			sm.Store(id, true)
+			sm.Store(id.String(), true)
 		}
 		return func(d *platform.Dashboard) bool {
-			_, ok := sm.Load(d.ID)
+			_, ok := sm.Load(d.ID.String())
 			return ok
 		}
 	}

--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/influxdata/platform"
@@ -61,8 +62,8 @@ func (c *Client) findDashboardByID(ctx context.Context, tx *bolt.Tx, id platform
 
 // FindDashboard retrieves a dashboard using an arbitrary dashboard filter.
 func (c *Client) FindDashboard(ctx context.Context, filter platform.DashboardFilter) (*platform.Dashboard, error) {
-	if filter.ID != nil {
-		return c.FindDashboardByID(ctx, *filter.ID)
+	if len(filter.IDs) == 1 {
+		return c.FindDashboardByID(ctx, *filter.IDs[0])
 	}
 
 	var d *platform.Dashboard
@@ -89,9 +90,14 @@ func (c *Client) FindDashboard(ctx context.Context, filter platform.DashboardFil
 }
 
 func filterDashboardsFn(filter platform.DashboardFilter) func(d *platform.Dashboard) bool {
-	if filter.ID != nil {
+	if len(filter.IDs) > 0 {
+		var sm sync.Map
+		for _, id := range filter.IDs {
+			sm.Store(id, true)
+		}
 		return func(d *platform.Dashboard) bool {
-			return bytes.Equal(d.ID, *filter.ID)
+			_, ok := sm.Load(d.ID)
+			return ok
 		}
 	}
 
@@ -100,8 +106,8 @@ func filterDashboardsFn(filter platform.DashboardFilter) func(d *platform.Dashbo
 
 // FindDashboards retrives all dashboards that match an arbitrary dashboard filter.
 func (c *Client) FindDashboards(ctx context.Context, filter platform.DashboardFilter) ([]*platform.Dashboard, int, error) {
-	if filter.ID != nil {
-		d, err := c.FindDashboardByID(ctx, *filter.ID)
+	if len(filter.IDs) == 1 {
+		d, err := c.FindDashboardByID(ctx, *filter.IDs[0])
 		if err != nil {
 			return nil, 0, err
 		}

--- a/bolt/user_resource_mapping.go
+++ b/bolt/user_resource_mapping.go
@@ -1,7 +1,6 @@
 package bolt
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -22,54 +21,12 @@ func (c *Client) initializeUserResourceMappings(ctx context.Context, tx *bolt.Tx
 }
 
 func filterMappingsFn(filter platform.UserResourceMappingFilter) func(m *platform.UserResourceMapping) bool {
-	if filter.UserID != nil && filter.ResourceID != nil && filter.UserType != "" {
-		return func(m *platform.UserResourceMapping) bool {
-			return bytes.Equal(m.ResourceID, filter.ResourceID) &&
-				bytes.Equal(m.UserID, filter.UserID) &&
-				m.UserType == filter.UserType
-		}
+	return func(mapping *platform.UserResourceMapping) bool {
+		return (filter.UserID == nil || (filter.UserID.String()) == mapping.UserID.String()) &&
+			(filter.ResourceID == nil || (filter.ResourceID.String()) == mapping.ResourceID.String()) &&
+			(filter.UserType == "" || (filter.UserType == mapping.UserType)) &&
+			(filter.ResourceType == "" || (filter.ResourceType == mapping.ResourceType))
 	}
-
-	if filter.UserID != nil && filter.ResourceID != nil {
-		return func(m *platform.UserResourceMapping) bool {
-			return bytes.Equal(m.UserID, filter.UserID) &&
-				bytes.Equal(m.ResourceID, filter.ResourceID)
-		}
-	}
-
-	if filter.UserID != nil && filter.UserType != "" {
-		return func(m *platform.UserResourceMapping) bool {
-			return bytes.Equal(m.UserID, filter.UserID) &&
-				m.UserType == filter.UserType
-		}
-	}
-
-	if filter.ResourceID != nil && filter.UserType != "" {
-		return func(m *platform.UserResourceMapping) bool {
-			return bytes.Equal(m.ResourceID, filter.ResourceID) &&
-				m.UserType == filter.UserType
-		}
-	}
-
-	if filter.UserID != nil {
-		return func(m *platform.UserResourceMapping) bool {
-			return bytes.Equal(m.UserID, filter.UserID)
-		}
-	}
-
-	if filter.ResourceID != nil {
-		return func(m *platform.UserResourceMapping) bool {
-			return bytes.Equal(m.ResourceID, filter.ResourceID)
-		}
-	}
-
-	if filter.UserType != "" {
-		return func(m *platform.UserResourceMapping) bool {
-			return m.UserType == filter.UserType
-		}
-	}
-
-	return func(m *platform.UserResourceMapping) bool { return true }
 }
 
 func (c *Client) FindUserResourceMappings(ctx context.Context, filter platform.UserResourceMappingFilter, opt ...platform.FindOptions) ([]*platform.UserResourceMapping, int, error) {

--- a/dashboard.go
+++ b/dashboard.go
@@ -63,7 +63,8 @@ type Cell struct {
 // DashboardFilter is a filter for dashboards.
 type DashboardFilter struct {
 	// TODO(desa): change to be a slice of IDs
-	ID *ID
+	ID      *ID
+	OwnerID *ID
 }
 
 // DashboardUpdate is the patch structure for a dashboard.

--- a/dashboard.go
+++ b/dashboard.go
@@ -62,9 +62,7 @@ type Cell struct {
 
 // DashboardFilter is a filter for dashboards.
 type DashboardFilter struct {
-	// TODO(desa): change to be a slice of IDs
-	ID      *ID
-	OwnerID *ID
+	IDs []*ID
 }
 
 // DashboardUpdate is the patch structure for a dashboard.

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -181,6 +181,14 @@ func decodeGetDashboardsRequest(ctx context.Context, r *http.Request) (*getDashb
 			return nil, err
 		}
 	}
+
+	if owner := qp.Get("owner"); owner != "" {
+		req.filter.OwnerID = &platform.ID{}
+		if err := req.filter.OwnerID.DecodeFromString(owner); err != nil {
+			return nil, err
+		}
+	}
+
 	return req, nil
 }
 

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
-	"strings"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/kit/errors"
@@ -195,8 +194,7 @@ func decodeGetDashboardsRequest(ctx context.Context, r *http.Request) (*getDashb
 	qp := r.URL.Query()
 	req := &getDashboardsRequest{}
 
-	if idsStr := qp.Get("ids"); idsStr != "" {
-		ids := strings.Split(idsStr, ",")
+	if ids, ok := qp["id"]; ok {
 		for _, id := range ids {
 			i := &platform.ID{}
 			if err := i.DecodeFromString(id); err != nil {
@@ -692,12 +690,8 @@ func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.D
 	}
 
 	qp := url.Query()
-	if len(filter.IDs) > 0 {
-		var ids string
-		for _, id := range filter.IDs {
-			ids = ids + id.String()
-		}
-		qp.Add("id", ids)
+	for _, id := range filter.IDs {
+		qp.Add("id", id.String())
 	}
 	url.RawQuery = qp.Encode()
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -721,19 +721,14 @@ paths:
       summary: Get all dashboards
       parameters:
           - in: query
-            name: org
-            description: specifies the organization of the resource
-            required: true
-            schema:
-              type: string
-          - in: query
             name: owner
-            description: specifies the owner to return resources for
+            description: specifies the owner id to return resources for
             schema:
               type: string
           - in: query
             name: ids
-            description: a comma separated list of ids to return
+            summary: dashboards to return
+            description: a comma separated id list of dashboards to return. If both this and owner are specified, only ids is used.
             schema:
               type: string
             example: 273de20b5b,667d679f84

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -726,6 +726,11 @@ paths:
             required: true
             schema:
               type: string
+          - in: query
+            name: owner
+            description: specifies the owner to return resources for
+            schema:
+              type: string
       responses:
         '200':
           description: all dashboards

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -731,6 +731,12 @@ paths:
             description: specifies the owner to return resources for
             schema:
               type: string
+          - in: query
+            name: ids
+            description: a comma separated list of ids to return
+            schema:
+              type: string
+            example: 273de20b5b,667d679f84
       responses:
         '200':
           description: all dashboards

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -726,12 +726,12 @@ paths:
             schema:
               type: string
           - in: query
-            name: ids
-            summary: dashboards to return
-            description: a comma separated id list of dashboards to return. If both this and owner are specified, only ids is used.
+            name: id
+            description: ID list of dashboards to return. If both this and owner are specified, only ids is used.
             schema:
-              type: string
-            example: 273de20b5b,667d679f84
+              type: array
+              items:
+                type: string
       responses:
         '200':
           description: all dashboards

--- a/inmem/dashboard.go
+++ b/inmem/dashboard.go
@@ -44,7 +44,7 @@ func filterDashboardFn(filter platform.DashboardFilter) func(d *platform.Dashboa
 
 // FindDashboards implements platform.DashboardService interface.
 func (s *Service) FindDashboards(ctx context.Context, filter platform.DashboardFilter) ([]*platform.Dashboard, int, error) {
-	if len(filter.IDs) != 1 {
+	if len(filter.IDs) == 1 {
 		d, err := s.FindDashboardByID(ctx, *filter.IDs[0])
 		if err != nil {
 			return nil, 0, err

--- a/inmem/dashboard.go
+++ b/inmem/dashboard.go
@@ -31,10 +31,10 @@ func filterDashboardFn(filter platform.DashboardFilter) func(d *platform.Dashboa
 	if len(filter.IDs) > 0 {
 		var sm sync.Map
 		for _, id := range filter.IDs {
-			sm.Store(id, true)
+			sm.Store(id.String(), true)
 		}
 		return func(d *platform.Dashboard) bool {
-			_, ok := sm.Load(d.ID)
+			_, ok := sm.Load(d.ID.String())
 			return ok
 		}
 	}

--- a/inmem/user_resource_mapping_service.go
+++ b/inmem/user_resource_mapping_service.go
@@ -72,7 +72,8 @@ func (s *Service) FindUserResourceMappings(ctx context.Context, filter platform.
 	filterFunc := func(mapping *platform.UserResourceMapping) bool {
 		return (filter.UserID == nil || (filter.UserID.String()) == mapping.UserID.String()) &&
 			(filter.ResourceID == nil || (filter.ResourceID.String()) == mapping.ResourceID.String()) &&
-			(filter.UserType == "" || (filter.UserType == mapping.UserType))
+			(filter.UserType == "" || (filter.UserType == mapping.UserType)) &&
+			(filter.ResourceType == "" || (filter.ResourceType == mapping.ResourceType))
 	}
 
 	mappings, err := s.filterUserResourceMappings(ctx, filterFunc)

--- a/mock/user_resource_mapping_service.go
+++ b/mock/user_resource_mapping_service.go
@@ -23,5 +23,5 @@ func (s *UserResourceMappingService) CreateUserResourceMapping(ctx context.Conte
 }
 
 func (s *UserResourceMappingService) DeleteUserResourceMapping(ctx context.Context, resourceID platform.ID, userID platform.ID) error {
-	return s.DeleteUserResourceMapping(ctx, resourceID, userID)
+	return s.DeleteMappingF(ctx, resourceID, userID)
 }

--- a/mock/user_resource_mapping_service.go
+++ b/mock/user_resource_mapping_service.go
@@ -1,0 +1,27 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/influxdata/platform"
+)
+
+var _ platform.UserResourceMappingService = &UserResourceMappingService{}
+
+type UserResourceMappingService struct {
+	FindMappingsF  func(context.Context, platform.UserResourceMappingFilter) ([]*platform.UserResourceMapping, int, error)
+	CreateMappingF func(context.Context, *platform.UserResourceMapping) error
+	DeleteMappingF func(context.Context, platform.ID, platform.ID) error
+}
+
+func (s *UserResourceMappingService) FindUserResourceMappings(ctx context.Context, filter platform.UserResourceMappingFilter, opt ...platform.FindOptions) ([]*platform.UserResourceMapping, int, error) {
+	return s.FindMappingsF(ctx, filter)
+}
+
+func (s *UserResourceMappingService) CreateUserResourceMapping(ctx context.Context, m *platform.UserResourceMapping) error {
+	return s.CreateMappingF(ctx, m)
+}
+
+func (s *UserResourceMappingService) DeleteUserResourceMapping(ctx context.Context, resourceID platform.ID, userID platform.ID) error {
+	return s.DeleteUserResourceMapping(ctx, resourceID, userID)
+}

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -18,6 +18,10 @@ const (
 	dashThreeID = "020f755c3c082002"
 )
 
+func idPtr(id platform.ID) *platform.ID {
+	return &id
+}
+
 var dashboardCmpOptions = cmp.Options{
 	cmp.Comparer(func(x, y []byte) bool {
 		return bytes.Equal(x, y)
@@ -386,11 +390,44 @@ func FindDashboards(
 			},
 			args: args{
 				IDs: []*platform.ID{
-					func() *platform.ID { a := idFromString(t, dashTwoID); return &a }(),
+					idPtr(idFromString(t, dashTwoID)),
 				},
 			},
 			wants: wants{
 				dashboards: []*platform.Dashboard{
+					{
+						ID:   idFromString(t, dashTwoID),
+						Name: "xyz",
+					},
+				},
+			},
+		},
+		{
+			name: "find multiple dashboards by id",
+			fields: DashboardFields{
+				Dashboards: []*platform.Dashboard{
+					{
+						ID:   idFromString(t, dashOneID),
+						Name: "abc",
+					},
+					{
+						ID:   idFromString(t, dashTwoID),
+						Name: "xyz",
+					},
+				},
+			},
+			args: args{
+				IDs: []*platform.ID{
+					idPtr(idFromString(t, dashOneID)),
+					idPtr(idFromString(t, dashTwoID)),
+				},
+			},
+			wants: wants{
+				dashboards: []*platform.Dashboard{
+					{
+						ID:   idFromString(t, dashOneID),
+						Name: "abc",
+					},
 					{
 						ID:   idFromString(t, dashTwoID),
 						Name: "xyz",

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -328,7 +328,7 @@ func FindDashboards(
 	t *testing.T,
 ) {
 	type args struct {
-		ID   platform.ID
+		IDs  []*platform.ID
 		name string
 	}
 
@@ -385,7 +385,9 @@ func FindDashboards(
 				},
 			},
 			args: args{
-				ID: idFromString(t, dashTwoID),
+				IDs: []*platform.ID{
+					func() *platform.ID { a := idFromString(t, dashTwoID); return &a }(),
+				},
 			},
 			wants: wants{
 				dashboards: []*platform.Dashboard{
@@ -405,8 +407,8 @@ func FindDashboards(
 			ctx := context.Background()
 
 			filter := platform.DashboardFilter{}
-			if tt.args.ID != nil {
-				filter.ID = &tt.args.ID
+			if tt.args.IDs != nil {
+				filter.IDs = tt.args.IDs
 			}
 
 			dashboards, _, err := s.FindDashboards(ctx, filter)

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -444,7 +444,7 @@ func FindUserResourceMappings(
 					{
 						ResourceID:   idFromString(t, bucketTwoID),
 						UserID:       idFromString(t, userTwoID),
-						UserType:     platform.Owner,
+						UserType:     platform.Member,
 						ResourceType: platform.BucketResourceType,
 					},
 				},

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -369,7 +369,7 @@ func FindUserResourceMappings(
 			},
 		},
 		{
-			name: "find mappings filtered by type",
+			name: "find mappings filtered by user type",
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
@@ -395,6 +395,40 @@ func FindUserResourceMappings(
 						ResourceID: idFromString(t, bucketTwoID),
 						UserID:     idFromString(t, userTwoID),
 						UserType:   platform.Owner,
+					},
+				},
+			},
+		},
+		{
+			name: "find mappings filtered by resource type",
+			fields: UserResourceFields{
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.DashboardResourceType,
+					},
+					{
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
+					},
+				},
+			},
+			args: args{
+				filter: platform.UserResourceMappingFilter{
+					ResourceType: platform.BucketResourceType,
+				},
+			},
+			wants: wants{
+				mappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Owner,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -86,30 +86,34 @@ func CreateUserResourceMapping(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
 			args: args{
 				mapping: &platform.UserResourceMapping{
-					ResourceID: idFromString(t, bucketTwoID),
-					UserID:     idFromString(t, userTwoID),
-					UserType:   platform.Member,
+					ResourceID:   idFromString(t, bucketTwoID),
+					UserID:       idFromString(t, userTwoID),
+					UserType:     platform.Member,
+					ResourceType: platform.BucketResourceType,
 				},
 			},
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -277,14 +281,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -294,14 +300,16 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -311,14 +319,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -330,9 +340,10 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -342,14 +353,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -361,9 +374,10 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -373,14 +387,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketOneID),
-						UserID:     idFromString(t, userOneID),
-						UserType:   platform.Member,
+						ResourceID:   idFromString(t, bucketOneID),
+						UserID:       idFromString(t, userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketResourceType,
 					},
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Owner,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Owner,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},
@@ -392,9 +408,10 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: idFromString(t, bucketTwoID),
-						UserID:     idFromString(t, userTwoID),
-						UserType:   platform.Owner,
+						ResourceID:   idFromString(t, bucketTwoID),
+						UserID:       idFromString(t, userTwoID),
+						UserType:     platform.Owner,
+						ResourceType: platform.BucketResourceType,
 					},
 				},
 			},

--- a/user_resource_mapping.go
+++ b/user_resource_mapping.go
@@ -6,10 +6,13 @@ import (
 )
 
 type UserType string
+type ResourceType string
 
 const (
-	Owner  UserType = "owner"
-	Member UserType = "member"
+	Owner                 UserType     = "owner"
+	Member                UserType     = "member"
+	DashboardResourceType ResourceType = "dashboard"
+	BucketResourceType    ResourceType = "bucket"
 )
 
 // UserResourceMappingService maps the relationships between users and resources
@@ -26,9 +29,10 @@ type UserResourceMappingService interface {
 
 // UserResourceMapping represents a mapping of a resource to its user
 type UserResourceMapping struct {
-	ResourceID ID       `json:"resource_id"`
-	UserID     ID       `json:"user_id"`
-	UserType   UserType `json:"user_type"`
+	ResourceID   ID           `json:"resource_id"`
+	ResourceType ResourceType `json:"resource_type"`
+	UserID       ID           `json:"user_id"`
+	UserType     UserType     `json:"user_type"`
 }
 
 // Validate reports any validation errors for the mapping.
@@ -47,7 +51,8 @@ func (m UserResourceMapping) Validate() error {
 
 // UserResourceMapping represents a set of filters that restrict the returned results.
 type UserResourceMappingFilter struct {
-	ResourceID ID
-	UserID     ID
-	UserType   UserType
+	ResourceID   ID
+	ResourceType ResourceType
+	UserID       ID
+	UserType     UserType
 }

--- a/user_resource_mapping.go
+++ b/user_resource_mapping.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 type UserType string
@@ -38,16 +39,18 @@ type UserResourceMapping struct {
 // Validate reports any validation errors for the mapping.
 func (m UserResourceMapping) Validate() error {
 	if len(m.ResourceID) == 0 {
-		return errors.New("ResourceID is required")
+		return errors.New("resourceID is required")
 	}
 	if len(m.UserID) == 0 {
-		return errors.New("UserID is required")
+		return errors.New("userID is required")
 	}
 	if m.UserType != Owner && m.UserType != Member {
-		return errors.New("A valid user type is required")
+		return errors.New("a valid user type is required")
 	}
-	if m.ResourceType != DashboardResourceType && m.ResourceType != BucketResourceType {
-		return errors.New("A valid resource type is required")
+	switch m.ResourceType {
+	case DashboardResourceType, BucketResourceType:
+	default:
+		return fmt.Errorf("a valid resource type is required")
 	}
 	return nil
 }

--- a/user_resource_mapping.go
+++ b/user_resource_mapping.go
@@ -46,6 +46,9 @@ func (m UserResourceMapping) Validate() error {
 	if m.UserType != Owner && m.UserType != Member {
 		return errors.New("A valid user type is required")
 	}
+	if m.ResourceType != DashboardResourceType && m.ResourceType != BucketResourceType {
+		return errors.New("A valid resource type is required")
+	}
 	return nil
 }
 

--- a/user_resource_mapping_test.go
+++ b/user_resource_mapping_test.go
@@ -6,9 +6,10 @@ import (
 
 func TestOwnerMappingValidate(t *testing.T) {
 	type fields struct {
-		ResourceID ID
-		UserID     ID
-		UserType   UserType
+		ResourceID   ID
+		ResourceType ResourceType
+		UserID       ID
+		UserType     UserType
 	}
 	tests := []struct {
 		name    string
@@ -18,33 +19,56 @@ func TestOwnerMappingValidate(t *testing.T) {
 		{
 			name: "mapping requires a resourceid",
 			fields: fields{
-				UserID:   []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
-				UserType: Owner,
+				UserID:       []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserType:     Owner,
+				ResourceType: DashboardResourceType,
 			},
 			wantErr: true,
 		},
 		{
-			name: "mapping requires an Owner",
+			name: "mapping requires a userid",
 			fields: fields{
-				ResourceID: []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
-				UserType:   Owner,
+				ResourceID:   []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserType:     Owner,
+				ResourceType: DashboardResourceType,
 			},
 			wantErr: true,
 		},
 		{
 			name: "mapping requires a usertype",
 			fields: fields{
+				ResourceID:   []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserID:       []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				ResourceType: DashboardResourceType,
+			},
+			wantErr: true,
+		},
+		{
+			name: "mapping requires a resourcetype",
+			fields: fields{
 				ResourceID: []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
 				UserID:     []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserType:   Owner,
 			},
 			wantErr: true,
 		},
 		{
 			name: "the usertype provided must be valid",
 			fields: fields{
-				ResourceID: []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
-				UserID:     []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
-				UserType:   "foo",
+				ResourceID:   []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserID:       []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserType:     "foo",
+				ResourceType: DashboardResourceType,
+			},
+			wantErr: true,
+		},
+		{
+			name: "the resourcetype provided must be valid",
+			fields: fields{
+				ResourceID:   []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserID:       []byte{0xde, 0xba, 0xc1, 0xe0, 0xde, 0xad, 0xbe, 0xef},
+				UserType:     Owner,
+				ResourceType: "foo",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
`GET /dashboards` now takes `ids` and `owner` params, so that a request can filter on dashboards that belong to an owner, or a slice of dashboard ids.

closes #924.