### PR TITLE
http(write): support timestamp precision

### DIFF
--- a/http/errors.go
+++ b/http/errors.go
@@ -10,7 +10,9 @@ import (
 )
 
 const (
-	ErrorHeader     = "X-Influx-Error"
+	// ErrorHeader is the standard location for influx errors to be reported.
+	ErrorHeader = "X-Influx-Error"
+	// ReferenceHeader is the header for the reference error reference code.
 	ReferenceHeader = "X-Influx-Reference"
 
 	errorHeaderMaxLength = 256

--- a/models/points.go
+++ b/models/points.go
@@ -315,6 +315,16 @@ func ParseName(buf []byte) []byte {
 	return UnescapeMeasurement(name)
 }
 
+// ValidPrecision checks if the precision is known.
+func ValidPrecision(precision string) bool {
+	switch precision {
+	case "n", "ns", "u", "us", "ms", "s":
+		return true
+	default:
+		return false
+	}
+}
+
 // ParsePointsWithPrecision is similar to ParsePoints, but allows the
 // caller to provide a precision for time.
 //


### PR DESCRIPTION
Closes #1202 

_Briefly describe your proposed changes:_
Add query parameter `precision` to be specified for writing line protocol to the server.

_What was the problem?_
Swagger definition had precision, but, it was not yet supported.

_What was the solution?_
Add precision support of:

- ns (default)
- n
- us
- u
- ms
- s

Note this is different than influxdb 1.x as it supported minutes and hours.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)