### PR TITLE
fix(http): add userID parameter

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3121,6 +3121,13 @@ paths:
       summary: Update password
       security:
         - basicAuth: []
+      parameters:
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: ID of the user
       requestBody:
         description: new password
         required: true


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_

_What was the problem?_
Declared parameter `userID` in path `/users/{userID}/password` but not in parameters block.

_What was the solution?_
add userID parameter

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)