### PR TITLE
WIP: Add keyvalue log - basis for auditlog and oplog

### DIFF
--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -157,6 +157,11 @@ func (c *Client) initialize(ctx context.Context) error {
 			return err
 		}
 
+		// Always create KeyValueLog bucket.
+		if err := c.initializeKeyValueLog(ctx, tx); err != nil {
+			return err
+		}
+
 		return nil
 	}); err != nil {
 		return err

--- a/bolt/keyvalue_log.go
+++ b/bolt/keyvalue_log.go
@@ -1,0 +1,366 @@
+package bolt
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	bolt "github.com/coreos/bbolt"
+	"github.com/influxdata/platform"
+)
+
+var (
+	keyValueLogBucket = []byte("keyvaluelog/v1")
+	keyValueLogIndex  = []byte("keyvaluelogindex/v1")
+)
+
+var _ platform.KeyValueLog = (*Client)(nil)
+
+type keyValueLogBounds struct {
+	Start int64 `json:"start"`
+	Stop  int64 `json:"stop"`
+}
+
+func newKeyValueLogBounds(now time.Time) *keyValueLogBounds {
+	return &keyValueLogBounds{
+		Start: now.UTC().UnixNano(),
+		Stop:  now.UTC().UnixNano(),
+	}
+}
+
+func (b *keyValueLogBounds) update(t time.Time) {
+	now := t.UTC().UnixNano()
+	if now < b.Start {
+		b.Start = now
+	} else if b.Stop < now {
+		b.Stop = now
+	}
+
+	return
+}
+
+// StartTime retrieves the start value of a bounds as a time.Time
+func (b *keyValueLogBounds) StartTime() time.Time {
+	return time.Unix(0, b.Start)
+}
+
+// StopTime retrieves the stop value of a bounds as a time.Time
+func (b *keyValueLogBounds) StopTime() time.Time {
+	return time.Unix(0, b.Stop)
+}
+
+// Bounds returns the key boundaries for the keyvaluelog for a resourceType/resourceID pair.
+func (b *keyValueLogBounds) Bounds(k []byte) ([]byte, []byte, error) {
+	start, err := encodeLogEntryKey(k, b.Start)
+	if err != nil {
+		return nil, nil, err
+	}
+	stop, err := encodeLogEntryKey(k, b.Stop)
+	if err != nil {
+		return nil, nil, err
+	}
+	return start, stop, nil
+}
+
+func encodeLogEntryKey(key []byte, v int64) ([]byte, error) {
+	prefix := encodeKeyValueIndexKey(key)
+	k := make([]byte, len(prefix)+8)
+
+	buf := bytes.NewBuffer(k)
+	_, err := buf.Write(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	// This needs to be big-endian so that the iteration order is preserved when scanning keys
+	if err := binary.Write(buf, binary.BigEndian, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func decodeLogEntryKey(key []byte) ([]byte, time.Time, error) {
+	buf := bytes.NewReader(key[len(key)-8:])
+	var ts int64
+	// This needs to be big-endian so that the iteration order is preserved when scanning keys
+	err := binary.Read(buf, binary.BigEndian, &ts)
+	if err != nil {
+		return nil, time.Unix(0, 0), err
+	}
+	return key[:len(key)-8], time.Unix(0, ts), nil
+}
+
+func encodeKeyValueIndexKey(k []byte) []byte {
+	// keys produced must be fixed length to ensure that we can iterate through the keyspace without any error.
+	h := sha1.New()
+	h.Write([]byte(k))
+	return h.Sum(nil)
+}
+
+func (c *Client) initializeKeyValueLog(ctx context.Context, tx *bolt.Tx) error {
+	if _, err := tx.CreateBucketIfNotExists([]byte(keyValueLogBucket)); err != nil {
+		return err
+	}
+	if _, err := tx.CreateBucketIfNotExists([]byte(keyValueLogIndex)); err != nil {
+		return err
+	}
+	return nil
+}
+
+var errKeyValueLogBoundsNotFound = fmt.Errorf("oplog not found")
+
+func (c *Client) getKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, key []byte) (*keyValueLogBounds, error) {
+	k := encodeKeyValueIndexKey(key)
+
+	v := tx.Bucket(keyValueLogIndex).Get(k)
+
+	if len(v) == 0 {
+		return nil, errKeyValueLogBoundsNotFound
+	}
+
+	bounds := &keyValueLogBounds{}
+	if err := json.Unmarshal(v, bounds); err != nil {
+		return nil, err
+	}
+
+	return bounds, nil
+}
+
+func (c *Client) putKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, key []byte, bounds *keyValueLogBounds) error {
+	k := encodeKeyValueIndexKey(key)
+
+	v, err := json.Marshal(bounds)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Bucket(keyValueLogIndex).Put(k, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) updateKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, k []byte, t time.Time) error {
+	// retrieve the keyValue log boundaries
+	bounds, err := c.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil && err != errKeyValueLogBoundsNotFound {
+		return err
+	}
+
+	if err == errKeyValueLogBoundsNotFound {
+		// if the bounds don't exist yet, create them
+		bounds = newKeyValueLogBounds(t)
+	}
+
+	// update the bounds to if needed
+	bounds.update(t)
+	if err := c.putKeyValueLogBounds(ctx, tx, k, bounds); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ForEachLogEntry retrieves the keyValue log for a resource type ID combination. KeyValues may be returned in ascending and descending order.
+func (c *Client) ForEachLogEntry(ctx context.Context, k []byte, opts platform.FindOptions, fn func([]byte, time.Time) error) error {
+	return c.db.View(func(tx *bolt.Tx) error {
+		return c.forEachLogEntry(ctx, tx, k, opts, fn)
+	})
+}
+
+func (c *Client) forEachLogEntry(ctx context.Context, tx *bolt.Tx, k []byte, opts platform.FindOptions, fn func([]byte, time.Time) error) error {
+	b, err := c.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil {
+		return err
+	}
+
+	cur := tx.Bucket(keyValueLogBucket).Cursor()
+
+	next := cur.Next
+	startKey, stopKey, err := b.Bounds(k)
+	if err != nil {
+		return err
+	}
+
+	if opts.Descending {
+		next = cur.Prev
+		startKey, stopKey = stopKey, startKey
+	}
+
+	k, v := cur.Seek(startKey)
+	if !bytes.Equal(k, startKey) {
+		return fmt.Errorf("the first key not the key found in the log bounds. This should be impossible. Please report this error.")
+	}
+
+	count := 0
+
+	if opts.Offset == 0 {
+		// Seek returns the kv at the position that was seeked to which should be the first element
+		// in the sequence of keyValues. If this condition is reached we need to start of iteration
+		// at 1 instead of 0.
+		_, ts, err := decodeLogEntryKey(k)
+		if err != nil {
+			return err
+		}
+		if err := fn(v, ts); err != nil {
+			return err
+		}
+		count++
+		if bytes.Equal(startKey, stopKey) {
+			// If the start and stop are the same, then there is only a single entry in the log
+			return nil
+		}
+	} else {
+		// Skip offset many items
+		for i := 0; i < opts.Offset-1; i++ {
+			k, _ := next()
+			if bytes.Equal(k, stopKey) {
+				return nil
+			}
+		}
+	}
+
+	for {
+		if count >= opts.Limit && opts.Limit != 0 {
+			break
+		}
+
+		k, v := next()
+
+		_, ts, err := decodeLogEntryKey(k)
+		if err != nil {
+			return err
+		}
+
+		if err := fn(v, ts); err != nil {
+			return err
+		}
+
+		if bytes.Equal(k, stopKey) {
+			// if we've reached the stop key, there are no keys log entries left
+			// in the keyspace.
+			break
+		}
+
+		count++
+	}
+
+	return nil
+
+}
+
+// LogKeyValue logs an keyValue for a particular resource type ID pairing.
+func (c *Client) AddLogEntry(ctx context.Context, k, v []byte, t time.Time) error {
+	return c.db.Update(func(tx *bolt.Tx) error {
+		return c.addLogEntry(ctx, tx, k, v, t)
+	})
+}
+
+func (c *Client) addLogEntry(ctx context.Context, tx *bolt.Tx, k, v []byte, t time.Time) error {
+	if err := c.updateKeyValueLogBounds(ctx, tx, k, t); err != nil {
+		return err
+	}
+
+	if err := c.putLogEntry(ctx, tx, k, v, t); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) putLogEntry(ctx context.Context, tx *bolt.Tx, k, v []byte, t time.Time) error {
+	key, err := encodeLogEntryKey(k, t.UTC().UnixNano())
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Bucket(keyValueLogBucket).Put(key, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) getLogEntry(ctx context.Context, tx *bolt.Tx, k []byte, t time.Time) ([]byte, time.Time, error) {
+	key, err := encodeLogEntryKey(k, t.UTC().UnixNano())
+	if err != nil {
+		return nil, t, err
+	}
+
+	v := tx.Bucket(keyValueLogBucket).Get(key)
+
+	if len(v) == 0 {
+		return nil, t, fmt.Errorf("log entry not found")
+	}
+
+	return v, t, nil
+}
+
+// FirstLogEntry retrieves the first log entry for a key value log.
+func (c *Client) FirstLogEntry(ctx context.Context, k []byte) ([]byte, time.Time, error) {
+	var v []byte
+	var t time.Time
+
+	err := c.db.View(func(tx *bolt.Tx) error {
+		val, ts, err := c.firstLogEntry(ctx, tx, k)
+		if err != nil {
+			return err
+		}
+
+		v, t = val, ts
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, t, err
+	}
+
+	return v, t, nil
+}
+
+// LastLogEntry retrieves the first log entry for a key value log.
+func (c *Client) LastLogEntry(ctx context.Context, k []byte) ([]byte, time.Time, error) {
+	var v []byte
+	var t time.Time
+
+	err := c.db.View(func(tx *bolt.Tx) error {
+		val, ts, err := c.lastLogEntry(ctx, tx, k)
+		if err != nil {
+			return err
+		}
+
+		v, t = val, ts
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, t, err
+	}
+
+	return v, t, nil
+}
+
+func (c *Client) firstLogEntry(ctx context.Context, tx *bolt.Tx, k []byte) ([]byte, time.Time, error) {
+	bounds, err := c.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil {
+		return nil, bounds.StartTime(), err
+	}
+
+	return c.getLogEntry(ctx, tx, k, bounds.StartTime())
+}
+
+func (c *Client) lastLogEntry(ctx context.Context, tx *bolt.Tx, k []byte) ([]byte, time.Time, error) {
+	bounds, err := c.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil {
+		return nil, bounds.StopTime(), err
+	}
+
+	return c.getLogEntry(ctx, tx, k, bounds.StopTime())
+}

--- a/bolt/keyvalue_log_test.go
+++ b/bolt/keyvalue_log_test.go
@@ -1,0 +1,30 @@
+package bolt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/platform"
+	platformtesting "github.com/influxdata/platform/testing"
+)
+
+func initKeyValueLog(f platformtesting.KeyValueLogFields, t *testing.T) (platform.KeyValueLog, func()) {
+	c, closeFn, err := NewTestClient()
+	if err != nil {
+		t.Fatalf("failed to create new bolt client: %v", err)
+	}
+	ctx := context.Background()
+	for _, e := range f.LogEntries {
+		if err := c.AddLogEntry(ctx, e.Key, e.Value, e.Time); err != nil {
+			t.Fatalf("failed to populate log entries")
+		}
+	}
+	return c, func() {
+		closeFn()
+	}
+}
+
+// TestKeyValueLog runs the conformance test for a keyvalue log
+func TestKeyValueLog(t *testing.T) {
+	platformtesting.KeyValueLog(initKeyValueLog, t)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,51 @@
+package platform_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/bolt"
+)
+
+func ExampleKeyValueLog() {
+	c := bolt.NewClient()
+	c.Path = "example.bolt"
+	ctx := context.Background()
+	if err := c.Open(ctx); err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		if err := c.AddLogEntry(ctx, []byte("bucket_0_auditlog"), []byte(fmt.Sprintf("abc-%v", i)), time.Now()); err != nil {
+			panic(err)
+		}
+	}
+
+	opts := platform.FindOptions{Limit: 2, Offset: 1, Descending: false}
+	if err := c.ForEachLogEntry(ctx, []byte("bucket_0_auditlog"), opts, func(v []byte, t time.Time) error {
+		fmt.Println(t.UTC())
+		fmt.Println(string(v))
+		fmt.Println()
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+
+	v, t, err := c.LastLogEntry(ctx, []byte("bucket_0_auditlog"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(t.UTC())
+	fmt.Println(string(v))
+	fmt.Println()
+
+	v, t, err = c.FirstLogEntry(ctx, []byte("bucket_0_auditlog"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(t.UTC())
+	fmt.Println(string(v))
+	fmt.Println()
+}

--- a/keyvalue_log.go
+++ b/keyvalue_log.go
@@ -1,0 +1,27 @@
+package platform
+
+import (
+	"context"
+	"time"
+)
+
+// KeyValuleLog is a generic type logs key-value pairs. This interface is intended to be used to construct other
+// higher-level log-like resources such as an oplog or audit log.
+//
+// The idea is to create a log who values can be accessed at the key k:
+// k -> [(v0,t0) (v1,t1) ... (vn,tn)]
+//
+// Logs may be retrieved in ascending or descending time order and support limits and offsets.
+type KeyValueLog interface {
+	// AddLogEntry adds an entry (v,t) to the log defined for the key k.
+	AddLogEntry(ctx context.Context, k []byte, v []byte, t time.Time) error
+
+	// ForEachLogEntry iterates through all the log entries at key k and applies the function fn for each record.
+	ForEachLogEntry(ctx context.Context, k []byte, opts FindOptions, fn func(v []byte, t time.Time) error) error
+
+	// FirstLogEntry is used to retrieve the first entry in the log at key k.
+	FirstLogEntry(ctx context.Context, k []byte) ([]byte, time.Time, error)
+
+	// LastLogEntry is used to retrieve the last entry in the log at key k.
+	LastLogEntry(ctx context.Context, k []byte) ([]byte, time.Time, error)
+}

--- a/testing/keyvalue_log.go
+++ b/testing/keyvalue_log.go
@@ -1,0 +1,835 @@
+package testing
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/platform"
+)
+
+var keyValueLogCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+}
+
+// A log entry is a comparable data structure that is used for testing
+type LogEntry struct {
+	Key   []byte
+	Value []byte
+	Time  time.Time
+}
+
+// KeyValueLogFields will include the IDGenerator, and keyValueLogs
+type KeyValueLogFields struct {
+	LogEntries []LogEntry
+}
+
+// KeyValueLog tests all the service functions.
+func KeyValueLog(
+	init func(KeyValueLogFields, *testing.T) (platform.KeyValueLog, func()), t *testing.T,
+) {
+	tests := []struct {
+		name string
+		fn   func(init func(KeyValueLogFields, *testing.T) (platform.KeyValueLog, func()),
+			t *testing.T)
+	}{
+		{
+			name: "AddLogEntry",
+			fn:   AddLogEntry,
+		},
+		{
+			name: "ForEachLogEntry",
+			fn:   ForEachLogEntry,
+		},
+		{
+			name: "FirstLogEntry",
+			fn:   FirstLogEntry,
+		},
+		{
+			name: "LastLogEntry",
+			fn:   LastLogEntry,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fn(init, t)
+		})
+	}
+}
+
+// AddLogEntry tests the AddLogEntry for the KeyValueLog contract
+func AddLogEntry(
+	init func(KeyValueLogFields, *testing.T) (platform.KeyValueLog, func()),
+	t *testing.T,
+) {
+	type args struct {
+		key   []byte
+		value []byte
+		time  time.Time
+	}
+	type wants struct {
+		err        error
+		logEntries []LogEntry
+	}
+
+	tests := []struct {
+		name   string
+		fields KeyValueLogFields
+		args   args
+		wants  wants
+	}{
+		{
+			name:   "Add entry to empty log",
+			fields: KeyValueLogFields{},
+			args: args{
+				key:   []byte("abc"),
+				value: []byte("hello"),
+				time:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("hello"),
+						Time:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "Add entry to non-empty log",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("hat"),
+						Time:  time.Date(2009, time.November, 10, 22, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key:   []byte("abc"),
+				value: []byte("hello"),
+				time:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("hat"),
+						Time:  time.Date(2009, time.November, 10, 22, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("hello"),
+						Time:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+			err := s.AddLogEntry(ctx, tt.args.key, tt.args.value, tt.args.time)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error messages to match '%v' got '%v'", tt.wants.err, err.Error())
+				}
+			}
+
+			logEntries := []LogEntry{}
+			opts := platform.FindOptions{}
+			err = s.ForEachLogEntry(ctx, tt.args.key, opts, func(v []byte, t time.Time) error {
+				logEntries = append(logEntries, LogEntry{
+					Key:   tt.args.key,
+					Value: v,
+					Time:  t,
+				})
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("failed to retrieve log entries: %v", err)
+			}
+			if diff := cmp.Diff(logEntries, tt.wants.logEntries, keyValueLogCmpOptions...); diff != "" {
+				t.Errorf("logEntries are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// ForEachLogEntry tests the AddLogEntry for the KeyValueLog contract
+func ForEachLogEntry(
+	init func(KeyValueLogFields, *testing.T) (platform.KeyValueLog, func()),
+	t *testing.T,
+) {
+	type args struct {
+		key  []byte
+		opts platform.FindOptions
+	}
+	type wants struct {
+		err        error
+		logEntries []LogEntry
+	}
+
+	tests := []struct {
+		name   string
+		fields KeyValueLogFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "all log entries",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key:  []byte("abc"),
+				opts: platform.FindOptions{},
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "all log entries descending order",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Descending: true,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "all log entries with offset",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Offset: 2,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "for each log entry with limit",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Limit: 3,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "log entries with offset and limit",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Offset: 2,
+					Limit:  2,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "descending log entries with offset and limit",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Offset:     2,
+					Limit:      2,
+					Descending: true,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
+		{
+			name: "offset exceeds log range",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Offset: 5,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{},
+			},
+		},
+		{
+			name: "offset exceeds log range descending",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+				opts: platform.FindOptions{
+					Offset:     5,
+					Descending: true,
+				},
+			},
+			wants: wants{
+				logEntries: []LogEntry{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+			logEntries := []LogEntry{}
+			err := s.ForEachLogEntry(ctx, tt.args.key, tt.args.opts, func(v []byte, t time.Time) error {
+				logEntries = append(logEntries, LogEntry{
+					Key:   tt.args.key,
+					Value: v,
+					Time:  t,
+				})
+				return nil
+			})
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error messages to match '%v' got '%v'", tt.wants.err, err.Error())
+				}
+			}
+
+			if diff := cmp.Diff(logEntries, tt.wants.logEntries, keyValueLogCmpOptions...); diff != "" {
+				t.Errorf("logEntries are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// FirstLogEntry tests the FirstLogEntry method for the KeyValueLog contract.
+func FirstLogEntry(
+	init func(KeyValueLogFields, *testing.T) (platform.KeyValueLog, func()),
+	t *testing.T,
+) {
+	type args struct {
+		key []byte
+	}
+	type wants struct {
+		err      error
+		logEntry LogEntry
+	}
+
+	tests := []struct {
+		name   string
+		fields KeyValueLogFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "get first log entry",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+			},
+			wants: wants{
+				logEntry: LogEntry{
+					Key:   []byte("abc"),
+					Value: []byte("1"),
+					Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+			var err error
+			logEntry := LogEntry{Key: tt.args.key}
+			logEntry.Value, logEntry.Time, err = s.FirstLogEntry(ctx, tt.args.key)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error messages to match '%v' got '%v'", tt.wants.err, err.Error())
+				}
+			}
+
+			if diff := cmp.Diff(logEntry, tt.wants.logEntry, keyValueLogCmpOptions...); diff != "" {
+				t.Errorf("logEntries are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// LastLogEntry tests the LastLogEntry method for the KeyValueLog contract.
+func LastLogEntry(
+	init func(KeyValueLogFields, *testing.T) (platform.KeyValueLog, func()),
+	t *testing.T,
+) {
+	type args struct {
+		key []byte
+	}
+	type wants struct {
+		err      error
+		logEntry LogEntry
+	}
+
+	tests := []struct {
+		name   string
+		fields KeyValueLogFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "get last log entry",
+			fields: KeyValueLogFields{
+				LogEntries: []LogEntry{
+					{
+						Key:   []byte("abc"),
+						Value: []byte("1"),
+						Time:  time.Date(2009, time.November, 10, 1, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("2"),
+						Time:  time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("3"),
+						Time:  time.Date(2009, time.November, 10, 3, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("4"),
+						Time:  time.Date(2009, time.November, 10, 4, 0, 0, 0, time.UTC),
+					},
+					{
+						Key:   []byte("abc"),
+						Value: []byte("5"),
+						Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				key: []byte("abc"),
+			},
+			wants: wants{
+				logEntry: LogEntry{
+					Key:   []byte("abc"),
+					Value: []byte("5"),
+					Time:  time.Date(2009, time.November, 10, 5, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := init(tt.fields, t)
+			defer done()
+			ctx := context.TODO()
+			var err error
+			logEntry := LogEntry{Key: tt.args.key}
+			logEntry.Value, logEntry.Time, err = s.LastLogEntry(ctx, tt.args.key)
+			if (err != nil) != (tt.wants.err != nil) {
+				t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
+			}
+
+			if err != nil && tt.wants.err != nil {
+				if err.Error() != tt.wants.err.Error() {
+					t.Fatalf("expected error messages to match '%v' got '%v'", tt.wants.err, err.Error())
+				}
+			}
+
+			if diff := cmp.Diff(logEntry, tt.wants.logEntry, keyValueLogCmpOptions...); diff != "" {
+				t.Errorf("logEntries are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1233 

_Briefly describe your proposed changes:_
This PR introduces an abstract interface that can be used to create logs of key value pairs. The intention for this is to implement an audit log as well as an operation log for all stored resources. Additionally it is intended that this log be used to update the `meta` fields associated with a resource.

This originally started out as an oplog, but was made more general.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass