### PR TITLE
fix 404 to an empty array

### DIFF
--- a/bolt/telegraf.go
+++ b/bolt/telegraf.go
@@ -88,9 +88,7 @@ func (c *Client) findTelegrafConfigs(ctx context.Context, tx *bolt.Tx, filter pl
 		}
 	}
 	if len(m) == 0 {
-		return nil, 0, &platform.Error{
-			Code: platform.ENotFound,
-		}
+		return tcs, 0, nil
 	}
 	for _, item := range m {
 		tc, err := c.findTelegrafConfigByID(ctx, tx, item.ResourceID)

--- a/inmem/telegraf.go
+++ b/inmem/telegraf.go
@@ -66,9 +66,7 @@ func (s *Service) findTelegrafConfigs(ctx context.Context, filter platform.UserR
 		}
 	}
 	if len(m) == 0 {
-		return nil, 0, &platform.Error{
-			Code: platform.ENotFound,
-		}
+		return tcs, 0, nil
 	}
 	for _, item := range m {
 		tc, err := s.findTelegrafConfigByID(ctx, item.ResourceID)

--- a/testing/telegraf.go
+++ b/testing/telegraf.go
@@ -727,6 +727,21 @@ func FindTelegrafConfigs(
 		wants  wants
 	}{
 		{
+			name: "find nothing",
+			fields: TelegrafConfigFields{
+				UserResourceMappings: []*platform.UserResourceMapping{},
+				TelegrafConfigs:      []*platform.TelegrafConfig{},
+			},
+			args: args{
+				filter: platform.UserResourceMappingFilter{
+					ResourceType: platform.TelegrafResourceType,
+				},
+			},
+			wants: wants{
+				telegrafConfigs: []*platform.TelegrafConfig{},
+			},
+		},
+		{
 			name: "find all telegraf configs",
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{


### PR DESCRIPTION
Closes https://github.com/influxdata/platform/issues/1390

Currently if no telegraf configs was in db, it will return 404 not found error.
As chronograf team points out, we should not return an empty array without error.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)