### PR TITLE
feat(kit/grpc): add translation between gRPC status and platform.Error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -10,11 +10,12 @@ import (
 // Some error code constant, ideally we want define common platform codes here
 // projects on use platform's error, should have their own central place like this.
 const (
-	EInternal   = "internal error"
-	ENotFound   = "not found"
-	EConflict   = "conflict" // action cannot be performed
-	EInvalid    = "invalid"  // validation failed
-	EEmptyValue = "empty value"
+	EInternal    = "internal error"
+	ENotFound    = "not found"
+	EConflict    = "conflict" // action cannot be performed
+	EInvalid     = "invalid"  // validation failed
+	EEmptyValue  = "empty value"
+	EUnavailable = "unavailable"
 )
 
 // Error is the error struct of platform.

--- a/http/errors.go
+++ b/http/errors.go
@@ -170,9 +170,10 @@ func statusCode(e kerrors.Error) int {
 
 // statusCodePlatformError is the map convert platform.Error to error
 var statusCodePlatformError = map[string]int{
-	platform.EInternal:   http.StatusInternalServerError,
-	platform.EInvalid:    http.StatusBadRequest,
-	platform.EEmptyValue: http.StatusBadRequest,
-	platform.EConflict:   http.StatusUnprocessableEntity,
-	platform.ENotFound:   http.StatusNotFound,
+	platform.EInternal:    http.StatusInternalServerError,
+	platform.EInvalid:     http.StatusBadRequest,
+	platform.EEmptyValue:  http.StatusBadRequest,
+	platform.EConflict:    http.StatusUnprocessableEntity,
+	platform.ENotFound:    http.StatusNotFound,
+	platform.EUnavailable: http.StatusServiceUnavailable,
 }

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3905,6 +3905,7 @@ components:
             - conflict
             - invalid
             - empty value
+            - unavailable
         message:
           readOnly: true
           description: message is a human-readable message.
@@ -3930,6 +3931,7 @@ components:
             - conflict
             - invalid
             - empty value
+            - unavailable
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/kit/grpc/errors.go
+++ b/kit/grpc/errors.go
@@ -1,0 +1,54 @@
+package grpc
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/influxdata/platform"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ToStatus converts a platform.Error to a gRPC status message.
+func ToStatus(err *platform.Error) (*status.Status, error) {
+	if err == nil {
+		return status.New(codes.OK, ""), nil
+	}
+
+	c := codes.Unknown
+	switch err.Code {
+	case platform.EInternal:
+		c = codes.Internal
+	case platform.ENotFound:
+		c = codes.NotFound
+	case platform.EConflict, platform.EInvalid, platform.EEmptyValue: // not really sure how to express this as gRPC only has Invalid
+		c = codes.InvalidArgument
+	case platform.EUnavailable:
+		c = codes.Unavailable
+	}
+
+	buf, jerr := json.Marshal(err)
+	if jerr != nil {
+		return nil, jerr
+	}
+
+	return status.New(c, string(buf)), nil
+}
+
+// FromStatus converts a gRPC status message to a platform.Error.
+func FromStatus(s *status.Status) *platform.Error {
+	if s == nil || s.Code() == codes.OK {
+		return nil
+	}
+
+	msg := s.Message()
+	var perr platform.Error
+	if err := json.Unmarshal([]byte(msg), &perr); err != nil {
+		return &platform.Error{
+			Err:  errors.New(msg),
+			Code: platform.EInternal,
+		}
+	}
+
+	return &perr
+}

--- a/kit/grpc/errors_test.go
+++ b/kit/grpc/errors_test.go
@@ -1,0 +1,126 @@
+package grpc
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/platform"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestToStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         *platform.Error
+		wantCode    codes.Code
+		wantMessage string
+		wantErr     bool
+	}{
+		{
+			name:     "encode nil error",
+			wantCode: codes.OK,
+		},
+		{
+			name: "encode internal error",
+			err: &platform.Error{
+				Err:  fmt.Errorf("error"),
+				Op:   "kit/grpc",
+				Code: platform.EInternal,
+				Msg:  "howdy",
+			},
+			wantCode:    codes.Internal,
+			wantMessage: `{"code":"internal error","msg":"howdy","op":"kit/grpc","err":"error"}`,
+		},
+		{
+			name: "encode not found error",
+			err: &platform.Error{
+				Err:  fmt.Errorf("error"),
+				Op:   "kit/grpc",
+				Code: platform.ENotFound,
+				Msg:  "howdy",
+			},
+			wantCode:    codes.NotFound,
+			wantMessage: `{"code":"not found","msg":"howdy","op":"kit/grpc","err":"error"}`,
+		},
+		{
+			name: "encode invalid error",
+			err: &platform.Error{
+				Err:  fmt.Errorf("error"),
+				Op:   "kit/grpc",
+				Code: platform.EInvalid,
+				Msg:  "howdy",
+			},
+			wantCode:    codes.InvalidArgument,
+			wantMessage: `{"code":"invalid","msg":"howdy","op":"kit/grpc","err":"error"}`,
+		},
+		{
+			name: "encode unavailable error",
+			err: &platform.Error{
+				Err:  fmt.Errorf("error"),
+				Op:   "kit/grpc",
+				Code: platform.EUnavailable,
+				Msg:  "howdy",
+			},
+			wantCode:    codes.Unavailable,
+			wantMessage: `{"code":"unavailable","msg":"howdy","op":"kit/grpc","err":"error"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToStatus(tt.err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.Code() != tt.wantCode {
+				t.Errorf("ToStatus().Code() = %v, want %v", got.Code(), tt.wantCode)
+			}
+			if got.Message() != tt.wantMessage {
+				t.Errorf("ToStatus().Message() = %v, want %v", got.Message(), tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestFromStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *status.Status
+		want *platform.Error
+	}{
+		{
+			name: "nil status returns nil error",
+		},
+		{
+			name: "OK status returns nil error",
+			s: status.New(codes.OK, ""),
+		},
+		{
+			name: "status message that is not JSON is internal error",
+			s: status.New(codes.Internal, "bad"),
+			want: &platform.Error{
+				Err: fmt.Errorf("bad"),
+				Code: platform.EInternal,
+			},
+		},	
+		{
+			name: "status message with embedded platform error",
+			s: status.New(codes.Internal, `{"code":"unavailable","msg":"howdy","op":"kit/grpc","err":"error"}`),
+			want: &platform.Error{
+				Err: fmt.Errorf("error"),
+				Code: platform.EUnavailable,
+				Msg: "howdy",
+				Op: "kit/grpc",
+			},
+		},	
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FromStatus(tt.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FromStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
Add new kit library to standardize translate between gRPC status errors and platform.Errors.

_What was the problem?_
gRPC services have a "status" error that is returned.  We need to translate them to our standard error format.

_What was the solution?_
Translates between gRPC status errors and platform.Error

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
