### PR TITLE
fix(storage): Add db/rp fields for InfluxDB OSS

### DIFF
--- a/query/functions/inputs/storage/storage.go
+++ b/query/functions/inputs/storage/storage.go
@@ -201,6 +201,9 @@ type ReadSpec struct {
 	// When GroupMode is GroupModeBy, the results will be grouped by the specified keys.
 	// When GroupMode is GroupModeExcept, the results will be grouped by all keys, except those specified.
 	GroupKeys []string
+
+	Database        string // required by InfluxDB OSS
+	RetentionPolicy string // required by InfluxDB OSS
 }
 
 type Reader interface {


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_

Add `Database` and `RetentionPolicy` fields to the `storage.ReadSpec` struct

_What was the problem?_

The `platform.ID` type was changed from `[]byte` to `uint64`. Previously, InfluxDB was using the `ReadSpec.BucketID` field to encode the database and retention policy for a `from` request. This is no longer possible in a `uint64`, which prevents any future updates to the flux and platform repositories in influxdb OSS.

_What was the solution?_

Adding `Database` and `RetentionPolicy` fields to the `storage.ReadSpec` struct permits the OSS implementation of Flux to assign Database and RetentionPolicy values.