### PR TITLE
fix: conform to logging style guide for initial log messages

### DIFF
--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -333,7 +333,7 @@ func platformF(cmd *cobra.Command, args []string) {
 		h.Handler = platformHandler
 
 		httpServer.Handler = h
-		logger.Info("listening", zap.String("transport", "http"), zap.String("addr", httpBindAddress))
+		logger.Info("Listening", zap.String("transport", "http"), zap.String("addr", httpBindAddress))
 		errc <- httpServer.ListenAndServe()
 	}()
 

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxql"
+	"github.com/influxdata/platform/logger"
 	"github.com/influxdata/platform/models"
 	"github.com/influxdata/platform/tsdb"
 	"github.com/influxdata/platform/tsdb/tsi1"
@@ -200,8 +201,8 @@ func (e *Engine) runRetentionEnforcer() {
 	}
 
 	interval := time.Duration(e.config.RetentionInterval) * time.Second
-	logger := e.logger.With(zap.String("component", "retention_enforcer"), zap.Duration("check_interval", interval))
-	logger.Info("Starting")
+	l := e.logger.With(zap.String("component", "retention_enforcer"), logger.DurationLiteral("check_interval", interval))
+	l.Info("Starting")
 
 	ticker := time.NewTicker(interval)
 	e.wg.Add(1)
@@ -212,7 +213,7 @@ func (e *Engine) runRetentionEnforcer() {
 			// modified if this goroutine is active.
 			select {
 			case <-e.closing:
-				logger.Info("Stopping")
+				l.Info("Stopping")
 				return
 			case <-ticker.C:
 				e.retentionEnforcer.run()

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -283,7 +283,7 @@ func (i *Index) Open() error {
 
 	// Mark opened.
 	i.opened = true
-	i.logger.Info(fmt.Sprintf("index opened with %d partitions", partitionN))
+	i.logger.Info("Index opened", zap.Int("partitions", partitionN))
 	return nil
 }
 


### PR DESCRIPTION
These are the log messages that get printed immediately when starting
the application for the first time. This fixes the messages to conform
to the logging style guide.