### PR TITLE
fix(http): all DELETEs now return 204

### DIFF
--- a/http/errors.go
+++ b/http/errors.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -28,6 +29,19 @@ var ErrNotFound = errors.New("no results found")
 type AuthzError interface {
 	error
 	AuthzError() error
+}
+
+// CheckErrorStatus for status and any error in the response.
+func CheckErrorStatus(code int, res *http.Response) error {
+	if err := CheckError(res); err != nil {
+		return err
+	}
+
+	if res.StatusCode != code {
+		return fmt.Errorf("unexpected status code: %s", res.Status)
+	}
+
+	return nil
 }
 
 // CheckError reads the http.Response and returns an error if one exists.

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -240,7 +240,7 @@ func (h *OrgHandler) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 type deleteOrganizationRequest struct {
@@ -490,7 +490,8 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, id platfor
 	if err != nil {
 		return err
 	}
-	return CheckError(resp)
+
+	return CheckErrorStatus(http.StatusNoContent, resp)
 }
 
 func organizationIDPath(id platform.ID) string {

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -71,7 +71,7 @@ func (h *ScraperHandler) handleDeleteScraperTarget(w http.ResponseWriter, r *htt
 		return
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handlePatchScraperTarget is the HTTP handler for the PATCH /api/v2/scrapertargets/:id route.
@@ -314,7 +314,8 @@ func (s *ScraperService) RemoveTarget(ctx context.Context, id platform.ID) error
 	if err != nil {
 		return err
 	}
-	return CheckError(resp)
+
+	return CheckErrorStatus(http.StatusNoContent, resp)
 }
 
 // GetTargetByID returns a single target by ID.

--- a/http/source_service.go
+++ b/http/source_service.go
@@ -339,7 +339,7 @@ func (h *SourceHandler) handleDeleteSource(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 type deleteSourceRequest struct {
@@ -623,7 +623,7 @@ func (s *SourceService) DeleteSource(ctx context.Context, id platform.ID) error 
 		return err
 	}
 
-	return CheckError(resp)
+	return CheckErrorStatus(http.StatusNoContent, resp)
 }
 
 func sourceIDPath(id platform.ID) string {

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -355,7 +355,7 @@ func (h *TaskHandler) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 type deleteTaskRequest struct {
@@ -627,12 +627,14 @@ func decodeRetryRunRequest(ctx context.Context, r *http.Request) (*retryRunReque
 	}, nil
 }
 
+// TaskService connects to Influx via HTTP using tokens to manage tasks.
 type TaskService struct {
 	Addr               string
 	Token              string
 	InsecureSkipVerify bool
 }
 
+// FindTaskByID returns a single task
 func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
 	u, err := newURL(t.Addr, taskIDPath(id))
 	if err != nil {
@@ -669,6 +671,8 @@ func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfor
 	return &tr.Task, nil
 }
 
+// FindTasks returns a list of tasks that match a filter (limit 100) and the total count
+// of matching tasks.
 func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
 	u, err := newURL(t.Addr, tasksPath)
 	if err != nil {
@@ -714,6 +718,7 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 	return tasks, len(tasks), nil
 }
 
+// CreateTask creates a new task.
 func (t TaskService) CreateTask(ctx context.Context, tsk *platform.Task) error {
 	u, err := newURL(t.Addr, tasksPath)
 	if err != nil {
@@ -754,6 +759,7 @@ func (t TaskService) CreateTask(ctx context.Context, tsk *platform.Task) error {
 	return nil
 }
 
+// UpdateTask updates a single task with changeset.
 func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
 	u, err := newURL(t.Addr, taskIDPath(id))
 	if err != nil {
@@ -793,6 +799,7 @@ func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platfor
 	return &tr.Task, nil
 }
 
+// DeleteTask removes a task by ID and purges all associated data and scheduled runs.
 func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 	u, err := newURL(t.Addr, taskIDPath(id))
 	if err != nil {
@@ -815,17 +822,15 @@ func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 	}
 	defer resp.Body.Close()
 
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	return nil
+	return CheckErrorStatus(http.StatusNoContent, resp)
 }
 
+// FindLogs returns logs for a run.
 func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
 	return nil, -1, errors.New("not yet implemented")
 }
 
+// FindRuns returns a list of runs that match a filter and the total count of returned runs.
 func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
 	if filter.Task == nil {
 		return nil, 0, errors.New("task ID required")
@@ -873,10 +878,12 @@ func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([
 	return runs, len(runs), nil
 }
 
+// FindRunByID returns a single run of a specific task.
 func (t TaskService) FindRunByID(ctx context.Context, orgID, runID platform.ID) (*platform.Run, error) {
 	return nil, errors.New("not yet implemented")
 }
 
+// RetryRun creates and returns a new run (which is a retry of another run).
 func (t TaskService) RetryRun(ctx context.Context, id platform.ID) (*platform.Run, error) {
 	return nil, errors.New("not yet implemented")
 }

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -216,7 +216,7 @@ func (h *UserHandler) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 type deleteUserRequest struct {
@@ -574,7 +574,8 @@ func (s *UserService) DeleteUser(ctx context.Context, id platform.ID) error {
 	if err != nil {
 		return err
 	}
-	return CheckError(resp)
+
+	return CheckErrorStatus(http.StatusNoContent, resp)
 }
 
 func userIDPath(id platform.ID) string {

--- a/task.go
+++ b/task.go
@@ -31,32 +31,32 @@ type Log string
 
 // TaskService represents a service for managing one-off and recurring tasks.
 type TaskService interface {
-	// Returns a single task
+	// FindTaskByID returns a single task
 	FindTaskByID(ctx context.Context, id ID) (*Task, error)
 
-	// Returns a list of tasks that match a filter (limit 100) and the total count
+	// FindTasks returns a list of tasks that match a filter (limit 100) and the total count
 	// of matching tasks.
 	FindTasks(ctx context.Context, filter TaskFilter) ([]*Task, int, error)
 
-	// Creates a new task
+	// CreateTask creates a new task.
 	CreateTask(ctx context.Context, t *Task) error
 
-	// Updates a single task with changeset
+	// UpdateTask updates a single task with changeset.
 	UpdateTask(ctx context.Context, id ID, upd TaskUpdate) (*Task, error)
 
-	// Removes a task by ID and purges all associated data and scheduled runs
+	// DeleteTask removes a task by ID and purges all associated data and scheduled runs.
 	DeleteTask(ctx context.Context, id ID) error
 
-	// Returns logs for a run.
+	// FindLogs returns logs for a run.
 	FindLogs(ctx context.Context, filter LogFilter) ([]*Log, int, error)
 
-	// Returns a list of runs that match a filter and the total count of returned runs.
+	// FindRuns returns a list of runs that match a filter and the total count of returned runs.
 	FindRuns(ctx context.Context, filter RunFilter) ([]*Run, int, error)
 
-	// Returns a single run
+	// FindRunByID returns a single run.
 	FindRunByID(ctx context.Context, orgID, runID ID) (*Run, error)
 
-	// Creates and returns a new run (which is a retry of another run)
+	// RetryRun creates and returns a new run (which is a retry of another run).
 	RetryRun(ctx context.Context, id ID) (*Run, error)
 }
 


### PR DESCRIPTION
Closes #170

_Briefly describe your proposed changes:_
`DELETE` of resources all return 204 for now (as is in the swagger).

In the future we may have 202's to designate asynchronous operations that can take a while before completing such as the deletion of a bucket.

_What was the problem?_
Inconsistent usage of status codes for DELETE of resources

_What was the solution?_
Add checks for status codes and unify status codes to be 204 for DELETEs.
This should change in the future when we have real async operations.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)