### PR TITLE
storage: MeasurementStats.ReadFrom requires ByteReader

### DIFF
--- a/tsdb/tsm1/reader.go
+++ b/tsdb/tsm1/reader.go
@@ -1,6 +1,7 @@
 package tsm1
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
@@ -370,7 +371,7 @@ func (t *TSMReader) MeasurementStats() (MeasurementStats, error) {
 	defer f.Close()
 
 	stats := make(MeasurementStats)
-	if _, err := stats.ReadFrom(f); err != nil {
+	if _, err := stats.ReadFrom(bufio.NewReader(f)); err != nil {
 		return nil, err
 	}
 	return stats, err


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Fix call to `MeasurementStats.ReadFrom(io.Reader)`

_What was the problem?_
`MeasurementStats.ReadFrom(io.Reader)` takes a `ByteReader`, but we were calling with a `Reader`.

_What was the solution?_
Wrap the Reader in `bufio.NewReader`

  - [x] Rebased/mergeable
  - [ ] Tests pass