### PR TITLE
WIP: add operation log for resources

### DIFF
--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -5,16 +5,30 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/influxdata/platform"
+	platformcontext "github.com/influxdata/platform/context"
 )
 
 var (
 	dashboardBucket = []byte("dashboardsv2")
 )
 
+// TODO(desa): what do we want these to be?
+const (
+	dashboardCreatedEvent = "Dashboard Created"
+	dashboardUpdatedEvent = "Dashboard Updated"
+
+	dashboardCellsReplacedEvent = "Dashboard Cells Replaced"
+	dashboardCellAddedEvent     = "Dashboard Cell Added"
+	dashboardCellRemovedEvent   = "Dashboard Cell Removed"
+	dashboardCellUpdatedEvent   = "Dashboard Cell Updated"
+)
+
 var _ platform.DashboardService = (*Client)(nil)
+var _ platform.DashboardOperationLogService = (*Client)(nil)
 
 func (c *Client) initializeDashboards(ctx context.Context, tx *bolt.Tx) error {
 	if _, err := tx.CreateBucketIfNotExists([]byte(dashboardBucket)); err != nil {
@@ -167,6 +181,11 @@ func (c *Client) CreateDashboard(ctx context.Context, d *platform.Dashboard) err
 			}
 		}
 
+		if err := c.appendDashboardEventToLog(ctx, tx, d.ID, dashboardCreatedEvent); err != nil {
+			return err
+		}
+
+		// TODO(desa): don't populate this here. use the first/last methods of the oplog to get meta fields.
 		d.Meta.CreatedAt = c.time()
 
 		return c.putDashboardWithMeta(ctx, tx, d)
@@ -205,7 +224,7 @@ func (c *Client) createViewIfNotExists(ctx context.Context, tx *bolt.Tx, cell *p
 	return nil
 }
 
-// ReplaceDashboardCells creates a platform dashboard and sets d.ID.
+// ReplaceDashboardCells updates the positions of each cell in a dashboard concurrently.
 func (c *Client) ReplaceDashboardCells(ctx context.Context, id platform.ID, cs []*platform.Cell) error {
 	return c.db.Update(func(tx *bolt.Tx) error {
 		d, err := c.findDashboardByID(ctx, tx, id)
@@ -234,6 +253,9 @@ func (c *Client) ReplaceDashboardCells(ctx context.Context, id platform.ID, cs [
 		}
 
 		d.Cells = cs
+		if err := c.appendDashboardEventToLog(ctx, tx, d.ID, dashboardCellsReplacedEvent); err != nil {
+			return err
+		}
 
 		return c.putDashboardWithMeta(ctx, tx, d)
 	})
@@ -252,6 +274,10 @@ func (c *Client) AddDashboardCell(ctx context.Context, id platform.ID, cell *pla
 		}
 
 		d.Cells = append(d.Cells, cell)
+
+		if err := c.appendDashboardEventToLog(ctx, tx, d.ID, dashboardCellAddedEvent); err != nil {
+			return err
+		}
 
 		return c.putDashboardWithMeta(ctx, tx, d)
 	})
@@ -281,6 +307,10 @@ func (c *Client) RemoveDashboardCell(ctx context.Context, dashboardID, cellID pl
 		}
 
 		d.Cells = append(d.Cells[:idx], d.Cells[idx+1:]...)
+
+		if err := c.appendDashboardEventToLog(ctx, tx, d.ID, dashboardCellRemovedEvent); err != nil {
+			return err
+		}
 
 		return c.putDashboardWithMeta(ctx, tx, d)
 	})
@@ -316,6 +346,10 @@ func (c *Client) UpdateDashboardCell(ctx context.Context, dashboardID, cellID pl
 
 		cell = d.Cells[idx]
 
+		if err := c.appendDashboardEventToLog(ctx, tx, d.ID, dashboardCellUpdatedEvent); err != nil {
+			return err
+		}
+
 		return c.putDashboardWithMeta(ctx, tx, d)
 	})
 
@@ -349,6 +383,7 @@ func (c *Client) putDashboard(ctx context.Context, tx *bolt.Tx, d *platform.Dash
 }
 
 func (c *Client) putDashboardWithMeta(ctx context.Context, tx *bolt.Tx, d *platform.Dashboard) error {
+	// TODO(desa): don't populate this here. use the first/last methods of the oplog to get meta fields.
 	d.Meta.UpdatedAt = c.time()
 	return c.putDashboard(ctx, tx, d)
 }
