### PR TITLE
fix(bolt): create bolt/data dir if not exist

### DIFF
--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/coreos/bbolt"
@@ -64,6 +65,11 @@ func (c *Client) WithTime(fn func() time.Time) {
 
 // Open / create boltDB file.
 func (c *Client) Open(ctx context.Context) error {
+	// Ensure the required directory structure exists.
+	if err := os.MkdirAll(filepath.Dir(c.Path), 0700); err != nil {
+		return fmt.Errorf("unable to create directory %s: %v", c.Path, err)
+	}
+
 	if _, err := os.Stat(c.Path); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/bolt/bbolt_test.go
+++ b/bolt/bbolt_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"testing"
 
 	"github.com/influxdata/platform/bolt"
 	"golang.org/x/crypto/bcrypt"
@@ -32,4 +34,30 @@ func NewTestClient() (*bolt.Client, func(), error) {
 	}
 
 	return c, close, nil
+}
+
+func TestClientOpen(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unable to create temporary test directory %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("unable to delete temporary test directory %s: %v", tempDir, err)
+		}
+	}()
+
+	boltFile := filepath.Join(tempDir, "test", "bolt.db")
+
+	c := bolt.NewClient()
+	c.Path = boltFile
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("unable to create database %s: %v", boltFile, err)
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("unable to close database %s: %v", boltFile, err)
+	}
 }


### PR DESCRIPTION
Closes #1207 

_Briefly describe your proposed changes:_
Create directory for data if it does not already exist

_What was the problem?_
If the directory was not yet created, bolt's creation would fail.

_What was the solution?_
Create directory with permission 700 before open/create of bolt.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)