### PR TITLE
Properly handle spaces in PATH with make tasks

### DIFF
--- a/query/promql/Makefile
+++ b/query/promql/Makefile
@@ -1,7 +1,7 @@
 all: promql.go
 
 promql.go: promql.peg gen.go ../../bin/$(GOOS)/pigeon
-	PATH=../../bin/${GOOS}:${PATH} go generate -x ./...
+	PATH="../../bin/${GOOS}:${PATH}" go generate -x ./...
 
 clean:
 	rm -f promql.go

--- a/task/backend/Makefile
+++ b/task/backend/Makefile
@@ -3,7 +3,7 @@ targets := meta.pb.go
 all: $(targets)
 
 $(targets): meta.proto
-	PATH=../../../../../bin/${GOOS}:${PATH} $(GO_GENERATE) -x ./
+	PATH="../../../../../bin/${GOOS}:${PATH}" $(GO_GENERATE) -x ./
 
 clean:
 	rm -f $(targets)


### PR DESCRIPTION
`make run` currently fails if you have anything in `PATH` with spaces, this change handles those cases 

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)