### PR TITLE
Fixed the organizations members paths

### DIFF
--- a/http/org_service.go
+++ b/http/org_service.go
@@ -29,9 +29,9 @@ const (
 	organizationsIDPath          = "/api/v2/orgs/:id"
 	organizationsIDLogPath       = "/api/v2/orgs/:id/log"
 	organizationsIDMembersPath   = "/api/v2/orgs/:id/members"
-	organizationsIDMembersIDPath = "/api/v2/orgs/:id/members/:organizationID"
+	organizationsIDMembersIDPath = "/api/v2/orgs/:id/members/:userID"
 	organizationsIDOwnersPath    = "/api/v2/orgs/:id/owners"
-	organizationsIDOwnersIDPath  = "/api/v2/orgs/:id/owners/:organizationID"
+	organizationsIDOwnersIDPath  = "/api/v2/orgs/:id/owners/:userID"
 )
 
 // NewOrgHandler returns a new instance of OrgHandler.


### PR DESCRIPTION
_What was the problem?_
The `org_service newDeleteMemberHandler` doesn't delete members and a `url missing member id` error is produce.

_What was the solution?_
Changing the mapping from a `organizationID ` to a `userID` according to implementation of [decodeDeleteMemberRequest](https://github.com/influxdata/platform/blob/b2afb98f7c2d4dfbce12757c0beb37705e585223/http/user_resource_mapping_service.go#L206).

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)