### PR TITLE
Eliminate race condition in TimeSeries component

### DIFF
--- a/ui/src/utils/restartable.test.ts
+++ b/ui/src/utils/restartable.test.ts
@@ -1,0 +1,72 @@
+import {restartable, CancellationError} from 'src/utils/restartable'
+
+describe('restartable', () => {
+  test('with three concurrent promises', async () => {
+    let n = 0
+
+    const f = () => new Promise(res => setTimeout(() => res(n++), 50))
+    const restartableF = restartable(f)
+
+    const successMock = jest.fn()
+    const errorMock = jest.fn()
+
+    const g = async () => {
+      try {
+        const result = await restartableF()
+
+        successMock(result)
+      } catch (e) {
+        if (e instanceof CancellationError) {
+          errorMock()
+        }
+      }
+    }
+
+    g()
+    g()
+    g()
+
+    await new Promise(res => setTimeout(res, 200))
+
+    expect(successMock).toHaveBeenCalledTimes(1)
+    expect(successMock.mock.calls[0][0]).toEqual(2)
+
+    expect(errorMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('with two sequential promises', async () => {
+    let n = 0
+
+    const f = () => new Promise(res => setTimeout(() => res(n++), 50))
+    const restartableF = restartable(f)
+
+    const successMock = jest.fn()
+    const errorMock = jest.fn()
+
+    const g = async () => {
+      try {
+        const result = await restartableF()
+
+        successMock(result)
+      } catch (e) {
+        if (e instanceof CancellationError) {
+          errorMock()
+        }
+      }
+    }
+
+    g()
+
+    await new Promise(res => setTimeout(res, 200))
+
+    g()
+
+    await new Promise(res => setTimeout(res, 200))
+
+    expect(successMock).toHaveBeenCalledTimes(2)
+    expect(successMock.mock.calls[0][0]).toEqual(0)
+    expect(successMock.mock.calls[1][0]).toEqual(1)
+
+    expect(errorMock).toHaveBeenCalledTimes(0)
+  })
+})

--- a/ui/src/utils/restartable.ts
+++ b/ui/src/utils/restartable.ts
@@ -1,0 +1,58 @@
+import Deferred from 'src/utils/Deferred'
+
+export class CancellationError extends Error {}
+
+// `restartable` is a utility that wraps promise-returning functions so that
+// concurrent calls resolve successfully exactly once, and with the most
+// up-to-date data.
+//
+// As an example, let `f` be a function returning a `Promise<V>`, and suppose
+// that `f` is executed three times in immediate succession. The order in which
+// each promise returned by `f` resolves is undefined, which often creates
+// problems for impure callbacks chained off of the promises returned by `f`.
+//
+// Instead, we can let `g = restartable(f)` and call `g` three times instead.
+// This will return three promises; the first two promises are guaranteed to
+// reject with a `CancellationError`, while the third promise (the most recent
+// call) will either resolve or reject according to the original behavior of
+// `f`.
+//
+export function restartable<T extends any[], V>(
+  f: (...args: T) => Promise<V>
+): ((...args: T) => Promise<V>) {
+  let id: number = 0
+
+  const checkResult = async (
+    promise: Promise<V>,
+    deferred: Deferred,
+    promiseID: number
+  ) => {
+    let result
+    let isOk = true
+
+    try {
+      result = await promise
+    } catch (error) {
+      result = error
+      isOk = false
+    }
+
+    if (promiseID !== id) {
+      deferred.reject(new CancellationError())
+    } else if (!isOk) {
+      deferred.reject(result)
+    } else {
+      deferred.resolve(result)
+    }
+  }
+
+  return (...args: T): Promise<V> => {
+    const deferred = new Deferred()
+    const promise = f(...args)
+
+    id += 1
+    checkResult(promise, deferred, id)
+
+    return deferred.promise
+  }
+}


### PR DESCRIPTION
_Problem:_

A `TimeSeries` component fetches time series data according to its props, and provides the data to its children once it has been fetched.

If the props are updated in quick succession, multiple requests for data are issued concurrently. These requests may resolve in an order different than the order in which they were issued, resulting in stale data being provided to the children.

Since the status of each request is represented by a `Promise`, no idiomatic solution exists for canceling old requests.

_Solution:_

Introduce a `restartable` utility for wrapping a `Promise`-returning function. This utility ensures that when multiple pending promises for a function exist, 

- Only the last issue promise can resolve successfully
- Every other promise will be rejected with a `CancellationError`
