### PR TITLE
open tracing context handling for tasks and for HTTP endpoints for tasks and query

### DIFF
--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/influxdata/platform/snowflake"
+	"github.com/opentracing/opentracing-go"
 	nethttp "net/http"
 	_ "net/http/pprof"
 	"os"
@@ -33,6 +35,7 @@ import (
 	taskexecutor "github.com/influxdata/platform/task/backend/executor"
 	_ "github.com/influxdata/platform/tsdb/tsi1"
 	_ "github.com/influxdata/platform/tsdb/tsm1"
+	pzap "github.com/influxdata/platform/zap"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -152,6 +155,12 @@ func run() error {
 		return err
 	}
 	defer logger.Sync()
+
+	// set tracing
+	tracer := new(pzap.Tracer)
+	tracer.Logger = logger
+	tracer.IDGenerator = snowflake.NewIDGenerator()
+	opentracing.SetGlobalTracer(tracer)
 
 	reg := prom.NewRegistry()
 	reg.MustRegister(prometheus.NewGoCollector())
@@ -338,6 +347,7 @@ func run() error {
 		h := http.NewHandlerFromRegistry("platform", reg)
 		h.Handler = platformHandler
 		h.Logger = logger
+		h.Tracer = opentracing.GlobalTracer()
 
 		httpServer.Handler = h
 		logger.Info("Listening", zap.String("transport", "http"), zap.String("addr", httpBindAddress))

--- a/http/query_service.go
+++ b/http/query_service.go
@@ -54,7 +54,6 @@ func (h *QueryHandler) handlePing(w http.ResponseWriter, r *http.Request) {
 // handlePostQuery is the HTTP handler for the POST /api/v2/query route.
 func (h *QueryHandler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
 	var req query.Request
 	req.WithCompilerMappings(h.CompilerMappings)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {


### PR DESCRIPTION
This adds open tracing for http endpoints for tasks and query.  Originally it was just my intent to add it for tasks, but then I realized it would be useful for query too, as both will often be behind backend software for a lot of people.

WIP