### PR TITLE
fix(storage): missing `continue`

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -308,6 +308,7 @@ func (e *Engine) WritePoints(points []models.Point) error {
 			}
 			collection.Dropped++
 			collection.DroppedKeys = append(collection.DroppedKeys, iter.Key())
+			continue
 		}
 
 		// Filter out any tags with key equal to "time": they are invalid.


### PR DESCRIPTION
Looks like a 'continue` is missing here.

  - [x] Rebased/mergeable
  - [x] Tests pass

