### PR TITLE
Improve Usability of Radio Buttons

### DIFF
--- a/ui/src/clockface/components/radio_buttons/RadioButtons.scss
+++ b/ui/src/clockface/components/radio_buttons/RadioButtons.scss
@@ -5,50 +5,43 @@
 
 @import "src/style/modules";
 
+$radio-buttons--padding: 4px;
+
 .radio-buttons {
   display: inline-flex;
   align-items: stretch;
+  padding: $radio-buttons--padding;
+  border-radius: $radius;
+  background-color: $g5-pepper;
 }
 
 .radio-button {
   @include no-user-select();
+  border: 0;
   font-family: $ix-text-font;
   font-weight: 600;
+  background-color: transparent;
   transition: background-color 0.25s ease, color 0.25s ease;
-  background-color: $g2-kevlar;
   color: $g11-sidewalk;
   text-transform: capitalize;
+  border-radius: $radius - 1px;
   outline: none;
-  border: $ix-border solid $g5-pepper;
-  border-right-width: 0;
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
 
-  &:first-child {
-    border-top-left-radius: $ix-radius;
-    border-bottom-left-radius: $ix-radius;
-  }
-
-  &:last-child {
-    border-top-right-radius: $ix-radius;
-    border-bottom-right-radius: $ix-radius;
-    border-right-width: $ix-border;
-  }
-
   &:hover {
-    background-color: $g4-onyx;
+    // background-color: $g4-onyx;
     color: $g15-platinum;
     cursor: pointer;
   }
 
   &.active {
-    background-color: $g5-pepper;
+    color: $g20-white;
   }
 
   &.disabled,
   &.disabled:hover {
-    background-color: $g2-kevlar;
     font-style: italic;
     color: $g7-graphite;
   }
@@ -59,7 +52,8 @@
   height: $height;
 
   .radio-button {
-    height: $height;
+    height: $height - ($radio-buttons--padding * 2);
+    line-height: $height - ($radio-buttons--padding * 2);
     padding: 0 $padding;
     font-size: $fontSize;
   }
@@ -82,32 +76,32 @@
 /* Color Modifiers */
 .radio-buttons--default {
   .radio-button.active {
-    color: $g18-cloud;
+    background-color: $g7-graphite;
   }
 }
 .radio-buttons--primary {
   .radio-button.active {
-    color: $c-pool;
+    background-color: $c-pool;
   }
 }
 .radio-buttons--success {
   .radio-button.active {
-    color: $c-rainforest;
+    background-color: $c-rainforest;
   }
 }
 .radio-buttons--warning {
   .radio-button.active {
-    color: $c-comet;
+    background-color: $c-star;
   }
 }
 .radio-buttons--danger {
   .radio-button.active {
-    color: $c-dreamsicle;
+    background-color: $c-curacao;
   }
 }
 .radio-buttons--alert {
   .radio-button.active {
-    color: $c-pineapple;
+    background-color: $c-pineapple;
   }
 }
 

--- a/ui/src/clockface/components/radio_buttons/RadioButtons.scss
+++ b/ui/src/clockface/components/radio_buttons/RadioButtons.scss
@@ -31,7 +31,6 @@ $radio-buttons--padding: 4px;
   overflow: hidden;
 
   &:hover {
-    // background-color: $g4-onyx;
     color: $g15-platinum;
     cursor: pointer;
   }
@@ -84,14 +83,14 @@ $radio-buttons--padding: 4px;
     background-color: $c-pool;
   }
 }
+.radio-buttons--secondary {
+  .radio-button.active {
+    background-color: $c-star;
+  }
+}
 .radio-buttons--success {
   .radio-button.active {
     background-color: $c-rainforest;
-  }
-}
-.radio-buttons--warning {
-  .radio-button.active {
-    background-color: $c-star;
   }
 }
 .radio-buttons--danger {

--- a/ui/src/clockface/components/radio_buttons/RadioButtons.scss
+++ b/ui/src/clockface/components/radio_buttons/RadioButtons.scss
@@ -3,6 +3,8 @@
    -----------------------------------------------------------------------------
 */
 
+@import "src/style/modules";
+
 .radio-buttons {
   display: inline-flex;
   align-items: stretch;

--- a/ui/src/clockface/components/radio_buttons/RadioButtons.tsx
+++ b/ui/src/clockface/components/radio_buttons/RadioButtons.tsx
@@ -11,6 +11,9 @@ import {ComponentColor, ComponentSize, ButtonShape} from 'src/clockface/types'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+// Styles
+import './RadioButtons.scss'
+
 interface Props {
   children: JSX.Element[]
   customClass?: string

--- a/ui/src/clockface/components/radio_buttons/RadioButtons.tsx
+++ b/ui/src/clockface/components/radio_buttons/RadioButtons.tsx
@@ -25,7 +25,7 @@ interface Props {
 @ErrorHandling
 class Radio extends Component<Props> {
   public static defaultProps: Partial<Props> = {
-    color: ComponentColor.Default,
+    color: ComponentColor.Primary,
     size: ComponentSize.Small,
     shape: ButtonShape.Default,
   }

--- a/ui/src/clockface/styles.scss
+++ b/ui/src/clockface/styles.scss
@@ -13,7 +13,6 @@
 @import 'components/inputs/Input';
 @import 'components/overlays/Overlay';
 @import 'components/panel/Panel';
-@import 'components/radio_buttons/RadioButtons';
 @import 'components/slide_toggle/SlideToggle';
 @import 'components/wizard/WizardFullScreen';
 @import 'components/wizard/WizardProgressHeader';


### PR DESCRIPTION
_What was the problem?_

Unless there are at least 3 items in a radio button set, it is very difficult to tell which is the selected item

_What was the solution?_

Re-styled the radio buttons to look less like text inputs and have a more obvious active state by default. Radio buttons use the `Primary` theme by default which makes them blue

![screen shot 2018-11-14 at 2 35 15 pm](https://user-images.githubusercontent.com/2433762/48517478-45f14180-e81b-11e8-8d24-b00167e13e50.png)

  - [x] Rebased/mergeable
  - [x] Tests pass