### PR TITLE
chore: add test binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ influxd.bolt
 /transpilerd
 /bin
 
+# Binaries built with go test -c.
+/*.test
+
 ui/node_modules
 ui/yarn-error.log
 ui/build


### PR DESCRIPTION
Ensure that test binaries with `go test -c` cannot be accidentally
staged with `git add .`.