### PR TITLE
Add CreatedAt and UpdatedAt fields to dashboards

### DIFF
--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -32,6 +32,7 @@ type Client struct {
 
 	IDGenerator    platform.IDGenerator
 	TokenGenerator platform.TokenGenerator
+	time           func() time.Time
 }
 
 // NewClient returns an instance of a Client.
@@ -40,6 +41,7 @@ func NewClient() *Client {
 		Logger:         zap.NewNop(),
 		IDGenerator:    snowflake.NewIDGenerator(),
 		TokenGenerator: rand.NewTokenGenerator(64),
+		time:           time.Now,
 	}
 }
 
@@ -52,6 +54,12 @@ func (c *Client) DB() *bolt.DB {
 // the client has been open.
 func (c *Client) WithLogger(l *zap.Logger) {
 	c.Logger = l
+}
+
+// WithTime sets the function for computing the current time. Used for updating meta data
+// about objects stored. Should only be used in tests for mocking.
+func (c *Client) WithTime(fn func() time.Time) {
+	c.time = fn
 }
 
 // Open / create boltDB file.

--- a/bolt/dashboard_test.go
+++ b/bolt/dashboard_test.go
@@ -14,6 +14,7 @@ func initDashboardService(f platformtesting.DashboardFields, t *testing.T) (plat
 		t.Fatalf("failed to create new bolt client: %v", err)
 	}
 	c.IDGenerator = f.IDGenerator
+	c.WithTime(f.NowFn)
 	ctx := context.TODO()
 	for _, b := range f.Dashboards {
 		if err := c.PutDashboard(ctx, b); err != nil {

--- a/dashboard.go
+++ b/dashboard.go
@@ -3,6 +3,8 @@ package platform
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
 )
 
 // ErrDashboardNotFound is the error for a missing dashboard.
@@ -18,7 +20,7 @@ type DashboardService interface {
 
 	// FindDashboards returns a list of dashboards that match filter and the total count of matching dashboards.
 	// Additional options provide pagination & sorting.
-	FindDashboards(ctx context.Context, filter DashboardFilter) ([]*Dashboard, int, error)
+	FindDashboards(ctx context.Context, filter DashboardFilter, opts FindOptions) ([]*Dashboard, int, error)
 
 	// CreateDashboard creates a new dashboard and sets b.ID with the new identifier.
 	CreateDashboard(ctx context.Context, b *Dashboard) error
@@ -45,10 +47,47 @@ type DashboardService interface {
 
 // Dashboard represents all visual and query data for a dashboard
 type Dashboard struct {
-	ID          ID      `json:"id,omitempty"`
-	Name        string  `json:"name"`
-	Description string  `json:"description"`
-	Cells       []*Cell `json:"cells"`
+	ID          ID            `json:"id,omitempty"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Cells       []*Cell       `json:"cells"`
+	Meta        DashboardMeta `json:"meta"`
+}
+
+// Dashboard meta contains meta information about dashboards
+type DashboardMeta struct {
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// DefaultDashboardFindOptions are the default find options for dashboards
+var DefaultDashboardFindOptions = FindOptions{
+	SortBy: "ID",
+}
+
+// SortDashboards sorts a slice of dashboards by a field.
+func SortDashboards(by string, ds []*Dashboard) {
+	var sorter func(i, j int) bool
+	switch by {
+	case "CreatedAt":
+		sorter = func(i, j int) bool {
+			return ds[j].Meta.CreatedAt.After(ds[i].Meta.CreatedAt)
+		}
+	case "UpdatedAt":
+		sorter = func(i, j int) bool {
+			return ds[j].Meta.UpdatedAt.After(ds[i].Meta.UpdatedAt)
+		}
+	case "Name":
+		sorter = func(i, j int) bool {
+			return ds[i].Name < ds[j].Name
+		}
+	default:
+		sorter = func(i, j int) bool {
+			return ds[i].ID < ds[j].ID
+		}
+	}
+
+	sort.Slice(ds, sorter)
 }
 
 // Cell holds positional information about a cell on dashboard and a reference to a cell.

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/inmem"
@@ -40,12 +41,16 @@ func TestService_handleGetDashboards(t *testing.T) {
 			name: "get all dashboards",
 			fields: fields{
 				&mock.DashboardService{
-					FindDashboardsF: func(ctx context.Context, filter platform.DashboardFilter) ([]*platform.Dashboard, int, error) {
+					FindDashboardsF: func(ctx context.Context, filter platform.DashboardFilter, opts platform.FindOptions) ([]*platform.Dashboard, int, error) {
 						return []*platform.Dashboard{
 							{
 								ID:          platformtesting.MustIDBase16("da7aba5e5d81e550"),
 								Name:        "hello",
 								Description: "oh hello there!",
+								Meta: platform.DashboardMeta{
+									CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+									UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
+								},
 								Cells: []*platform.Cell{
 									{
 										ID:     platformtesting.MustIDBase16("da7aba5e5d81e550"),
@@ -58,7 +63,11 @@ func TestService_handleGetDashboards(t *testing.T) {
 								},
 							},
 							{
-								ID:   platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								ID: platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								Meta: platform.DashboardMeta{
+									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
+									UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
+								},
 								Name: "example",
 							},
 						}, 2, nil
@@ -79,6 +88,10 @@ func TestService_handleGetDashboards(t *testing.T) {
       "id": "da7aba5e5d81e550",
       "name": "hello",
       "description": "oh hello there!",
+      "meta": {
+        "createdAt": "2009-11-10T23:00:00Z",
+        "updatedAt": "2009-11-11T00:00:00Z"
+      },
       "cells": [
         {
           "id": "da7aba5e5d81e550",
@@ -102,6 +115,10 @@ func TestService_handleGetDashboards(t *testing.T) {
       "id": "0ca2204eca2204e0",
       "name": "example",
       "description": "",
+      "meta": {
+        "createdAt": "2012-11-10T23:00:00Z",
+        "updatedAt": "2012-11-11T00:00:00Z"
+      },
       "cells": [],
       "links": {
         "self": "/api/v2/dashboards/0ca2204eca2204e0",
@@ -117,7 +134,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 			name: "get all dashboards when there are none",
 			fields: fields{
 				&mock.DashboardService{
-					FindDashboardsF: func(ctx context.Context, filter platform.DashboardFilter) ([]*platform.Dashboard, int, error) {
+					FindDashboardsF: func(ctx context.Context, filter platform.DashboardFilter, opts platform.FindOptions) ([]*platform.Dashboard, int, error) {
 						return []*platform.Dashboard{}, 0, nil
 					},
 				},
@@ -201,7 +218,11 @@ func TestService_handleGetDashboard(t *testing.T) {
 					FindDashboardByIDF: func(ctx context.Context, id platform.ID) (*platform.Dashboard, error) {
 						if id == platformtesting.MustIDBase16("020f755c3c082000") {
 							return &platform.Dashboard{
-								ID:   platformtesting.MustIDBase16("020f755c3c082000"),
+								ID: platformtesting.MustIDBase16("020f755c3c082000"),
+								Meta: platform.DashboardMeta{
+									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
+									UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
+								},
 								Name: "hello",
 								Cells: []*platform.Cell{
 									{
@@ -231,6 +252,10 @@ func TestService_handleGetDashboard(t *testing.T) {
   "id": "020f755c3c082000",
   "name": "hello",
   "description": "",
+  "meta": {
+    "createdAt": "2012-11-10T23:00:00Z",
+    "updatedAt": "2012-11-11T00:00:00Z"
+  },
   "cells": [
     {
       "id": "da7aba5e5d81e550",
@@ -335,6 +360,10 @@ func TestService_handlePostDashboard(t *testing.T) {
 				&mock.DashboardService{
 					CreateDashboardF: func(ctx context.Context, c *platform.Dashboard) error {
 						c.ID = platformtesting.MustIDBase16("020f755c3c082000")
+						c.Meta = platform.DashboardMeta{
+							CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
+							UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
+						}
 						return nil
 					},
 				},
@@ -364,6 +393,10 @@ func TestService_handlePostDashboard(t *testing.T) {
   "id": "020f755c3c082000",
   "name": "hello",
   "description": "howdy there",
+  "meta": {
+    "createdAt": "2012-11-10T23:00:00Z",
+    "updatedAt": "2012-11-11T00:00:00Z"
+  },
   "cells": [
     {
       "id": "da7aba5e5d81e550",
@@ -547,6 +580,10 @@ func TestService_handlePatchDashboard(t *testing.T) {
 							d := &platform.Dashboard{
 								ID:   platformtesting.MustIDBase16("020f755c3c082000"),
 								Name: "hello",
+								Meta: platform.DashboardMeta{
+									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
+									UpdatedAt: time.Date(2012, time.November, 10, 25, 0, 0, 0, time.UTC),
+								},
 								Cells: []*platform.Cell{
 									{
 										ID:     platformtesting.MustIDBase16("da7aba5e5d81e550"),
@@ -582,6 +619,10 @@ func TestService_handlePatchDashboard(t *testing.T) {
   "id": "020f755c3c082000",
   "name": "example",
   "description": "",
+  "meta": {
+    "createdAt": "2012-11-10T23:00:00Z",
+    "updatedAt": "2012-11-11T01:00:00Z"
+  },
   "cells": [
     {
       "id": "da7aba5e5d81e550",
@@ -1032,11 +1073,11 @@ func initDashboardService(f platformtesting.DashboardFields, t *testing.T) (plat
 	t.Helper()
 	svc := inmem.NewService()
 	svc.IDGenerator = f.IDGenerator
-
+	svc.WithTime(f.NowFn)
 	ctx := context.Background()
-	for _, o := range f.Dashboards {
-		if err := svc.PutDashboard(ctx, o); err != nil {
-			t.Fatalf("failed to populate organizations")
+	for _, d := range f.Dashboards {
+		if err := svc.PutDashboard(ctx, d); err != nil {
+			t.Fatalf("failed to populate dashboard")
 		}
 	}
 	for _, b := range f.Views {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1015,6 +1015,15 @@ paths:
             schema:
               type: string
           - in: query
+            name: sortBy
+            description: specifies the owner id to return resources for
+            schema:
+              type: string
+              enum:
+                - "ID"
+                - "CreatedAt"
+                - "UpdatedAt"
+          - in: query
             name: id
             description: ID list of dashboards to return. If both this and owner are specified, only ids is used.
             schema:
@@ -4397,6 +4406,15 @@ components:
         description:
           type: string
           description: user-facing description of the dashboard
+        meta:
+          type: object
+          properties:
+            createdAt:
+              type: string
+              format: date
+            updatedAt:
+              type: string
+              format: date
         cells:
             $ref: "#/components/schemas/Cells"
     Dashboards:
@@ -4493,7 +4511,7 @@ components:
               type:
                 type: string
                 enum: [input, output, processor, aggregator]
-              comment: 
+              comment:
                 type: string
               config:
                 oneOf:
@@ -4649,7 +4667,7 @@ components:
         bucket:
           type: string
         retentionPeriodHrs:
-          type: integer  
+          type: integer
       required:
         - username
         - password

--- a/inmem/dashboard_test.go
+++ b/inmem/dashboard_test.go
@@ -12,6 +12,7 @@ func initDashboardService(f platformtesting.DashboardFields, t *testing.T) (plat
 	s := NewService()
 	s.IDGenerator = f.IDGenerator
 	ctx := context.Background()
+	s.WithTime(f.NowFn)
 	for _, b := range f.Dashboards {
 		if err := s.PutDashboard(ctx, b); err != nil {
 			t.Fatalf("failed to populate Dashboards")

--- a/inmem/service.go
+++ b/inmem/service.go
@@ -2,6 +2,7 @@ package inmem
 
 import (
 	"sync"
+	"time"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/rand"
@@ -24,6 +25,7 @@ type Service struct {
 
 	TokenGenerator platform.TokenGenerator
 	IDGenerator    platform.IDGenerator
+	time           func() time.Time
 }
 
 // NewService creates an instance of a Service.
@@ -31,5 +33,12 @@ func NewService() *Service {
 	return &Service{
 		TokenGenerator: rand.NewTokenGenerator(64),
 		IDGenerator:    snowflake.NewIDGenerator(),
+		time:           time.Now,
 	}
+}
+
+// WithTime sets the function for computing the current time. Used for updating meta data
+// about objects stored. Should only be used in tests for mocking.
+func (s *Service) WithTime(fn func() time.Time) {
+	s.time = fn
 }

--- a/mock/dashboard_service.go
+++ b/mock/dashboard_service.go
@@ -11,7 +11,7 @@ var _ platform.DashboardService = &DashboardService{}
 type DashboardService struct {
 	CreateDashboardF   func(context.Context, *platform.Dashboard) error
 	FindDashboardByIDF func(context.Context, platform.ID) (*platform.Dashboard, error)
-	FindDashboardsF    func(context.Context, platform.DashboardFilter) ([]*platform.Dashboard, int, error)
+	FindDashboardsF    func(context.Context, platform.DashboardFilter, platform.FindOptions) ([]*platform.Dashboard, int, error)
 	UpdateDashboardF   func(context.Context, platform.ID, platform.DashboardUpdate) (*platform.Dashboard, error)
 	DeleteDashboardF   func(context.Context, platform.ID) error
 
@@ -26,8 +26,8 @@ func (s *DashboardService) FindDashboardByID(ctx context.Context, id platform.ID
 	return s.FindDashboardByIDF(ctx, id)
 }
 
-func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.DashboardFilter) ([]*platform.Dashboard, int, error) {
-	return s.FindDashboardsF(ctx, filter)
+func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.DashboardFilter, opts platform.FindOptions) ([]*platform.Dashboard, int, error) {
+	return s.FindDashboardsF(ctx, filter, opts)
 }
 
 func (s *DashboardService) CreateDashboard(ctx context.Context, b *platform.Dashboard) error {


### PR DESCRIPTION
Closes #1098

_Briefly describe your proposed changes:_
This PR introduces the meta fields `CreatedAt` and `UpdatedAt` to dashboards. Additionally it allows the user to specify if they would like to sort the results by those fields.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)