### PR TITLE
Add local flag to influx command

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -6,8 +6,10 @@ import (
 	"os"
 
 	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/bolt"
 	"github.com/influxdata/platform/cmd/influx/internal"
 	"github.com/influxdata/platform/http"
+	"github.com/influxdata/platform/internal/fs"
 	"github.com/spf13/cobra"
 )
 
@@ -83,13 +85,13 @@ func authorizationCreateF(cmd *cobra.Command, args []string) {
 		Permissions: permissions,
 	}
 
-	s := &http.AuthorizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+	s, err := newAuthorizationService(flags)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
-	err := s.CreateAuthorization(context.Background(), authorization)
-	if err != nil {
+	if err := s.CreateAuthorization(context.Background(), authorization); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -143,10 +145,31 @@ func init() {
 	authorizationCmd.AddCommand(authorizationFindCmd)
 }
 
-func authorizationFindF(cmd *cobra.Command, args []string) {
-	s := &http.AuthorizationService{
+func newAuthorizationService(f Flags) (platform.AuthorizationService, error) {
+	if flags.local {
+		boltFile, err := fs.BoltFile()
+		if err != nil {
+			return nil, err
+		}
+		c := bolt.NewClient()
+		c.Path = boltFile
+		if err := c.Open(context.Background()); err != nil {
+			return nil, err
+		}
+
+		return c, nil
+	}
+	return &http.AuthorizationService{
 		Addr:  flags.host,
 		Token: flags.token,
+	}, nil
+}
+
+func authorizationFindF(cmd *cobra.Command, args []string) {
+	s, err := newAuthorizationService(flags)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	filter := platform.AuthorizationFilter{}
@@ -225,9 +248,10 @@ func init() {
 }
 
 func authorizationDeleteF(cmd *cobra.Command, args []string) {
-	s := &http.AuthorizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+	s, err := newAuthorizationService(flags)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	id, err := platform.IDFromString(authorizationDeleteFlags.id)
@@ -295,9 +319,10 @@ func init() {
 }
 
 func authorizationActiveF(cmd *cobra.Command, args []string) {
-	s := &http.AuthorizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+	s, err := newAuthorizationService(flags)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	var id platform.ID
@@ -365,9 +390,10 @@ func init() {
 }
 
 func authorizationInactiveF(cmd *cobra.Command, args []string) {
-	s := &http.AuthorizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+	s, err := newAuthorizationService(flags)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	var id platform.ID

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -34,6 +34,7 @@ func init() {
 type Flags struct {
 	token string
 	host  string
+	local bool
 }
 
 var flags Flags
@@ -52,6 +53,8 @@ func init() {
 	if h := viper.GetString("HOST"); h != "" {
 		flags.host = h
 	}
+
+	influxCmd.PersistentFlags().BoolVar(&flags.local, "local", false, "Run commands locally against the filesystem")
 }
 
 func influxF(cmd *cobra.Command, args []string) {

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -34,6 +34,11 @@ func init() {
 }
 
 func fluxQueryF(cmd *cobra.Command, args []string) {
+	if flags.local {
+		fmt.Println("Local flag not supported for query command")
+		os.Exit(1)
+	}
+
 	q, err := repl.LoadQuery(args[0])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/influx/repl.go
+++ b/cmd/influx/repl.go
@@ -41,6 +41,11 @@ func init() {
 }
 
 func replF(cmd *cobra.Command, args []string) {
+	if flags.local {
+		fmt.Println("Local flag not supported for repl command")
+		os.Exit(1)
+	}
+
 	if replFlags.OrgID == "" && replFlags.Org == "" {
 		fmt.Fprintln(os.Stderr, "must specify exactly one of org or org-id")
 		_ = cmd.Usage()

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -22,6 +22,11 @@ var setupCmd = &cobra.Command{
 }
 
 func setupF(cmd *cobra.Command, args []string) {
+	if flags.local {
+		fmt.Println("Local flag not supported for setup command")
+		os.Exit(1)
+	}
+
 	// check if setup is allowed
 	s := &http.SetupService{
 		Addr: flags.host,

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -21,6 +21,11 @@ var taskCmd = &cobra.Command{
 }
 
 func taskF(cmd *cobra.Command, args []string) {
+	if flags.local {
+		fmt.Println("Local flag not supported for task command")
+		os.Exit(1)
+	}
+
 	cmd.Usage()
 }
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -6,7 +6,6 @@ import (
 	nethttp "net/http"
 	_ "net/http/pprof"
 	"os"
-	"os/user"
 	"path/filepath"
 	"sync"
 	"time"
@@ -19,6 +18,7 @@ import (
 	"github.com/influxdata/platform/chronograf/server"
 	"github.com/influxdata/platform/gather"
 	"github.com/influxdata/platform/http"
+	"github.com/influxdata/platform/internal/fs"
 	"github.com/influxdata/platform/kit/cli"
 	"github.com/influxdata/platform/kit/prom"
 	"github.com/influxdata/platform/kit/signals"
@@ -43,7 +43,7 @@ import (
 )
 
 func main() {
-	dir, err := influxDir()
+	dir, err := fs.InfluxDir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to determine influx directory: %v", err)
 		os.Exit(1)
@@ -107,26 +107,6 @@ var (
 	developerMode   bool
 	enginePath      string
 )
-
-func influxDir() (string, error) {
-	var dir string
-	// By default, store meta and data files in current users home directory
-	u, err := user.Current()
-	if err == nil {
-		dir = u.HomeDir
-	} else if home := os.Getenv("HOME"); home != "" {
-		dir = home
-	} else {
-		wd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		dir = wd
-	}
-	dir = filepath.Join(dir, ".influxdbv2")
-
-	return dir, nil
-}
 
 func run() error {
 	ctx := context.Background()

--- a/internal/fs/influx_dir.go
+++ b/internal/fs/influx_dir.go
@@ -1,0 +1,59 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// InfluxDir retrieves the influxdbv2 directory.
+func InfluxDir() (string, error) {
+	var dir string
+	// By default, store meta and data files in current users home directory
+	u, err := user.Current()
+	if err == nil {
+		dir = u.HomeDir
+	} else if home := os.Getenv("HOME"); home != "" {
+		dir = home
+	} else {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		dir = wd
+	}
+	dir = filepath.Join(dir, ".influxdbv2")
+
+	return dir, nil
+}
+
+// BoltFile returns the path to the bolt file for influxdb
+func BoltFile() (string, error) {
+	dir, err := InfluxDir()
+	if err != nil {
+		return "", err
+	}
+	var file string
+	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if file != "" {
+			return fmt.Errorf("bolt file found")
+		}
+
+		if strings.Contains(p, ".bolt") {
+			file = p
+		}
+
+		return nil
+	})
+
+	if file == "" {
+		return "", fmt.Errorf("bolt file not found")
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_
This PR adds a local flag to the `influx` command that works with the data directly in the filesystem.
_What was the problem?_
People have been regularly losing their tokens and do not have a way to retrieve them.
_What was the solution?_
Add a local flag that allows users to interact directly with a local influxdb file.

  - [x] Rebased/mergeable
  - [x] Tests pass

Add support for:
- [x] organization
- [x] bucket
- [x] authorization
- [x] setup
- [x] query
- [x] task
- [x] user