### PR TITLE
fix GetMembersHandler

### DIFF
--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -125,7 +125,7 @@ func newGetMembersHandler(s platform.UserResourceMappingService, userType platfo
 
 		filter := platform.UserResourceMappingFilter{
 			ResourceID: req.ResourceID,
-			UserType:   platform.Member,
+			UserType:   userType,
 		}
 
 		opts := platform.FindOptions{}


### PR DESCRIPTION
_What was the problem?_
The `user_resource_mapping_service` return only the `platform.Member` user mappings.

_What was the solution?_
Use the `userType` parameter to filtering user resource.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)