@@ -382,6 +417,7 @@ func (c *Client) UpdateDashboard(ctx context.Context, id platform.ID, upd platfo
 			return err
 		}
 		d = dash
+
 		return nil
 	})
 
@@ -395,6 +431,10 @@ func (c *Client) updateDashboard(ctx context.Context, tx *bolt.Tx, id platform.I
 	}
 
 	if err := upd.Apply(d); err != nil {
+		return nil, err
+	}
+
+	if err := c.appendDashboardEventToLog(ctx, tx, d.ID, dashboardUpdatedEvent); err != nil {
 		return nil, err
 	}
 
@@ -429,8 +469,76 @@ func (c *Client) deleteDashboard(ctx context.Context, tx *bolt.Tx, id platform.I
 	if err := tx.Bucket(dashboardBucket).Delete(encodedID); err != nil {
 		return err
 	}
+	// TODO(desa): add DeleteKeyValueLog method and use it here.
 	return c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
 		ResourceID:   id,
 		ResourceType: platform.DashboardResourceType,
 	})
+}
+
+const dashboardOperationLogKeyPrefix = "dashboard"
+
+func encodeDashboardOperationLogKey(id platform.ID) ([]byte, error) {
+	buf, err := id.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(dashboardOperationLogKeyPrefix), buf...), nil
+}
+
+// GetDashboardOperationLog retrieves a dashboards operation log.
+func (c *Client) GetDashboardOperationLog(ctx context.Context, id platform.ID, opts platform.FindOptions) ([]*platform.OperationLogEntry, int, error) {
+	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
+	log := []*platform.OperationLogEntry{}
+
+	err := c.db.View(func(tx *bolt.Tx) error {
+		key, err := encodeDashboardOperationLogKey(id)
+		if err != nil {
+			return err
+		}
+
+		return c.forEachLogEntry(ctx, tx, key, opts, func(v []byte, t time.Time) error {
+			e := &platform.OperationLogEntry{}
+			if err := json.Unmarshal(v, e); err != nil {
+				return err
+			}
+			e.Time = t
+
+			log = append(log, e)
+
+			return nil
+		})
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return log, len(log), nil
+}
+
+func (c *Client) appendDashboardEventToLog(ctx context.Context, tx *bolt.Tx, id platform.ID, s string) error {
+	e := &platform.OperationLogEntry{
+		Description: s,
+	}
+	// TODO(desa): this is fragile and non explicit since it requires an authorizer to be on context. It should be
+	//             replaced with a higher level transaction so that adding to the log can take place in the http handler
+	//             where the userID will exist explicitly.
+	a, err := platformcontext.GetAuthorizer(ctx)
+	if err == nil {
+		// Add the user to the log if you can, but don't error if its not there.
+		e.UserID = a.GetUserID()
+	}
+
+	v, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+
+	k, err := encodeDashboardOperationLogKey(id)
+	if err != nil {
+		return err
+	}
+
+	return c.addLogEntry(ctx, tx, k, v, c.time())
 }

--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/coreos/bbolt"
 	"github.com/influxdata/platform"
+	platformcontext "github.com/influxdata/platform/context"
 )
 
 var (
@@ -15,6 +17,7 @@ var (
 )
 
 var _ platform.OrganizationService = (*Client)(nil)
+var _ platform.OrganizationOperationLogService = (*Client)(nil)
 
 func (c *Client) initializeOrganizations(ctx context.Context, tx *bolt.Tx) error {
 	if _, err := tx.CreateBucketIfNotExists([]byte(organizationBucket)); err != nil {
@@ -199,6 +202,9 @@ func (c *Client) CreateOrganization(ctx context.Context, o *platform.Organizatio
 		}
 
 		o.ID = c.IDGenerator.ID()
+		if err := c.appendOrganizationEventToLog(ctx, tx, o.ID, organizationCreatedEvent); err != nil {
+			return err
+		}
 
 		return c.putOrganization(ctx, tx, o)
 	})
@@ -281,6 +287,10 @@ func (c *Client) updateOrganization(ctx context.Context, tx *bolt.Tx, id platfor
 		o.Name = *upd.Name
 	}
 
+	if err := c.appendOrganizationEventToLog(ctx, tx, o.ID, organizationUpdatedEvent); err != nil {
+		return nil, err
+	}
+
 	if err := c.putOrganization(ctx, tx, o); err != nil {
 		return nil, err
 	}
@@ -327,4 +337,75 @@ func (c *Client) deleteOrganizationsBuckets(ctx context.Context, tx *bolt.Tx, id
 		}
 	}
 	return nil
+}
+
+// GeOrganizationOperationLog retrieves a organization operation log.
+func (c *Client) GetOrganizationOperationLog(ctx context.Context, id platform.ID, opts platform.FindOptions) ([]*platform.OperationLogEntry, int, error) {
+	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
+	log := []*platform.OperationLogEntry{}
+
+	err := c.db.View(func(tx *bolt.Tx) error {
+		key, err := encodeBucketOperationLogKey(id)
+		if err != nil {
+			return err
+		}
+
+		return c.forEachLogEntry(ctx, tx, key, opts, func(v []byte, t time.Time) error {
+			e := &platform.OperationLogEntry{}
+			if err := json.Unmarshal(v, e); err != nil {
+				return err
+			}
+			e.Time = t
+
+			log = append(log, e)
+
+			return nil
+		})
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return log, len(log), nil
+}
+
+// TODO(desa): what do we want these to be?
+const (
+	organizationCreatedEvent = "Organization Created"
+	organizationUpdatedEvent = "Organization Updated"
+)
+
+func encodeOrganizationOperationLogKey(id platform.ID) ([]byte, error) {
+	buf, err := id.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(bucketOperationLogKeyPrefix), buf...), nil
+}
+
+func (c *Client) appendOrganizationEventToLog(ctx context.Context, tx *bolt.Tx, id platform.ID, s string) error {
+	e := &platform.OperationLogEntry{
+		Description: s,
+	}
+	// TODO(desa): this is fragile and non explicit since it requires an authorizer to be on context. It should be
+	//             replaced with a higher level transaction so that adding to the log can take place in the http handler
+	//             where the organizationID will exist explicitly.
+	a, err := platformcontext.GetAuthorizer(ctx)
+	if err == nil {
+		// Add the organization to the log if you can, but don't error if its not there.
+		e.UserID = a.GetUserID()
+	}
+
+	v, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+
+	k, err := encodeOrganizationOperationLogKey(id)
+	if err != nil {
+		return err
+	}
+
+	return c.addLogEntry(ctx, tx, k, v, c.time())
 }

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/influxdata/platform/snowflake"
-	"github.com/opentracing/opentracing-go"
 	nethttp "net/http"
 	_ "net/http/pprof"
 	"os"
@@ -12,6 +10,9 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/influxdata/platform/snowflake"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/bolt"
@@ -175,19 +176,23 @@ func run() error {
 	}(logger)
 
 	var (
-		orgSvc           platform.OrganizationService        = c
-		authSvc          platform.AuthorizationService       = c
-		userSvc          platform.UserService                = c
-		viewSvc          platform.ViewService                = c
-		macroSvc         platform.MacroService               = c
-		bucketSvc        platform.BucketService              = c
-		sourceSvc        platform.SourceService              = c
-		sessionSvc       platform.SessionService             = c
-		basicAuthSvc     platform.BasicAuthService           = c
-		dashboardSvc     platform.DashboardService           = c
-		onboardingSvc    platform.OnboardingService          = c
-		userResourceSvc  platform.UserResourceMappingService = c
-		scraperTargetSvc platform.ScraperTargetStoreService  = c
+		orgSvc           platform.OrganizationService             = c
+		authSvc          platform.AuthorizationService            = c
+		userSvc          platform.UserService                     = c
+		viewSvc          platform.ViewService                     = c
+		macroSvc         platform.MacroService                    = c
+		bucketSvc        platform.BucketService                   = c
+		sourceSvc        platform.SourceService                   = c
+		sessionSvc       platform.SessionService                  = c
+		basicAuthSvc     platform.BasicAuthService                = c
+		dashboardSvc     platform.DashboardService                = c
+		dashboardLogSvc  platform.DashboardOperationLogService    = c
+		userLogSvc       platform.UserOperationLogService         = c
+		bucketLogSvc     platform.BucketOperationLogService       = c
+		orgLogSvc        platform.OrganizationOperationLogService = c
+		onboardingSvc    platform.OnboardingService               = c
+		userResourceSvc  platform.UserResourceMappingService      = c
+		scraperTargetSvc platform.ScraperTargetStoreService       = c
 	)
 
 	chronografSvc, err := server.NewServiceV2(ctx, c.DB())
@@ -305,27 +310,31 @@ func run() error {
 	}
 
 	handlerConfig := &http.APIBackend{
-		Logger:                     logger,
-		NewBucketService:           source.NewBucketService,
-		NewQueryService:            source.NewQueryService,
-		PointsWriter:               pointsWriter,
-		AuthorizationService:       authSvc,
-		BucketService:              bucketSvc,
-		SessionService:             sessionSvc,
-		UserService:                userSvc,
-		OrganizationService:        orgSvc,
-		UserResourceMappingService: userResourceSvc,
-		DashboardService:           dashboardSvc,
-		ViewService:                viewSvc,
-		SourceService:              sourceSvc,
-		MacroService:               macroSvc,
-		BasicAuthService:           basicAuthSvc,
-		OnboardingService:          onboardingSvc,
-		ProxyQueryService:          storageQueryService,
-		TaskService:                taskSvc,
-		TelegrafService:            telegrafSvc,
-		ScraperTargetStoreService:  scraperTargetSvc,
-		ChronografService:          chronografSvc,
+		Logger:                          logger,
+		NewBucketService:                source.NewBucketService,
+		NewQueryService:                 source.NewQueryService,
+		PointsWriter:                    pointsWriter,
+		AuthorizationService:            authSvc,
+		BucketService:                   bucketSvc,
+		SessionService:                  sessionSvc,
+		UserService:                     userSvc,
+		OrganizationService:             orgSvc,
+		UserResourceMappingService:      userResourceSvc,
+		DashboardService:                dashboardSvc,
+		DashboardOperationLogService:    dashboardLogSvc,
+		BucketOperationLogService:       bucketLogSvc,
+		UserOperationLogService:         userLogSvc,
+		OrganizationOperationLogService: orgLogSvc,
+		ViewService:                     viewSvc,
+		SourceService:                   sourceSvc,
+		MacroService:                    macroSvc,
+		BasicAuthService:                basicAuthSvc,
+		OnboardingService:               onboardingSvc,
+		ProxyQueryService:               storageQueryService,
+		TaskService:                     taskSvc,
+		TelegrafService:                 telegrafSvc,
+		ScraperTargetStoreService:       scraperTargetSvc,
+		ChronografService:               chronografSvc,
 	}
 
 	// HTTP server

--- a/dashboard.go
+++ b/dashboard.go
@@ -45,7 +45,7 @@ type DashboardService interface {
 	ReplaceDashboardCells(ctx context.Context, id ID, c []*Cell) error
 }
 
-// Dashboard represents all visual and query data for a dashboard
+// Dashboard represents all visual and query data for a dashboard.
 type Dashboard struct {
 	ID          ID            `json:"id,omitempty"`
 	Name        string        `json:"name"`

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -39,24 +39,28 @@ type APIBackend struct {
 	NewBucketService func(*platform.Source) (platform.BucketService, error)
 	NewQueryService  func(*platform.Source) (query.ProxyQueryService, error)
 
-	PointsWriter               storage.PointsWriter
-	AuthorizationService       platform.AuthorizationService
-	BucketService              platform.BucketService
-	SessionService             platform.SessionService
-	UserService                platform.UserService
-	OrganizationService        platform.OrganizationService
-	UserResourceMappingService platform.UserResourceMappingService
-	DashboardService           platform.DashboardService
-	ViewService                platform.ViewService
-	SourceService              platform.SourceService
-	MacroService               platform.MacroService
-	BasicAuthService           platform.BasicAuthService
-	OnboardingService          platform.OnboardingService
-	ProxyQueryService          query.ProxyQueryService
-	TaskService                platform.TaskService
-	TelegrafService            platform.TelegrafConfigStore
-	ScraperTargetStoreService  platform.ScraperTargetStoreService
-	ChronografService          *server.Service
+	PointsWriter                    storage.PointsWriter
+	AuthorizationService            platform.AuthorizationService
+	BucketService                   platform.BucketService
+	SessionService                  platform.SessionService
+	UserService                     platform.UserService
+	OrganizationService             platform.OrganizationService
+	UserResourceMappingService      platform.UserResourceMappingService
+	DashboardService                platform.DashboardService
+	DashboardOperationLogService    platform.DashboardOperationLogService
+	BucketOperationLogService       platform.BucketOperationLogService
+	UserOperationLogService         platform.UserOperationLogService
+	OrganizationOperationLogService platform.OrganizationOperationLogService
+	ViewService                     platform.ViewService
+	SourceService                   platform.SourceService
+	MacroService                    platform.MacroService
+	BasicAuthService                platform.BasicAuthService
+	OnboardingService               platform.OnboardingService
+	ProxyQueryService               query.ProxyQueryService
+	TaskService                     platform.TaskService
+	TelegrafService                 platform.TelegrafConfigStore
+	ScraperTargetStoreService       platform.ScraperTargetStoreService
+	ChronografService               *server.Service
 }
 
 // NewAPIHandler constructs all api handlers beneath it and returns an APIHandler
@@ -69,17 +73,21 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 
 	h.BucketHandler = NewBucketHandler(b.UserResourceMappingService)
 	h.BucketHandler.BucketService = b.BucketService
+	h.BucketHandler.BucketOperationLogService = b.BucketOperationLogService
 
 	h.OrgHandler = NewOrgHandler(b.UserResourceMappingService)
 	h.OrgHandler.OrganizationService = b.OrganizationService
 	h.OrgHandler.BucketService = b.BucketService
+	h.OrgHandler.OrganizationOperationLogService = b.OrganizationOperationLogService
 
 	h.UserHandler = NewUserHandler()
 	h.UserHandler.UserService = b.UserService
 	h.UserHandler.BasicAuthService = b.BasicAuthService
+	h.UserHandler.UserOperationLogService = b.UserOperationLogService
 
 	h.DashboardHandler = NewDashboardHandler(b.UserResourceMappingService)
 	h.DashboardHandler.DashboardService = b.DashboardService
+	h.DashboardHandler.DashboardOperationLogService = b.DashboardOperationLogService
 
 	h.ViewHandler = NewViewHandler(b.UserResourceMappingService)
 	h.ViewHandler.ViewService = b.ViewService

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -72,7 +72,8 @@ func TestService_handleGetBuckets(t *testing.T) {
     {
       "links": {
         "org": "/api/v2/orgs/50f7ba1150f7ba11",
-        "self": "/api/v2/buckets/0b501e7e557ab1ed"
+        "self": "/api/v2/buckets/0b501e7e557ab1ed",
+        "log": "/api/v2/buckets/0b501e7e557ab1ed/log"
       },
       "id": "0b501e7e557ab1ed",
       "organizationID": "50f7ba1150f7ba11",
@@ -82,7 +83,8 @@ func TestService_handleGetBuckets(t *testing.T) {
     {
       "links": {
         "org": "/api/v2/orgs/7e55e118dbabb1ed",
-        "self": "/api/v2/buckets/c0175f0077a77005"
+        "self": "/api/v2/buckets/c0175f0077a77005",
+        "log": "/api/v2/buckets/c0175f0077a77005/log"
       },
       "id": "c0175f0077a77005",
       "organizationID": "7e55e118dbabb1ed",
@@ -203,7 +205,8 @@ func TestService_handleGetBucket(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
-    "self": "/api/v2/buckets/020f755c3c082000"
+    "self": "/api/v2/buckets/020f755c3c082000",
+    "log": "/api/v2/buckets/020f755c3c082000/log"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",
@@ -313,7 +316,8 @@ func TestService_handlePostBucket(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/6f626f7274697320",
-    "self": "/api/v2/buckets/020f755c3c082000"
+    "self": "/api/v2/buckets/020f755c3c082000",
+    "log": "/api/v2/buckets/020f755c3c082000/log"
   },
   "id": "020f755c3c082000",
   "organizationID": "6f626f7274697320",
@@ -515,7 +519,8 @@ func TestService_handlePatchBucket(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
-    "self": "/api/v2/buckets/020f755c3c082000"
+    "self": "/api/v2/buckets/020f755c3c082000",
+    "log": "/api/v2/buckets/020f755c3c082000/log"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",
@@ -582,7 +587,8 @@ func TestService_handlePatchBucket(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
-    "self": "/api/v2/buckets/020f755c3c082000"
+    "self": "/api/v2/buckets/020f755c3c082000",
+    "log": "/api/v2/buckets/020f755c3c082000/log"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",
@@ -630,7 +636,8 @@ func TestService_handlePatchBucket(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
-    "self": "/api/v2/buckets/020f755c3c082000"
+    "self": "/api/v2/buckets/020f755c3c082000",
+    "log": "/api/v2/buckets/020f755c3c082000/log"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -108,7 +108,8 @@ func TestService_handleGetDashboards(t *testing.T) {
       ],
       "links": {
         "self": "/api/v2/dashboards/da7aba5e5d81e550",
-        "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells"
+        "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
+        "log": "/api/v2/dashboards/da7aba5e5d81e550/log"
       }
     },
     {
@@ -122,6 +123,7 @@ func TestService_handleGetDashboards(t *testing.T) {
       "cells": [],
       "links": {
         "self": "/api/v2/dashboards/0ca2204eca2204e0",
+        "log": "/api/v2/dashboards/0ca2204eca2204e0/log",
         "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells"
       }
     }
@@ -272,6 +274,7 @@ func TestService_handleGetDashboard(t *testing.T) {
   ],
   "links": {
     "self": "/api/v2/dashboards/020f755c3c082000",
+    "log": "/api/v2/dashboards/020f755c3c082000/log",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells"
   }
 }
@@ -413,6 +416,7 @@ func TestService_handlePostDashboard(t *testing.T) {
   ],
   "links": {
     "self": "/api/v2/dashboards/020f755c3c082000",
+    "log": "/api/v2/dashboards/020f755c3c082000/log",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells"
   }
 }
@@ -555,8 +559,8 @@ func TestService_handlePatchDashboard(t *testing.T) {
 		DashboardService platform.DashboardService
 	}
 	type args struct {
-		id    string
-		name  string
+		id   string
+		name string
 	}
 	type wants struct {
 		statusCode  int
@@ -638,6 +642,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
   ],
   "links": {
     "self": "/api/v2/dashboards/020f755c3c082000",
+    "log": "/api/v2/dashboards/020f755c3c082000/log",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells"
   }
 }

--- a/operation_log.go
+++ b/operation_log.go
@@ -1,0 +1,43 @@
+package platform
+
+import (
+	"context"
+	"time"
+)
+
+// OperationLogEntry is a record in an operation log.
+type OperationLogEntry struct {
+	Description string    `json:"description"`
+	UserID      ID        `json:"userID,omitempty"`
+	Time        time.Time `json:"time,omitempty"`
+}
+
+// DashboardOperationLogService is an interface for retrieving the operation log for a dashboard.
+type DashboardOperationLogService interface {
+	// GetDashboardOperationLog retrieves the operation log for the dashboard with the provided id.
+	GetDashboardOperationLog(ctx context.Context, id ID, opts FindOptions) ([]*OperationLogEntry, int, error)
+}
+
+// BucketOperationLogService is an interface for retrieving the operation log for a bucket.
+type BucketOperationLogService interface {
+	// GetBucketOperationLog retrieves the operation log for the bucket with the provided id.
+	GetBucketOperationLog(ctx context.Context, id ID, opts FindOptions) ([]*OperationLogEntry, int, error)
+}
+
+// UserOperationLogService is an interface for retrieving the operation log for a user.
+type UserOperationLogService interface {
+	// GeUserOperationLog retrieves the operation log for the user with the provided id.
+	GetUserOperationLog(ctx context.Context, id ID, opts FindOptions) ([]*OperationLogEntry, int, error)
+}
+
+// OrganizationOperationLogService is an interface for retrieving the operation log for an org.
+type OrganizationOperationLogService interface {
+	// GeOrganizationOperationLog retrieves the operation log for the org with the provided id.
+	GetOrganizationOperationLog(ctx context.Context, id ID, opts FindOptions) ([]*OperationLogEntry, int, error)
+}
+
+// DefaultOperationLogFindOptions are the default options for the operation log.
+var DefaultOperationLogFindOptions = FindOptions{
+	Descending: true,
+	Limit:      100,
+}


### PR DESCRIPTION
Closes #1233 

**Briefly describe your proposed changes:**
I'd like to get some initial feedback

**What was the problem?**
We want a way to view the history of operation against a resource. It is not entirely clear what specific values should be saved for each operation. I imagine we'll want some sort of plaintext description of what happened, but I'm not sure.

One concern that I have is that the log will likely consume more disk than the resource does and I think simply having a plaintext record of what took place may not be as valuable as having a way to undo the operation that took place.
 
**What was the solution?**
We use the key value log to store a each event that takes place for a resource.

**TODO**
- [x] Add operation log for dashboards
- [x] Add route to retrieve the operation log for dashboards
- [x] Add operation log for buckets
- [x] Add route to retrieve the operation log for bucket
- [x] Add operation log for users
- [x] Add route to retrieve the operation log for users
- [x] Add operation log for orgs
- [x] Add route to retrieve the operation log for orgs 
- [x] Add tests
- [x] Rebased/mergeable
- [x] Tests pass