### PR TITLE
Fix encoding bug that could tie up compactions

### DIFF
--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -388,6 +388,7 @@ NEXTVALUE:
 
 		// try to pack run of 240 or 120 1s
 		if len(remaining) >= 120 {
+			// Invariant: len(a) is fixed to 120 or 240 values
 			var a []uint64
 			if len(remaining) >= 240 {
 				a = remaining[:240]
@@ -395,24 +396,31 @@ NEXTVALUE:
 				a = remaining[:120]
 			}
 
+			// search for the longest sequence of 1s in a
+			// Postcondition: k equals the index of the last 1 or -1
 			k := 0
 			for k = range a {
 				if a[k] != 1 {
+					k--
 					break
 				}
 			}
 
 			v := uint64(0)
 			switch {
-			case k >= 239:
+			case k == 239:
+				// 240 1s
 				i += 240
+
 			case k >= 119:
+				// at least 120 1s
 				v = 1 << 60
 				i += 120
 
 			default:
 				goto CODES
 			}
+
 			dst[j] = v
 			j++
 			continue

--- a/pkg/encoding/simple8b/encoding_test.go
+++ b/pkg/encoding/simple8b/encoding_test.go
@@ -123,6 +123,16 @@ func TestEncodeAll(t *testing.T) {
 			in[120] = 5
 			return in
 		}},
+		{name: "119 ones", fn: func() []uint64 {
+			in := ones(240)()
+			in[119] = 5
+			return in
+		}},
+		{name: "239 ones", fn: func() []uint64 {
+			in := ones(241)()
+			in[239] = 5
+			return in
+		}},
 	}
 
 	for _, test := range tests {

--- a/tsdb/tsm1/compact.gen.go
+++ b/tsdb/tsm1/compact.gen.go
@@ -1076,6 +1076,14 @@ func (k *tsmBatchKeyIterator) combineFloat(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1150,6 +1158,11 @@ func (k *tsmBatchKeyIterator) combineFloat(dedup bool) blocks {
 		if err := DecodeFloatArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1282,6 +1295,14 @@ func (k *tsmBatchKeyIterator) combineInteger(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1356,6 +1377,11 @@ func (k *tsmBatchKeyIterator) combineInteger(dedup bool) blocks {
 		if err := DecodeIntegerArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1488,6 +1514,14 @@ func (k *tsmBatchKeyIterator) combineUnsigned(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1562,6 +1596,11 @@ func (k *tsmBatchKeyIterator) combineUnsigned(dedup bool) blocks {
 		if err := DecodeUnsignedArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1694,6 +1733,14 @@ func (k *tsmBatchKeyIterator) combineString(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1768,6 +1815,11 @@ func (k *tsmBatchKeyIterator) combineString(dedup bool) blocks {
 		if err := DecodeStringArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1900,6 +1952,14 @@ func (k *tsmBatchKeyIterator) combineBoolean(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1974,6 +2034,11 @@ func (k *tsmBatchKeyIterator) combineBoolean(dedup bool) blocks {
 		if err := DecodeBooleanArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block

--- a/tsdb/tsm1/compact.gen.go.tmpl
+++ b/tsdb/tsm1/compact.gen.go.tmpl
@@ -279,6 +279,14 @@ func (k *tsmBatchKeyIterator) combine{{.Name}}(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -353,6 +361,11 @@ func (k *tsmBatchKeyIterator) combine{{.Name}}(dedup bool) blocks {
 		if err := Decode{{.Name}}ArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block

--- a/tsdb/tsm1/compact_test.go
+++ b/tsdb/tsm1/compact_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/platform/tsdb/tsm1"
+	"github.com/influxdata/platform/tsdb/cursors"
 )
 
 //  Tests compacting a Cache snapshot into a single TSM file
@@ -86,6 +87,58 @@ func TestCompactor_Snapshot(t *testing.T) {
 		for i, point := range p.points {
 			assertValueEqual(t, values[i], point)
 		}
+	}
+}
+
+func TestCompactor_CompactFullLastTimestamp(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+
+	var vals tsm1.Values
+	ts := int64(1e9)
+	for i := 0; i < 120; i++ {
+		vals = append(vals, tsm1.NewIntegerValue(ts, 1))
+		ts += 1e9
+	}
+	// 121st timestamp skips a second
+	ts += 1e9
+	vals = append(vals, tsm1.NewIntegerValue(ts, 1))
+	writes := map[string][]tsm1.Value{
+		"cpu,host=A#!~#value": vals[:100],
+	}
+	f1 := MustWriteTSM(dir, 1, writes)
+
+	writes = map[string][]tsm1.Value{
+		"cpu,host=A#!~#value": vals[100:],
+	}
+	f2 := MustWriteTSM(dir, 2, writes)
+
+	fs := &fakeFileStore{}
+	defer fs.Close()
+	compactor := tsm1.NewCompactor()
+	compactor.Dir = dir
+	compactor.FileStore = fs
+	compactor.Open()
+
+	files, err := compactor.CompactFull([]string{f1, f2})
+	if err != nil {
+		t.Fatalf("unexpected error writing snapshot: %v", err)
+	}
+
+	r := MustOpenTSMReader(files[0])
+	entries := r.Entries([]byte("cpu,host=A#!~#value"))
+	_, b, err := r.ReadBytes(&entries[0], nil)
+	if err != nil {
+		t.Fatalf("ReadBytes: unexpected error %v", err)
+	}
+	var a cursors.IntegerArray
+	err = tsm1.DecodeIntegerArrayBlock(b, &a)
+	if err != nil {
+		t.Fatalf("DecodeIntegerArrayBlock: unexpected error %v", err)
+	}
+
+	if a.MaxTime() != entries[0].MaxTime {
+		t.Fatalf("expected MaxTime == a.MaxTime()")
 	}
 }
 


### PR DESCRIPTION
This PR brings in commits from InfluxDB https://github.com/influxdata/influxdb/pull/10479 to the 2.0 engine.

An encoding bug could cause certain compressed data to be incorrectly written in the case that there were 120 or 240 values in a row that all were 1, and were to be compressed with `simple8b`. This bug is quite hard to trigger, but most commonly was triggered by some sets of evenly spaced timestamps that were then delta encoded and compressed with `simple8b`.