### PR TITLE
ci(tests): remove go race tests from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ jobs:
       - run: make vet
       - run: make checkfmt
       - run: make checktidy
-      - run: make test-go-race # This doesn't use the test cache, and will not complete quickly.
+      # For now stop testing race conditions as we think it is taking too much memory on circle
+      # - run: make test-go-race # This doesn't use the test cache, and will not complete quickly.
       # TODO add these checks to the Makefile
       # - run: go get -v -t -d ./...
       # - run: go get honnef.co/go/tools/cmd/megacheck


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Remove the go race tests in circle ci.

_What was the problem?_
We think we are being OOM-killed as our plan as 4 GB of ram.

_What was the solution?_
Comment out circle race tests

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)