### PR TITLE
fix(logs/wrap): fix logs wrap message

### DIFF
--- a/chronograf/ui/src/logs/containers/logs_page/LogsPage.tsx
+++ b/chronograf/ui/src/logs/containers/logs_page/LogsPage.tsx
@@ -58,6 +58,7 @@ interface DispatchTableConfigProps {
   getConfig: typeof logActions.getLogConfigAsync
   getSources: typeof getSourcesAsync
   addFilter: typeof logActions.addFilter // TODO: update addFilters
+  setConfig: typeof logActions.setConfig
   updateConfig: typeof logActions.updateLogConfigAsync
   createConfig: typeof logActions.createLogConfigAsync
   removeFilter: typeof logActions.removeFilter
@@ -355,7 +356,7 @@ class LogsPage extends Component<Props, State> {
   private handleUpdateTruncation = (isTruncated: boolean) => {
     const {logConfig} = this.props
 
-    this.props.updateConfig({
+    this.props.setConfig({
       ...logConfig,
       isTruncated,
     })
@@ -523,6 +524,7 @@ const mdtp: DispatchProps = {
   changeFilter: logActions.changeFilter,
   clearFilters: logActions.clearFilters,
   getConfig: logActions.getLogConfigAsync,
+  setConfig: logActions.setConfig,
   setSearchStatus: logActions.setSearchStatus,
   setBucketAsync: logActions.setBucketAsync,
   getSourceAndPopulateBuckets: logActions.getSourceAndPopulateBucketsAsync,


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/174

_Briefly describe your proposed changes:_
Updates logs page to not use updateConfig for local config state
_What was the problem?_
Using updateConfig for truncation would attempt to patch a non-existent log config 
_What was the solution?_
Use setConfig for local config state updates and use save/update config for the overlay changes

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass