### PR TITLE
Add tsi1 measurement cardinality stats.

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -374,3 +374,13 @@ func (e *Engine) ApplyFnToSeriesIDSet(fn func(*tsdb.SeriesIDSet)) {
 	}
 	fn(e.index.SeriesIDSet())
 }
+
+// MeasurementCardinalityStats returns cardinality stats for all measurements.
+func (e *Engine) MeasurementCardinalityStats() tsi1.MeasurementCardinalityStats {
+	return e.index.MeasurementCardinalityStats()
+}
+
+// MeasurementStats returns the current measurement stats for the engine.
+func (e *Engine) MeasurementStats() (tsm1.MeasurementStats, error) {
+	return e.engine.MeasurementStats()
+}

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -192,6 +192,20 @@ func (f *SeriesFile) SeriesKey(id SeriesID) []byte {
 	return p.SeriesKey(id)
 }
 
+// SeriesKeyName returns the measurement name for a series id.
+func (f *SeriesFile) SeriesKeyName(id SeriesID) []byte {
+	if id.IsZero() {
+		return nil
+	}
+	data := f.SeriesIDPartition(id).SeriesKey(id)
+	if data == nil {
+		return nil
+	}
+	_, data = ReadSeriesKeyLen(data)
+	name, _ := ReadSeriesKeyMeasurement(data)
+	return name
+}
+
 // SeriesKeys returns a list of series keys from a list of ids.
 func (f *SeriesFile) SeriesKeys(ids []SeriesID) [][]byte {
 	keys := make([][]byte, len(ids))

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -1080,6 +1080,18 @@ func (i *Index) SetFieldName(measurement []byte, name string) {}
 // Rebuild rebuilds an index. It's a no-op for this index.
 func (i *Index) Rebuild() {}
 
+// MeasurementCardinalityStats returns cardinality stats for all measurements.
+func (i *Index) MeasurementCardinalityStats() MeasurementCardinalityStats {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	stats := NewMeasurementCardinalityStats()
+	for _, p := range i.partitions {
+		stats.Add(p.MeasurementCardinalityStats())
+	}
+	return stats
+}
+
 // IsIndexDir returns true if directory contains at least one partition directory.
 func IsIndexDir(path string) (bool, error) {
 	fis, err := ioutil.ReadDir(path)

--- a/tsdb/tsi1/stats.go
+++ b/tsdb/tsi1/stats.go
@@ -1,0 +1,233 @@
+package tsi1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"sort"
+
+	"github.com/influxdata/platform/pkg/binaryutil"
+)
+
+const (
+	// MeasurementCardinalityStatsMagicNumber is written as the first 4 bytes
+	// of a data file to identify the file as a tsi1 cardinality file.
+	MeasurementCardinalityStatsMagicNumber string = "TSIS"
+
+	// MeasurementCardinalityVersion indicates the version of the TSIC file format.
+	MeasurementCardinalityStatsVersion byte = 1
+)
+
+// MeasurementCardinalityStats represents a set of measurement sizes.
+type MeasurementCardinalityStats map[string]int
+
+// NewMeasurementCardinality returns a new instance of MeasurementCardinality.
+func NewMeasurementCardinalityStats() MeasurementCardinalityStats {
+	return make(MeasurementCardinalityStats)
+}
+
+// MeasurementNames returns a list of sorted measurement names.
+func (s MeasurementCardinalityStats) MeasurementNames() []string {
+	a := make([]string, 0, len(s))
+	for name := range s {
+		a = append(a, name)
+	}
+	sort.Strings(a)
+	return a
+}
+
+// Inc increments a measurement count by 1.
+func (s MeasurementCardinalityStats) Inc(name []byte) {
+	s[string(name)]++
+}
+
+// Dec decrements a measurement count by 1. Deleted if zero.
+func (s MeasurementCardinalityStats) Dec(name []byte) {
+	v := s[string(name)]
+	if v == 1 {
+		delete(s, string(name))
+	} else {
+		s[string(name)] = v - 1
+	}
+}
+
+// Add adds the values of all measurements in other to s.
+func (s MeasurementCardinalityStats) Add(other MeasurementCardinalityStats) {
+	for name, v := range other {
+		s[name] += v
+	}
+}
+
+// Sub subtracts the values of all measurements in other from s.
+func (s MeasurementCardinalityStats) Sub(other MeasurementCardinalityStats) {
+	for name, v := range other {
+		s[name] -= v
+	}
+}
+
+// Clone returns a copy of s.
+func (s MeasurementCardinalityStats) Clone() MeasurementCardinalityStats {
+	other := make(MeasurementCardinalityStats, len(s))
+	for k, v := range s {
+		other[k] = v
+	}
+	return other
+}
+
+// ReadFrom reads stats from r in a binary format. Reader must also be an io.ByteReader.
+func (s MeasurementCardinalityStats) ReadFrom(r io.Reader) (n int64, err error) {
+	br, ok := r.(io.ByteReader)
+	if !ok {
+		return 0, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: ByteReader required")
+	}
+
+	// Read & verify magic.
+	magic := make([]byte, 4)
+	nn, err := io.ReadFull(r, magic)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: cannot read stats magic: %s", err)
+	} else if string(magic) != MeasurementCardinalityStatsMagicNumber {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: invalid tsm1 stats file")
+	}
+
+	// Read & verify version.
+	version := make([]byte, 1)
+	nn, err = io.ReadFull(r, version)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: cannot read stats version: %s", err)
+	} else if version[0] != MeasurementCardinalityStatsVersion {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: incompatible tsm1 stats version: %d", version[0])
+	}
+
+	// Read checksum.
+	checksum := make([]byte, 4)
+	nn, err = io.ReadFull(r, checksum)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: cannot read checksum: %s", err)
+	}
+
+	// Read measurement count.
+	measurementN, err := binary.ReadVarint(br)
+	if err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: cannot read stats measurement count: %s", err)
+	}
+	n += int64(binaryutil.VarintSize(measurementN))
+
+	// Read measurements.
+	for i := int64(0); i < measurementN; i++ {
+		nn64, err := s.readMeasurementFrom(r)
+		if n += nn64; err != nil {
+			return n, err
+		}
+	}
+
+	// Expect end-of-file.
+	buf := make([]byte, 1)
+	if _, err := r.Read(buf); err != io.EOF {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.ReadFrom: file too large, expected EOF")
+	}
+
+	return n, nil
+}
+
+// readMeasurementFrom reads a measurement stat from r in a binary format.
+func (s MeasurementCardinalityStats) readMeasurementFrom(r io.Reader) (n int64, err error) {
+	br, ok := r.(io.ByteReader)
+	if !ok {
+		return 0, fmt.Errorf("tsm1.MeasurementCardinalityStats.readMeasurementFrom: ByteReader required")
+	}
+
+	// Read measurement name length.
+	nameLen, err := binary.ReadVarint(br)
+	if err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.readMeasurementFrom: cannot read stats measurement name length: %s", err)
+	}
+	n += int64(binaryutil.VarintSize(nameLen))
+
+	// Read measurement name. Use large capacity so it can usually be stack allocated.
+	// Go allocates unescaped variables smaller than 64KB on the stack.
+	name := make([]byte, nameLen)
+	nn, err := io.ReadFull(r, name)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.readMeasurementFrom: cannot read stats measurement name: %s", err)
+	}
+
+	// Read size.
+	sz, err := binary.ReadVarint(br)
+	if err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementCardinalityStats.readMeasurementFrom: cannot read stats measurement size: %s", err)
+	}
+	n += int64(binaryutil.VarintSize(sz))
+
+	// Insert into map.
+	s[string(name)] = int(sz)
+
+	return n, nil
+}
+
+// WriteTo writes stats to w in a binary format.
+func (s MeasurementCardinalityStats) WriteTo(w io.Writer) (n int64, err error) {
+	// Write magic & version.
+	nn, err := io.WriteString(w, MeasurementCardinalityStatsMagicNumber)
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+	nn, err = w.Write([]byte{MeasurementCardinalityStatsVersion})
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	// Write measurement count.
+	var buf bytes.Buffer
+	b := make([]byte, binary.MaxVarintLen64)
+	if _, err = buf.Write(b[:binary.PutVarint(b, int64(len(s)))]); err != nil {
+		return n, err
+	}
+
+	// Write all measurements in sorted order.
+	for _, name := range s.MeasurementNames() {
+		if _, err := s.writeMeasurementTo(&buf, name, s[name]); err != nil {
+			return n, err
+		}
+	}
+	data := buf.Bytes()
+
+	// Compute & write checksum.
+	if err := binary.Write(w, binary.BigEndian, crc32.ChecksumIEEE(data)); err != nil {
+		return n, err
+	}
+	n += 4
+
+	// Write buffer.
+	nn, err = w.Write(data)
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	return n, err
+}
+
+func (s MeasurementCardinalityStats) writeMeasurementTo(w io.Writer, name string, sz int) (n int64, err error) {
+	// Write measurement name length.
+	buf := make([]byte, binary.MaxVarintLen64)
+	nn, err := w.Write(buf[:binary.PutVarint(buf, int64(len(name)))])
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	// Write measurement name.
+	nn, err = io.WriteString(w, name)
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	// Write size.
+	nn, err = w.Write(buf[:binary.PutVarint(buf, int64(sz))])
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	return n, err
+}

