### PR TITLE
fix(storage): allow disabling the WAL

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -123,15 +123,17 @@ func NewEngine(path string, c Config, options ...Option) *Engine {
 		tsi1.WithPath(c.GetIndexPath(path)))
 
 	// Initialize WAL
+	var wal tsm1.Log = new(tsm1.NopWAL)
 	if c.WAL.Enabled {
 		e.wal = tsm1.NewWAL(c.GetWALPath(path))
 		e.wal.WithFsyncDelay(time.Duration(c.WAL.FsyncDelay))
 		e.wal.EnableTraceLogging(c.TraceLoggingEnabled)
+		wal = e.wal
 	}
 
 	// Initialise Engine
 	e.engine = tsm1.NewEngine(c.GetEnginePath(path), e.index, c.Engine,
-		tsm1.WithWAL(e.wal),
+		tsm1.WithWAL(wal),
 		tsm1.WithTraceLogging(c.TraceLoggingEnabled))
 
 	// Apply options.

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -181,6 +181,26 @@ func TestEngineClose_RemoveIndex(t *testing.T) {
 	}
 }
 
+func TestEngine_WALDisabled(t *testing.T) {
+	config := storage.NewConfig()
+	config.WAL.Enabled = false
+
+	engine := NewEngine(config)
+	defer engine.Close()
+	engine.MustOpen()
+
+	pt := models.MustNewPoint(
+		"cpu",
+		models.NewTags(map[string]string{"host": "server"}),
+		map[string]interface{}{"value": 1.0},
+		time.Unix(1, 2),
+	)
+
+	if err := engine.Write1xPoints([]models.Point{pt}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type Engine struct {
 	path string
 	*storage.Engine

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -115,6 +115,12 @@ type EngineOption func(i *Engine)
 
 // WithWAL sets the WAL for the Engine
 var WithWAL = func(wal Log) EngineOption {
+	// be defensive: it's very easy to pass in a nil WAL here
+	// which will panic. Set any nil WALs to the NopWAL.
+	if pwal, _ := wal.(*WAL); pwal == nil {
+		wal = NopWAL{}
+	}
+
 	return func(e *Engine) {
 		e.WAL = wal
 	}


### PR DESCRIPTION
We were passing a non-nil `tsm1.Log` containing a nil `*tsm1.WAL` which
would cause a panic when it was attempted to be used. Instead, always
pass a non-nil WAL.

We change the storage engine code to not pass in a nil WAL, and
additionally add a defensive check to change any nil WALs into a
`NopWAL`.
