### PR TITLE
Fix loading empty state

### DIFF
--- a/chronograf/ui/src/logs/components/loading_status/LoadingStatus.tsx
+++ b/chronograf/ui/src/logs/components/loading_status/LoadingStatus.tsx
@@ -1,5 +1,7 @@
 import React, {PureComponent} from 'react'
 
+import {EmptyState, ComponentSpacer,Alignment ComponentSize} from 'src/clockface'
+
 import {SearchStatus} from 'src/types/logs'
 import {formatTime} from 'src/logs/utils'
 
@@ -12,11 +14,18 @@ interface Props {
 class LoadingStatus extends PureComponent<Props> {
   public render() {
     return (
-      <div className="logs-viewer--table-container generic-empty-state">
-        {this.loadingSpinner}
-        <h4>
-          {this.loadingMessage} {this.description}
-        </h4>
+      <div className="logs-viewer--table-container">
+        <EmptyState size={ComponentSize.Large}>
+          {this.loadingSpinner}
+          <h4>
+          <ComponentSpacer align={Alignment.Center}>
+            <>{this.loadingMessage}</>
+            </ComponentSpacer>
+            <ComponentSpacer align={Alignment.Center}>
+            <>{this.description}</>
+          </ComponentSpacer>
+          </h4>
+        </EmptyState>
       </div>
     )
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/176

_Briefly describe your proposed changes:_
The loading message is centered using the alignment and empty state clockface components
_What was the problem?_
The component was previously expecting a `generic-empty-state` class to center itself
_What was the solution?_
Utilize the clockface components for empty state and alignment instead.

  - [x] Rebased/mergeable
  - [x] Make tests pass