--- a/tsdb/tsi1/stats_test.go
+++ b/tsdb/tsi1/stats_test.go
@@ -1,0 +1,42 @@
+package tsi1_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/platform/tsdb/tsi1"
+)
+
+func TestMeasurementCardinalityStats_WriteTo(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		stats, other := tsi1.NewMeasurementCardinalityStats(), tsi1.NewMeasurementCardinalityStats()
+		var buf bytes.Buffer
+		if wn, err := stats.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		} else if rn, err := other.ReadFrom(&buf); err != nil {
+			t.Fatal(err)
+		} else if wn != rn {
+			t.Fatalf("byte count mismatch: w=%d r=%d", wn, rn)
+		} else if diff := cmp.Diff(stats, other); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("WithData", func(t *testing.T) {
+		stats, other := tsi1.NewMeasurementCardinalityStats(), tsi1.NewMeasurementCardinalityStats()
+		stats["cpu"] = 100
+		stats["mem"] = 2000
+
+		var buf bytes.Buffer
+		if wn, err := stats.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		} else if rn, err := other.ReadFrom(&buf); err != nil {
+			t.Fatal(err)
+		} else if wn != rn {
+			t.Fatalf("byte count mismatch: w=%d r=%d", wn, rn)
+		} else if diff := cmp.Diff(stats, other); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Adds per-measurement cardinality stats to the TSI1 index.

_What was the problem?_

We need to quickly be able to fetch the number of series for every measurement in the system.

_What was the solution?_

This commit adds `MeasurementCardinalityStats` to `tsi1.Index`. The stats are maintained in each partition and all stats not in the non-active log file are written to disk on every compaction. At query time, every partition merges the non-active log file stats and the active log file stats and then the index merges every partition stats.

_Note: I need to rework the `LogFile` stats computation because there is a race condition where a series inserted and deleted in the same log file is double decremented.


  - [x] Rebased/mergeable
  - [x] Tests pass
