### PR TITLE
Ensure storage resources are cleaned up

### DIFF
--- a/storage/reads/table.go
+++ b/storage/reads/table.go
@@ -150,6 +150,8 @@ func (t *table) appendBounds() {
 	}
 }
 
+// hasPoints returns true if the next block from cur has data. If cur is not
+// nil, it will be closed.
 func hasPoints(cur cursors.Cursor) bool {
 	if cur == nil {
 		return false


### PR DESCRIPTION
During read operations, certain error conditions may result in storage resources not being closed. In most cases this leads to dangling references to TSM files, which cause the process to hang on shutdown or TSM files to leak after compactions. The PR ensures that all the `handle` methods correctly close these resources prior to returning.