### PR TITLE
feat(http): buckets now have multiple retention rules

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3388,11 +3388,9 @@ components:
           $ref: "#/components/schemas/Owners"
         name:
           type: string
-        retentionPeriods:
+        retentionRules:
           type: array
-          default:
-            type: expire
-            duration: "infinite"
+          description: rules to expire or retain data.  No rules means data never expires.
           items:
             type: object
             properties:
@@ -3401,12 +3399,13 @@ components:
                 default: expire
                 enum:
                   - expire
-              duration:
-                type: string
-                description: durations are an extension of the golang duration syntax
-                example: 1d
-                default: "infinite"
-      required: [organizationID, name, retentionPeriod]
+              everySeconds:
+                type: integer
+                description: duration in seconds for how long data will be kept in the database.
+                example: 86400
+                minimum: 1
+            required: [type, everySeconds]
+      required: [name, retentionRules]
     Buckets:
       type: object
       properties:


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
Bucket retentions are now rules.  Currently, only one rule is allowed, but, this gives us flexibility in the future.  No rules indicate infinite retention.

_What was the problem?_
Retention policies were time durations and were not flexible enough to express more than one rule

_What was the solution?_
Many rules and rule types

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)