### PR TITLE
feat(bolt): clean up user resource mappings after deleting resources

### DIFF
--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -419,5 +419,11 @@ func (c *Client) deleteBucket(ctx context.Context, tx *bolt.Tx, id platform.ID) 
 	if err != nil {
 		return err
 	}
-	return tx.Bucket(bucketBucket).Delete(encodedID)
+	if err := tx.Bucket(bucketBucket).Delete(encodedID); err != nil {
+		return err
+	}
+	return c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
+		ResourceID:   id,
+		ResourceType: platform.BucketResourceType,
+	})
 }

--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -422,5 +422,11 @@ func (c *Client) deleteDashboard(ctx context.Context, tx *bolt.Tx, id platform.I
 	if err != nil {
 		return err
 	}
-	return tx.Bucket(dashboardBucket).Delete(encodedID)
+	if err := tx.Bucket(dashboardBucket).Delete(encodedID); err != nil {
+		return err
+	}
+	return c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
+		ResourceID:   id,
+		ResourceType: platform.DashboardResourceType,
+	})
 }

--- a/bolt/user.go
+++ b/bolt/user.go
@@ -318,7 +318,12 @@ func (c *Client) deleteUser(ctx context.Context, tx *bolt.Tx, id platform.ID) er
 	if err := tx.Bucket(userIndex).Delete(userIndexKey(u.Name)); err != nil {
 		return err
 	}
-	return tx.Bucket(userBucket).Delete(encodedID)
+	if err := tx.Bucket(userBucket).Delete(encodedID); err != nil {
+		return err
+	}
+	return c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
+		UserID: id,
+	})
 }
 
 func (c *Client) deleteUsersAuthorizations(ctx context.Context, tx *bolt.Tx, id platform.ID) error {

--- a/bolt/view.go
+++ b/bolt/view.go
@@ -266,5 +266,11 @@ func (c *Client) deleteView(ctx context.Context, tx *bolt.Tx, id platform.ID) er
 	if err != nil {
 		return err
 	}
-	return tx.Bucket(viewBucket).Delete(encodedID)
+	if err := tx.Bucket(viewBucket).Delete(encodedID); err != nil {
+		return err
+	}
+	return c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
+		ResourceID:   id,
+		ResourceType: platform.ViewResourceType,
+	})
 }


### PR DESCRIPTION
When a resource is deleted, we need to make sure that its associated u/r mappings are purged. This PR fixes that.