### PR TITLE
Remove Index.CreateSeriesIfNotExists

### DIFF
--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -120,12 +120,6 @@ func (i *Index) MustOpen() {
 	}
 }
 
-func (idx *Index) AddSeries(name string, tags map[string]string, typ models.FieldType) error {
-	t := models.NewTags(tags)
-	key := fmt.Sprintf("%s,%s", name, t.HashKey())
-	return idx.CreateSeriesIfNotExists([]byte(key), []byte(name), t, typ)
-}
-
 // Reopen closes and re-opens the underlying index, without removing any data.
 func (i *Index) Reopen() error {
 	if err := i.Index.Close(); err != nil {

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -1107,10 +1107,6 @@ func (e *Engine) CreateSeriesListIfNotExists(collection *tsdb.SeriesCollection) 
 	return e.index.CreateSeriesListIfNotExists(collection)
 }
 
-func (e *Engine) CreateSeriesIfNotExists(key, name []byte, tags models.Tags, typ models.FieldType) error {
-	return e.index.CreateSeriesIfNotExists(key, name, tags, typ)
-}
-
 // WriteSnapshot will snapshot the cache and write a new TSM file with its contents, releasing the snapshot when done.
 func (e *Engine) WriteSnapshot() error {
 	// Lock and grab the cache snapshot along with all the closed WAL


### PR DESCRIPTION
Updates #896

It seems that the role of `CreateSeriesIfNotExists` method has been replaced by `CreateSeriesListIfNotExists` .

  - [x] Rebased/mergeable
  - [x] Tests pass
