### PR TITLE
Create a dropdown filter to filter tasks through Organizations

### DIFF
--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -27,6 +27,7 @@ export type Action =
   | SetCurrentScript
   | SetCurrentTask
   | SetShowInactive
+  | SetDropdownOrgID
 
 type GetStateFunc = () => AppState
 
@@ -37,6 +38,7 @@ export enum ActionTypes {
   SetCurrentScript = 'SET_CURRENT_SCRIPT',
   SetCurrentTask = 'SET_CURRENT_TASK',
   SetShowInactive = 'SET_TASKS_SHOW_INACTIVE',
+  SetDropdownOrgID = 'SET_DROPDOWN_ORG_ID',
 }
 
 export interface SetNewScript {
@@ -77,6 +79,13 @@ export interface SetShowInactive {
   payload: {}
 }
 
+export interface SetDropdownOrgID {
+  type: ActionTypes.SetDropdownOrgID
+  payload: {
+    dropdownOrgID: string
+  }
+}
+
 export const setNewScript = (script: string): SetNewScript => ({
   type: ActionTypes.SetNewScript,
   payload: {script},
@@ -105,6 +114,11 @@ export const setSearchTerm = (searchTerm: string): SetSearchTerm => ({
 export const setShowInactive = (): SetShowInactive => ({
   type: ActionTypes.SetShowInactive,
   payload: {},
+})
+
+export const setDropdownOrgID = (dropdownOrgID: string): SetDropdownOrgID => ({
+  type: ActionTypes.SetDropdownOrgID,
+  payload: {dropdownOrgID},
 })
 
 export const updateTaskStatus = (task: Task) => async (

--- a/ui/src/tasks/components/TasksHeader.tsx
+++ b/ui/src/tasks/components/TasksHeader.tsx
@@ -1,5 +1,8 @@
+// Libraries
 import React, {PureComponent} from 'react'
 import {Page} from 'src/pageLayout'
+
+// Components
 import {
   Button,
   ComponentColor,
@@ -8,6 +11,7 @@ import {
   SlideToggle,
 } from 'src/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import TaskOrgDropdown from 'src/tasks/components/TasksOrgDropdown'
 
 interface Props {
   onCreateTask: () => void
@@ -41,6 +45,7 @@ export default class TasksHeader extends PureComponent<Props> {
             placeholderText="Filter tasks by name..."
             onSearch={setSearchTerm}
           />
+          <TaskOrgDropdown />
           <Button
             color={ComponentColor.Primary}
             onClick={onCreateTask}

--- a/ui/src/tasks/components/TasksOrgDropdown.tsx
+++ b/ui/src/tasks/components/TasksOrgDropdown.tsx
@@ -1,0 +1,76 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Components
+import {Dropdown} from 'src/clockface'
+
+// Actions
+import {setDropdownOrgID as setDropdownOrgIDAction} from 'src/tasks/actions/v2'
+
+// Constants
+import {defaultAllOrgs} from 'src/tasks/constants'
+
+// Types
+import {Organization} from 'src/types/v2'
+
+interface ConnectedDispatchProps {
+  setDropdownOrgID: typeof setDropdownOrgIDAction
+}
+
+interface ConnectedStateProps {
+  orgs: Organization[]
+  dropdownOrgID: string
+}
+
+type Props = ConnectedDispatchProps & ConnectedStateProps
+
+class TasksOrgDropdown extends PureComponent<Props> {
+  public render() {
+    const {setDropdownOrgID} = this.props
+
+    return (
+      <Dropdown
+        selectedID={this.selectedID}
+        onChange={setDropdownOrgID}
+        widthPixels={200}
+        wrapText={true}
+      >
+        {this.allOrgs.map(({id, name}) => (
+          <Dropdown.Item key={id} value={id} id={id}>
+            {name}
+          </Dropdown.Item>
+        ))}
+      </Dropdown>
+    )
+  }
+
+  private get selectedID(): string {
+    const {dropdownOrgID} = this.props
+    if (!dropdownOrgID) {
+      return this.allOrgs[0].id
+    }
+    return dropdownOrgID
+  }
+
+  private get allOrgs(): Array<Partial<Organization>> {
+    const {orgs} = this.props
+    return [defaultAllOrgs, ...orgs]
+  }
+}
+
+const mstp = ({tasks: {dropdownOrgID}, orgs}): ConnectedStateProps => {
+  return {
+    orgs,
+    dropdownOrgID,
+  }
+}
+
+const mdtp: ConnectedDispatchProps = {
+  setDropdownOrgID: setDropdownOrgIDAction,
+}
+
+export default connect<ConnectedStateProps, ConnectedDispatchProps>(
+  mstp,
+  mdtp
+)(TasksOrgDropdown)

--- a/ui/src/tasks/constants/index.ts
+++ b/ui/src/tasks/constants/index.ts
@@ -1,0 +1,15 @@
+import {Organization} from 'src/types/v2'
+
+export const allOrganizationsID = 'All Organizations'
+
+export const defaultAllOrgs: Organization = {
+  id: allOrganizationsID,
+  name: 'All Organizations',
+  links: {
+    buckets: '',
+    dashboards: '',
+    members: '',
+    self: '',
+    tasks: '',
+  },
+}

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -7,6 +7,7 @@ import {InjectedRouter} from 'react-router'
 import TasksHeader from 'src/tasks/components/TasksHeader'
 import TasksList from 'src/tasks/components/TasksList'
 import {Page} from 'src/pageLayout'
+import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Actions
 import {
@@ -16,12 +17,15 @@ import {
   selectTask,
   setSearchTerm as setSearchTermAction,
   setShowInactive as setShowInactiveAction,
+  setDropdownOrgID as setDropdownOrgIDAction,
 } from 'src/tasks/actions/v2'
+
+// Constants
+import {allOrganizationsID} from 'src/tasks/constants'
 
 // Types
 import {Task, TaskStatus} from 'src/types/v2/tasks'
-
-import {ErrorHandling} from 'src/shared/decorators/errors'
+import {Organization} from 'src/types/v2'
 
 interface PassedInProps {
   router: InjectedRouter
@@ -34,12 +38,15 @@ interface ConnectedDispatchProps {
   selectTask: typeof selectTask
   setSearchTerm: typeof setSearchTermAction
   setShowInactive: typeof setShowInactiveAction
+  setDropdownOrgID: typeof setDropdownOrgIDAction
 }
 
 interface ConnectedStateProps {
   tasks: Task[]
   searchTerm: string
   showInactive: boolean
+  orgs: Organization[]
+  dropdownOrgID: string
 }
 
 type Props = ConnectedDispatchProps & PassedInProps & ConnectedStateProps
@@ -53,6 +60,7 @@ class TasksPage extends PureComponent<Props> {
     if (!props.showInactive) {
       props.setShowInactive()
     }
+    props.setDropdownOrgID(null)
   }
 
   public render(): JSX.Element {
@@ -104,7 +112,7 @@ class TasksPage extends PureComponent<Props> {
   }
 
   private get filteredTasks(): Task[] {
-    const {tasks, searchTerm, showInactive} = this.props
+    const {tasks, searchTerm, showInactive, dropdownOrgID} = this.props
     const matchingTasks = tasks.filter(t => {
       const searchTermFilter = t.name
         .toLowerCase()
@@ -113,8 +121,11 @@ class TasksPage extends PureComponent<Props> {
       if (!showInactive) {
         activeFilter = t.status === TaskStatus.Active
       }
-
-      return searchTermFilter && activeFilter
+      let orgIDFilter = true
+      if (dropdownOrgID && dropdownOrgID !== allOrganizationsID) {
+        orgIDFilter = t.organizationId === dropdownOrgID
+      }
+      return searchTermFilter && activeFilter && orgIDFilter
     })
 
     return matchingTasks
@@ -122,9 +133,16 @@ class TasksPage extends PureComponent<Props> {
 }
 
 const mstp = ({
-  tasks: {tasks, searchTerm, showInactive},
+  tasks: {tasks, searchTerm, showInactive, dropdownOrgID},
+  orgs,
 }): ConnectedStateProps => {
-  return {tasks, searchTerm, showInactive}
+  return {
+    tasks,
+    searchTerm,
+    showInactive,
+    orgs,
+    dropdownOrgID,
+  }
 }
 
 const mdtp: ConnectedDispatchProps = {
@@ -134,6 +152,7 @@ const mdtp: ConnectedDispatchProps = {
   selectTask,
   setSearchTerm: setSearchTermAction,
   setShowInactive: setShowInactiveAction,
+  setDropdownOrgID: setDropdownOrgIDAction,
 }
 
 export default connect<

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -8,6 +8,7 @@ export interface State {
   tasks: Task[]
   searchTerm: string
   showInactive: boolean
+  dropdownOrgID: string
 }
 
 const defaultState: State = {
@@ -16,6 +17,7 @@ const defaultState: State = {
   tasks: [],
   searchTerm: '',
   showInactive: true,
+  dropdownOrgID: null,
 }
 
 export default (state: State = defaultState, action: Action): State => {
@@ -38,6 +40,9 @@ export default (state: State = defaultState, action: Action): State => {
       return {...state, searchTerm}
     case ActionTypes.SetShowInactive:
       return {...state, showInactive: !state.showInactive}
+    case ActionTypes.SetDropdownOrgID:
+      const {dropdownOrgID} = action.payload
+      return {...state, dropdownOrgID}
     default:
       return state
   }


### PR DESCRIPTION
Co-authored-by: Palak Bhojani <palak@influxdata.com>
Co-authored-by: Deniz Kusefoglu <deniz@influxdata.com>

Closes #1372 

_What was the solution?_Created a dropdown on Task Header to show all organizations and an ability to filter tasks using the dropdown

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)