### PR TITLE
Added toggle on Task Header for option to show only active

### DIFF
--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -74,9 +74,7 @@ export interface SetSearchTerm {
 
 export interface SetShowInactive {
   type: ActionTypes.SetShowInactive
-  payload: {
-    showInactive: boolean
-  }
+  payload: {}
 }
 
 export const setNewScript = (script: string): SetNewScript => ({
@@ -104,9 +102,9 @@ export const setSearchTerm = (searchTerm: string): SetSearchTerm => ({
   payload: {searchTerm},
 })
 
-export const setShowInactive = (showInactive: boolean): SetShowInactive => ({
+export const setShowInactive = (): SetShowInactive => ({
   type: ActionTypes.SetShowInactive,
-  payload: {showInactive},
+  payload: {},
 })
 
 export const updateTaskStatus = (task: Task) => async (

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -26,6 +26,7 @@ export type Action =
   | SetSearchTerm
   | SetCurrentScript
   | SetCurrentTask
+  | SetShowInactive
 
 type GetStateFunc = () => AppState
 
@@ -35,6 +36,7 @@ export enum ActionTypes {
   SetSearchTerm = 'SET_TASKS_SEARCH_TERM',
   SetCurrentScript = 'SET_CURRENT_SCRIPT',
   SetCurrentTask = 'SET_CURRENT_TASK',
+  SetShowInactive = 'SET_TASKS_SHOW_INACTIVE',
 }
 
 export interface SetNewScript {
@@ -70,6 +72,13 @@ export interface SetSearchTerm {
   }
 }
 
+export interface SetShowInactive {
+  type: ActionTypes.SetShowInactive
+  payload: {
+    showInactive: boolean
+  }
+}
+
 export const setNewScript = (script: string): SetNewScript => ({
   type: ActionTypes.SetNewScript,
   payload: {script},
@@ -90,9 +99,14 @@ export const setTasks = (tasks: Task[]): SetTasks => ({
   payload: {tasks},
 })
 
-export const setSearchTerm = (searchTerm: string) => ({
+export const setSearchTerm = (searchTerm: string): SetSearchTerm => ({
   type: ActionTypes.SetSearchTerm,
   payload: {searchTerm},
+})
+
+export const setShowInactive = (showInactive: boolean): SetShowInactive => ({
+  type: ActionTypes.SetShowInactive,
+  payload: {showInactive},
 })
 
 export const updateTaskStatus = (task: Task) => async (

--- a/ui/src/tasks/api/v2/index.ts
+++ b/ui/src/tasks/api/v2/index.ts
@@ -51,7 +51,6 @@ export const getUserTasks = async (url, user): Promise<Task[]> => {
   const {
     data: {tasks},
   } = await AJAX({url: completeUrl})
-
   return tasks
 }
 

--- a/ui/src/tasks/components/TaskRow.tsx
+++ b/ui/src/tasks/components/TaskRow.tsx
@@ -22,7 +22,6 @@ interface Props {
 export default class TaskRow extends PureComponent<Props> {
   public render() {
     const {task} = this.props
-
     return (
       <IndexList.Row disabled={!this.isTaskActive}>
         <IndexList.Cell>

--- a/ui/src/tasks/components/TasksHeader.tsx
+++ b/ui/src/tasks/components/TasksHeader.tsx
@@ -1,16 +1,29 @@
 import React, {PureComponent} from 'react'
 import {Page} from 'src/pageLayout'
-import {Button, ComponentColor, IconFont} from 'src/clockface'
+import {
+  Button,
+  ComponentColor,
+  IconFont,
+  ComponentSize,
+  SlideToggle,
+} from 'src/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 
 interface Props {
   onCreateTask: () => void
-  filterTasks: (searchTerm: string) => void
+  setSearchTerm: (searchTerm: string) => void
+  setShowInactive: () => void
+  showInactive: boolean
 }
 
 export default class TasksHeader extends PureComponent<Props> {
   public render() {
-    const {onCreateTask, filterTasks} = this.props
+    const {
+      onCreateTask,
+      setSearchTerm,
+      setShowInactive,
+      showInactive,
+    } = this.props
 
     return (
       <Page.Header fullWidth={false}>
@@ -18,9 +31,15 @@ export default class TasksHeader extends PureComponent<Props> {
           <Page.Title title="Tasks" />
         </Page.Header.Left>
         <Page.Header.Right>
+          <div>Show Inactive Tasks</div>
+          <SlideToggle
+            active={showInactive}
+            size={ComponentSize.ExtraSmall}
+            onChange={setShowInactive}
+          />
           <SearchWidget
             placeholderText="Filter tasks by name..."
-            onSearch={filterTasks}
+            onSearch={setSearchTerm}
           />
           <Button
             color={ComponentColor.Primary}

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -46,21 +46,28 @@ type Props = ConnectedDispatchProps & PassedInProps & ConnectedStateProps
 
 @ErrorHandling
 class TasksPage extends PureComponent<Props> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
 
-    this.props.setSearchTerm('')
-    this.props.setShowInactive(true)
+    props.setSearchTerm('')
+    if (!props.showInactive) {
+      props.setShowInactive()
+    }
   }
 
   public render(): JSX.Element {
-    const {setSearchTerm, searchTerm, showInactive} = this.props
+    const {
+      setSearchTerm,
+      searchTerm,
+      setShowInactive,
+      showInactive,
+    } = this.props
     return (
       <Page>
         <TasksHeader
           onCreateTask={this.handleCreateTask}
           setSearchTerm={setSearchTerm}
-          setShowInactive={this.handleInactiveToggle}
+          setShowInactive={setShowInactive}
           showInactive={showInactive}
         />
         <Page.Contents fullWidth={false} scrollable={true}>
@@ -98,7 +105,6 @@ class TasksPage extends PureComponent<Props> {
 
   private get filteredTasks(): Task[] {
     const {tasks, searchTerm, showInactive} = this.props
-
     const matchingTasks = tasks.filter(t => {
       const searchTermFilter = t.name
         .toLowerCase()
@@ -112,11 +118,6 @@ class TasksPage extends PureComponent<Props> {
     })
 
     return matchingTasks
-  }
-
-  private handleInactiveToggle = () => {
-    const {showInactive, setShowInactive} = this.props
-    setShowInactive(!showInactive)
   }
 }
 

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -15,10 +15,11 @@ import {
   deleteTask,
   selectTask,
   setSearchTerm as setSearchTermAction,
+  setShowInactive as setShowInactiveAction,
 } from 'src/tasks/actions/v2'
 
 // Types
-import {Task} from 'src/types/v2/tasks'
+import {Task, TaskStatus} from 'src/types/v2/tasks'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -32,11 +33,13 @@ interface ConnectedDispatchProps {
   deleteTask: typeof deleteTask
   selectTask: typeof selectTask
   setSearchTerm: typeof setSearchTermAction
+  setShowInactive: typeof setShowInactiveAction
 }
 
 interface ConnectedStateProps {
   tasks: Task[]
   searchTerm: string
+  showInactive: boolean
 }
 
 type Props = ConnectedDispatchProps & PassedInProps & ConnectedStateProps
@@ -47,16 +50,18 @@ class TasksPage extends PureComponent<Props> {
     super(props)
 
     this.props.setSearchTerm('')
+    this.props.setShowInactive(true)
   }
 
   public render(): JSX.Element {
-    const {setSearchTerm, searchTerm} = this.props
-
+    const {setSearchTerm, searchTerm, showInactive} = this.props
     return (
       <Page>
         <TasksHeader
           onCreateTask={this.handleCreateTask}
-          filterTasks={setSearchTerm}
+          setSearchTerm={setSearchTerm}
+          setShowInactive={this.handleInactiveToggle}
+          showInactive={showInactive}
         />
         <Page.Contents fullWidth={false} scrollable={true}>
           <div className="col-xs-12">
@@ -92,18 +97,33 @@ class TasksPage extends PureComponent<Props> {
   }
 
   private get filteredTasks(): Task[] {
-    const {tasks, searchTerm} = this.props
+    const {tasks, searchTerm, showInactive} = this.props
 
-    const matchingTasks = tasks.filter(t =>
-      t.name.toLowerCase().includes(searchTerm.toLowerCase())
-    )
+    const matchingTasks = tasks.filter(t => {
+      const searchTermFilter = t.name
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase())
+      let activeFilter = true
+      if (!showInactive) {
+        activeFilter = t.status === TaskStatus.Active
+      }
+
+      return searchTermFilter && activeFilter
+    })
 
     return matchingTasks
   }
+
+  private handleInactiveToggle = () => {
+    const {showInactive, setShowInactive} = this.props
+    setShowInactive(!showInactive)
+  }
 }
 
-const mstp = ({tasks: {tasks, searchTerm}}): ConnectedStateProps => {
-  return {tasks, searchTerm}
+const mstp = ({
+  tasks: {tasks, searchTerm, showInactive},
+}): ConnectedStateProps => {
+  return {tasks, searchTerm, showInactive}
 }
 
 const mdtp: ConnectedDispatchProps = {
@@ -112,6 +132,7 @@ const mdtp: ConnectedDispatchProps = {
   deleteTask,
   selectTask,
   setSearchTerm: setSearchTermAction,
+  setShowInactive: setShowInactiveAction,
 }
 
 export default connect<

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -37,8 +37,7 @@ export default (state: State = defaultState, action: Action): State => {
       const {searchTerm} = action.payload
       return {...state, searchTerm}
     case ActionTypes.SetShowInactive:
-      const {showInactive} = action.payload
-      return {...state, showInactive}
+      return {...state, showInactive: !state.showInactive}
     default:
       return state
   }

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -7,6 +7,7 @@ export interface State {
   currentTask?: Task
   tasks: Task[]
   searchTerm: string
+  showInactive: boolean
 }
 
 const defaultState: State = {
@@ -14,6 +15,7 @@ const defaultState: State = {
   currentScript: '',
   tasks: [],
   searchTerm: '',
+  showInactive: true,
 }
 
 export default (state: State = defaultState, action: Action): State => {
@@ -34,6 +36,9 @@ export default (state: State = defaultState, action: Action): State => {
     case ActionTypes.SetSearchTerm:
       const {searchTerm} = action.payload
       return {...state, searchTerm}
+    case ActionTypes.SetShowInactive:
+      const {showInactive} = action.payload
+      return {...state, showInactive}
     default:
       return state
   }


### PR DESCRIPTION
Co-authored-by: Deniz Kusefoglu <deniz@influxdata.com>

Closes #1369 

_What was the solution?_ Added a toggle on task header for option to show only active tasks.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)