### PR TITLE
Add export button on task row

### DIFF
--- a/ui/src/tasks/components/TaskRow.tsx
+++ b/ui/src/tasks/components/TaskRow.tsx
@@ -9,6 +9,7 @@ import {
   SlideToggle,
 } from 'src/clockface'
 import IndexList from 'src/shared/components/index_views/IndexList'
+import download from 'src/external/download'
 
 import {Task, TaskStatus} from 'src/types/v2/tasks'
 
@@ -44,6 +45,12 @@ export default class TaskRow extends PureComponent<Props> {
           <ComponentSpacer align={Alignment.Right}>
             <Button
               size={ComponentSize.ExtraSmall}
+              color={ComponentColor.Default}
+              text="Export"
+              onClick={this.handleExport}
+            />
+            <Button
+              size={ComponentSize.ExtraSmall}
               color={ComponentColor.Danger}
               text="Delete"
               onClick={this.handleDelete}
@@ -62,6 +69,11 @@ export default class TaskRow extends PureComponent<Props> {
 
   private handleDelete = () => {
     this.props.onDelete(this.props.task)
+  }
+
+  private handleExport = () => {
+    const {task} = this.props
+    download(task.flux, `${task.name}.flux`, 'text/plain')
   }
 
   private get isTaskActive(): boolean {


### PR DESCRIPTION
Co-authored-by: Palak Bhojani <palak@influxdata.com>
Co-authored-by: Deniz Kusefoglu <deniz@influxdata.com>

Closes #1370 

_What was the solution?_ Task Row has an export button to export the flux in .flux extension

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)