### PR TITLE
Tasks/configure task options from flux page

### DIFF
--- a/ui/src/clockface/components/component_spacer/ComponentSpacer.scss
+++ b/ui/src/clockface/components/component_spacer/ComponentSpacer.scss
@@ -11,24 +11,70 @@
 
 .component-spacer--left {
   justify-content: flex-start;
-
-  > * {
-    margin-right: $ix-marg-a;
-  }
 }
 
 .component-spacer--center {
   justify-content: center;
-
-  > * {
-    margin: 0 ($ix-marg-a / 2);
-  }
 }
 
 .component-spacer--right {
   justify-content: flex-end;
+}
 
-  > * {
+.component-spacer--horizontal {
+  flex-direction: row;
+
+  &.component-spacer--stretch {
+    width: 100%;
+  }
+
+  &.component-spacer--left > * {
+    margin-right: $ix-marg-a;
+  
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  &.component-spacer--center > * {
+    margin-left: ($ix-marg-a / 2);
+    margin-right: ($ix-marg-a / 2);
+  }
+
+  &.component-spacer--right > * {
     margin-left: $ix-marg-a;
+  
+    &:last-child {
+      margin-left: 0;
+    }
+  }
+}
+
+.component-spacer--vertical {
+  flex-direction: column;
+
+  &.component-spacer--stretch {
+    height: 100%;
+  }
+
+  &.component-spacer--left > * {
+    margin-bottom: $ix-marg-a;
+  
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &.component-spacer--center > * {
+    margin-top: ($ix-marg-a / 2);
+    margin-top: ($ix-marg-a / 2);
+  }
+
+  &.component-spacer--right > * {
+    margin-top: $ix-marg-a;
+  
+    &:last-child {
+      margin-top: 0;
+    }
   }
 }

--- a/ui/src/clockface/components/component_spacer/ComponentSpacer.tsx
+++ b/ui/src/clockface/components/component_spacer/ComponentSpacer.tsx
@@ -3,19 +3,29 @@ import React, {SFC} from 'react'
 import classnames from 'classnames'
 
 // Types
-import {Alignment} from 'src/clockface'
+import {Alignment, Direction} from 'src/clockface'
 
 interface Props {
   children: JSX.Element | JSX.Element[]
   align: Alignment
+  direction?: Direction
+  stretchToFit?: boolean
 }
 
-const ComponentSpacer: SFC<Props> = ({children, align}) => (
+const ComponentSpacer: SFC<Props> = ({
+  children,
+  align,
+  direction = Direction.Horizontal,
+  stretchToFit = false,
+}) => (
   <div
     className={classnames('component-spacer', {
       'component-spacer--left': align === Alignment.Left,
       'component-spacer--center': align === Alignment.Center,
       'component-spacer--right': align === Alignment.Right,
+      'component-spacer--horizontal': direction === Direction.Horizontal,
+      'component-spacer--vertical': direction === Direction.Vertical,
+      'component-spacer--stretch': stretchToFit,
     })}
   >
     {children}

--- a/ui/src/clockface/components/dropdowns/Dropdown.tsx
+++ b/ui/src/clockface/components/dropdowns/Dropdown.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, CSSProperties} from 'react'
+import React, {Component, CSSProperties, MouseEvent} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -89,7 +89,8 @@ class Dropdown extends Component<Props, State> {
     )
   }
 
-  private toggleMenu = (): void => {
+  private toggleMenu = (e: MouseEvent<HTMLElement>): void => {
+    e.preventDefault()
     this.setState({expanded: !this.state.expanded})
   }
 

--- a/ui/src/clockface/components/dropdowns/DropdownButton.tsx
+++ b/ui/src/clockface/components/dropdowns/DropdownButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component} from 'react'
+import React, {Component, MouseEvent} from 'react'
 import classnames from 'classnames'
 
 // Types
@@ -15,7 +15,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   children: DropdownChild
-  onClick: () => void
+  onClick: (e: MouseEvent<HTMLElement>) => void
   status?: ComponentStatus
   active?: boolean
   color?: ComponentColor

--- a/ui/src/clockface/components/dropdowns/DropdownItem.tsx
+++ b/ui/src/clockface/components/dropdowns/DropdownItem.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component} from 'react'
+import React, {Component, MouseEvent} from 'react'
 import classnames from 'classnames'
 
 // Types
@@ -41,7 +41,8 @@ class DropdownItem extends Component<Props> {
     )
   }
 
-  private handleClick = (): void => {
+  private handleClick = (e: MouseEvent<HTMLElement>): void => {
+    e.preventDefault()
     const {onClick, value} = this.props
 
     onClick(value)

--- a/ui/src/clockface/index.ts
+++ b/ui/src/clockface/index.ts
@@ -31,6 +31,7 @@ import {
   IconFont,
   Columns,
   Alignment,
+  Direction,
   ButtonType,
   Sort,
 } from './types'
@@ -41,6 +42,7 @@ export {
   Button,
   ButtonType,
   ComponentSpacer,
+  Direction,
   Dropdown,
   DropdownMode,
   MultiSelectDropdown,

--- a/ui/src/clockface/types/index.ts
+++ b/ui/src/clockface/types/index.ts
@@ -171,3 +171,8 @@ export enum Sort {
   Ascending = 'asc',
   None = 'none',
 }
+
+export enum Direction {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -52,3 +52,5 @@
 @import "src/logs/components/logs_table/LogsTable";
 @import "src/logs/components/expandable_message/ExpandableMessage";
 @import "src/logs/components/logs_message/LogsMessage";
+
+@import "src/tasks/components/TaskPage";

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -20,6 +20,8 @@ import {
   taskUpdateFailed,
 } from 'src/shared/copy/v2/notifications'
 
+import {taskOptionsToFluxScript} from 'src/utils/taskOptionsToFluxScript'
+
 export type Action =
   | SetNewScript
   | SetTasks
@@ -28,97 +30,146 @@ export type Action =
   | SetCurrentTask
   | SetShowInactive
   | SetDropdownOrgID
+  | SetTaskInterval
+  | SetTaskCron
+  | ClearTaskOptions
+  | SetTaskOption
+  | SetScheduleUnit
 
 type GetStateFunc = () => AppState
 
-export enum ActionTypes {
-  SetNewScript = 'SET_NEW_SCRIPT',
-  SetTasks = 'SET_TASKS',
-  SetSearchTerm = 'SET_TASKS_SEARCH_TERM',
-  SetCurrentScript = 'SET_CURRENT_SCRIPT',
-  SetCurrentTask = 'SET_CURRENT_TASK',
-  SetShowInactive = 'SET_TASKS_SHOW_INACTIVE',
-  SetDropdownOrgID = 'SET_DROPDOWN_ORG_ID',
+export interface ClearTaskOptions {
+  type: 'CLEAR_TASK_OPTIONS'
+}
+
+export interface SetTaskInterval {
+  type: 'SET_TASK_INTERVAL'
+  payload: {
+    interval: string
+  }
+}
+
+export interface SetTaskCron {
+  type: 'SET_TASK_CRON'
+  payload: {
+    cron: string
+  }
 }
 
 export interface SetNewScript {
-  type: ActionTypes.SetNewScript
+  type: 'SET_NEW_SCRIPT'
   payload: {
     script: string
   }
 }
 export interface SetCurrentScript {
-  type: ActionTypes.SetCurrentScript
+  type: 'SET_CURRENT_SCRIPT'
   payload: {
     script: string
   }
 }
 export interface SetCurrentTask {
-  type: ActionTypes.SetCurrentTask
+  type: 'SET_CURRENT_TASK'
   payload: {
     task: Task
   }
 }
 
 export interface SetTasks {
-  type: ActionTypes.SetTasks
+  type: 'SET_TASKS'
   payload: {
     tasks: Task[]
   }
 }
 
 export interface SetSearchTerm {
-  type: ActionTypes.SetSearchTerm
+  type: 'SET_SEARCH_TERM'
   payload: {
     searchTerm: string
   }
 }
 
 export interface SetShowInactive {
-  type: ActionTypes.SetShowInactive
+  type: 'SET_SHOW_INACTIVE'
   payload: {}
 }
 
 export interface SetDropdownOrgID {
-  type: ActionTypes.SetDropdownOrgID
+  type: 'SET_DROPDOWN_ORG_ID'
   payload: {
     dropdownOrgID: string
   }
 }
 
+export interface SetTaskOption {
+  type: 'SET_TASK_OPTION'
+  payload: {
+    key: string
+    value: string
+  }
+}
+
+export interface SetScheduleUnit {
+  type: 'SET_SCHEDULE_UNIT'
+  payload: {
+    schedule: string
+    unit: string
+  }
+}
+
+export const setTaskOption = (taskOption: {
+  key: string
+  value: string
+}): SetTaskOption => ({
+  type: 'SET_TASK_OPTION',
+  payload: {...taskOption},
+})
+
+export const clearTaskOptions = (): ClearTaskOptions => ({
+  type: 'CLEAR_TASK_OPTIONS',
+})
+
 export const setNewScript = (script: string): SetNewScript => ({
-  type: ActionTypes.SetNewScript,
+  type: 'SET_NEW_SCRIPT',
   payload: {script},
 })
 
 export const setCurrentScript = (script: string): SetCurrentScript => ({
-  type: ActionTypes.SetCurrentScript,
+  type: 'SET_CURRENT_SCRIPT',
   payload: {script},
 })
 
 export const setCurrentTask = (task: Task): SetCurrentTask => ({
-  type: ActionTypes.SetCurrentTask,
+  type: 'SET_CURRENT_TASK',
   payload: {task},
 })
 
 export const setTasks = (tasks: Task[]): SetTasks => ({
-  type: ActionTypes.SetTasks,
+  type: 'SET_TASKS',
   payload: {tasks},
 })
 
 export const setSearchTerm = (searchTerm: string): SetSearchTerm => ({
-  type: ActionTypes.SetSearchTerm,
+  type: 'SET_SEARCH_TERM',
   payload: {searchTerm},
 })
 
 export const setShowInactive = (): SetShowInactive => ({
-  type: ActionTypes.SetShowInactive,
+  type: 'SET_SHOW_INACTIVE',
   payload: {},
 })
 
 export const setDropdownOrgID = (dropdownOrgID: string): SetDropdownOrgID => ({
-  type: ActionTypes.SetDropdownOrgID,
+  type: 'SET_DROPDOWN_ORG_ID',
   payload: {dropdownOrgID},
+})
+
+export const setScheduleUnit = (
+  unit: string,
+  schedule: string
+): SetScheduleUnit => ({
+  type: 'SET_SCHEDULE_UNIT',
+  payload: {unit, schedule},
 })
 
 export const updateTaskStatus = (task: Task) => async (
@@ -240,14 +291,26 @@ export const saveNewScript = () => async (
     const {
       orgs,
       links: {tasks: url, me: meUrl},
-      tasks: {newScript: script},
-    } = getState()
+      tasks: {newScript: script, taskOptions},
+    } = await getState()
+
+    const fluxTaskOptions = taskOptionsToFluxScript(taskOptions)
+    const scriptWithOptions = `${fluxTaskOptions}\n${script}`
 
     const user = await getMe(meUrl)
 
-    await submitNewTask(url, user, orgs[0], script)
+    let org = orgs.find(org => {
+      return org.id === taskOptions.orgID
+    })
+
+    if (!org) {
+      org = orgs[0]
+    }
+
+    await submitNewTask(url, user, org, scriptWithOptions)
 
     dispatch(setNewScript(''))
+    dispatch(clearTaskOptions())
     dispatch(goToTasks())
   } catch (e) {
     console.error(e)

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -1,33 +1,170 @@
 import _ from 'lodash'
-import React, {PureComponent} from 'react'
+import React, {PureComponent, ChangeEvent} from 'react'
 
-import {Form, Columns} from 'src/clockface'
+import {
+  ComponentSpacer,
+  Form,
+  Columns,
+  Input,
+  Radio,
+  ButtonShape,
+} from 'src/clockface'
+import TaskOptionsOrgDropdown from 'src/tasks/components/TasksOptionsOrgDropdown'
 import FluxEditor from 'src/shared/components/FluxEditor'
+import TaskScheduleFormField from 'src/tasks/components/TaskScheduleFormField'
+
+import {TaskOptions, TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
+
+import {Organization} from 'src/types/v2'
+import {Alignment, Direction} from 'src/clockface/types'
 
 interface Props {
   script: string
-  onChange: (script) => void
+  orgs: Organization[]
+  taskOptions: TaskOptions
+  onChangeScheduleType: (schedule: TaskSchedule) => void
+  onChangeScript: (script: string) => void
+  onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void
+  onChangeScheduleUnit: (unit: string, scheduleType: string) => void
+  onChangeTaskOrgID: (orgID: string) => void
 }
 
-export default class TaskForm extends PureComponent<Props> {
+interface State {
+  selectedIntervalUnit: string
+  cron: string
+  selectedDelayUnit: string
+  delayTime: string
+  retryAttempts: string
+  schedule: TaskSchedule
+}
+
+export default class TaskForm extends PureComponent<Props, State> {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      cron: '',
+      selectedIntervalUnit: 'd',
+      delayTime: '20',
+      selectedDelayUnit: 'm',
+      retryAttempts: '1',
+      schedule: props.taskOptions.taskScheduleType,
+    }
+  }
+
   public render() {
+    const {
+      script,
+      onChangeInput,
+      onChangeScript,
+      onChangeTaskOrgID,
+      taskOptions: {
+        name,
+        taskScheduleType,
+        intervalTime,
+        intervalUnit,
+        delayTime,
+        delayUnit,
+        cron,
+        orgID,
+      },
+      orgs,
+    } = this.props
+
     return (
-      <Form style={{height: '90%'}}>
-        <Form.Element
-          label="Script"
-          colsXS={Columns.Six}
-          offsetXS={Columns.Three}
-          errorMessage={''}
-        >
+      <div className="task-page">
+        <div className="task-page--options">
+          <Form>
+            <Form.Element label="Name" colsXS={Columns.Twelve}>
+              <Input
+                name="name"
+                placeholder="Name your task"
+                onChange={onChangeInput}
+                value={name}
+              />
+            </Form.Element>
+            <Form.Element label="Owner">
+              <TaskOptionsOrgDropdown
+                orgs={orgs}
+                selectedOrgID={orgID}
+                onChangeTaskOrgID={onChangeTaskOrgID}
+              />
+            </Form.Element>
+
+            <Form.Element label="Schedule Task" colsXS={Columns.Twelve}>
+              <ComponentSpacer
+                align={Alignment.Left}
+                direction={Direction.Vertical}
+              >
+                <Radio shape={ButtonShape.StretchToFit}>
+                  <Radio.Button
+                    id="interval"
+                    active={taskScheduleType === TaskSchedule.interval}
+                    value={TaskSchedule.interval}
+                    titleText="Interval + Delay"
+                    onClick={this.handleChangeScheduleType}
+                  >
+                    Interval + Delay
+                  </Radio.Button>
+                  <Radio.Button
+                    id="cron"
+                    active={taskScheduleType === TaskSchedule.cron}
+                    value={TaskSchedule.cron}
+                    titleText="Cron"
+                    onClick={this.handleChangeScheduleType}
+                  >
+                    Cron
+                  </Radio.Button>
+                </Radio>
+                <TaskScheduleFormField
+                  onChangeInput={onChangeInput}
+                  schedule={taskScheduleType}
+                  intervalTime={intervalTime}
+                  intervalUnit={intervalUnit}
+                  delayTime={delayTime}
+                  delayUnit={delayUnit}
+                  onChangeTaskScheduleUnit={this.handleChangeTaskScheduleUnit}
+                  cron={cron}
+                />
+              </ComponentSpacer>
+            </Form.Element>
+
+            <Form.Element label="Retry attempts" colsXS={Columns.Twelve}>
+              <Input
+                name="retry"
+                placeholder=""
+                onChange={this.handleChangeRetry}
+                value={this.state.retryAttempts}
+              />
+            </Form.Element>
+          </Form>
+        </div>
+        <div className="task-page--editor">
           <FluxEditor
-            script={this.props.script}
-            onChangeScript={this.props.onChange}
-            visibility={'visible'}
+            script={script}
+            onChangeScript={onChangeScript}
+            visibility="visible"
             status={{text: '', type: ''}}
             suggestions={[]}
           />
-        </Form.Element>
-      </Form>
+        </div>
+      </div>
     )
+  }
+
+  private handleChangeRetry = (e: ChangeEvent<HTMLInputElement>): void => {
+    const retryAttempts = e.target.value
+    this.setState({retryAttempts})
+  }
+
+  private handleChangeScheduleType = (schedule: TaskSchedule): void => {
+    this.props.onChangeScheduleType(schedule)
+  }
+
+  private handleChangeTaskScheduleUnit = (
+    unit: string,
+    scheduleType: string
+  ) => {
+    this.props.onChangeScheduleUnit(unit, scheduleType)
   }
 }

--- a/ui/src/tasks/components/TaskPage.scss
+++ b/ui/src/tasks/components/TaskPage.scss
@@ -1,0 +1,33 @@
+/*
+   Task Editor Page Styles
+   -----------------------------------------------------------------------------
+*/
+
+.task-page {
+    height: 100%;
+    display: flex;
+   align-items: stretch; 
+}
+
+.task-page--options {
+    flex: 1 0 0;
+    background-color: $g3-castle;
+    padding: $ix-marg-d;
+    border-radius: $radius 0 0 $radius;
+}
+
+.task-page--editor {
+    flex: 6 0 0;
+    background-color: $g2-kevlar;
+    border-radius: 0 $radius $radius 0;
+}
+
+.task-page--form-label {
+    height: 30px;
+    line-height: 30px;
+    font-size: 13px;
+    font-weight: 600;
+    color: $g11-sidewalk;
+    flex: 1 0 60px;
+    padding-left: 11px;
+}

--- a/ui/src/tasks/components/TaskScheduleFormField.tsx
+++ b/ui/src/tasks/components/TaskScheduleFormField.tsx
@@ -1,0 +1,100 @@
+// Libraries
+import React, {PureComponent, ChangeEvent} from 'react'
+
+// Components
+import {ComponentSpacer, Input, InputType} from 'src/clockface'
+
+// Types
+import {Alignment} from 'src/clockface'
+import {TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
+import TaskScheduleUnitDropdown from 'src/tasks/components/TaskScheduleUnitDropdown'
+
+interface Props {
+  schedule: TaskSchedule
+  cron: string
+  delayTime: string
+  delayUnit: string
+  intervalTime: string
+  intervalUnit: string
+  onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void
+  onChangeTaskScheduleUnit: (unit: string, scheduleType: string) => void
+}
+
+export default class TaskScheduleFormFields extends PureComponent<Props> {
+  public render() {
+    const {
+      schedule,
+      delayTime,
+      delayUnit,
+      intervalTime,
+      intervalUnit,
+      onChangeInput,
+    } = this.props
+    if (schedule === TaskSchedule.interval) {
+      return (
+        <>
+          <ComponentSpacer align={Alignment.Left} stretchToFit={true}>
+            <label className="task-page--form-label">Interval</label>
+            <Input
+              name="intervalTime"
+              widthPixels={120}
+              type={InputType.Number}
+              value={intervalTime}
+              onChange={this.props.onChangeInput}
+            />
+            <TaskScheduleUnitDropdown
+              onChange={this.handleChangeUnit}
+              selectedUnit={intervalUnit}
+              scheduleType="intervalUnit"
+            />
+          </ComponentSpacer>
+
+          <ComponentSpacer align={Alignment.Left} stretchToFit={true}>
+            <label className="task-page--form-label">Delay</label>
+            <Input
+              name="delayTime"
+              widthPixels={120}
+              type={InputType.Number}
+              value={delayTime}
+              onChange={onChangeInput}
+            />
+            <TaskScheduleUnitDropdown
+              onChange={this.handleChangeUnit}
+              selectedUnit={delayUnit}
+              scheduleType="delayUnit"
+            />
+          </ComponentSpacer>
+        </>
+      )
+    }
+    return (
+      <>
+        <Input
+          name="cron"
+          placeholder="02***"
+          onChange={this.props.onChangeInput}
+          value={this.props.cron}
+        />
+        <ComponentSpacer align={Alignment.Left} stretchToFit={true}>
+          <label className="task-page--form-label">Delay</label>
+          <Input
+            name="delayTime"
+            widthPixels={120}
+            type={InputType.Number}
+            value={this.props.delayTime}
+            onChange={this.props.onChangeInput}
+          />
+          <TaskScheduleUnitDropdown
+            onChange={this.handleChangeUnit}
+            selectedUnit={this.props.delayUnit}
+            scheduleType="delayUnit"
+          />
+        </ComponentSpacer>
+      </>
+    )
+  }
+
+  private handleChangeUnit = (unit: string, scheduleType: string) => {
+    this.props.onChangeTaskScheduleUnit(unit, scheduleType)
+  }
+}

--- a/ui/src/tasks/components/TaskScheduleUnitDropdown.tsx
+++ b/ui/src/tasks/components/TaskScheduleUnitDropdown.tsx
@@ -1,0 +1,48 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {Dropdown} from 'src/clockface'
+
+const timeUnits = ['Day', 'Hour', 'Minute']
+
+const timeUnitStringToAbbreviation = {
+  Day: 'd',
+  Hour: 'h',
+  Minute: 'm',
+}
+
+interface Props {
+  onChange: (scheduleUnit: string, scheduleType: string) => void
+  scheduleType: string
+  selectedUnit: string
+}
+
+export default class TaskScheduleUnitDropdown extends PureComponent<Props> {
+  public render() {
+    return (
+      <Dropdown
+        onChange={this.handleUnitChange}
+        selectedID={this.props.selectedUnit}
+      >
+        {timeUnits.map(unit => {
+          return (
+            <Dropdown.Item
+              value={timeUnitStringToAbbreviation[unit]}
+              key={unit}
+              id={timeUnitStringToAbbreviation[unit]}
+            >
+              {unit}
+            </Dropdown.Item>
+          )
+        })}
+      </Dropdown>
+    )
+  }
+
+  private handleUnitChange = (unit: string) => {
+    const {scheduleType} = this.props
+
+    this.props.onChange(unit, scheduleType)
+  }
+}

--- a/ui/src/tasks/components/TasksOptionsOrgDropdown.tsx
+++ b/ui/src/tasks/components/TasksOptionsOrgDropdown.tsx
@@ -1,0 +1,48 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import _ from 'lodash'
+
+// Components
+import {Dropdown} from 'src/clockface'
+
+// Types
+import {Organization} from 'src/types/v2'
+
+interface Props {
+  orgs: Organization[]
+  onChangeTaskOrgID: (selectedOrgID: string) => void
+  selectedOrgID: string
+}
+
+export default class TaskOptionsOrgDropdown extends PureComponent<Props> {
+  public render() {
+    return (
+      <Dropdown
+        selectedID={this.selectedID}
+        onChange={this.props.onChangeTaskOrgID}
+      >
+        {this.orgDropdownItems}
+      </Dropdown>
+    )
+  }
+  private get orgDropdownItems(): JSX.Element[] {
+    const {orgs} = this.props
+
+    return orgs.map(org => {
+      return (
+        <Dropdown.Item id={org.id} key={org.id} value={org.id}>
+          {org.name}
+        </Dropdown.Item>
+      )
+    })
+  }
+
+  private get selectedID(): string {
+    const {selectedOrgID, orgs} = this.props
+
+    if (!selectedOrgID) {
+      return _.get(orgs, '0.id', '')
+    }
+    return selectedOrgID
+  }
+}

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -1,5 +1,6 @@
-import {Action, ActionTypes} from 'src/tasks/actions/v2'
+import {Action} from 'src/tasks/actions/v2'
 import {Task} from 'src/types/v2/tasks'
+import {TaskOptions, TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
 
 export interface State {
   newScript: string
@@ -9,6 +10,19 @@ export interface State {
   searchTerm: string
   showInactive: boolean
   dropdownOrgID: string
+  interval: string
+  taskOptions: TaskOptions
+}
+
+const defaultTaskOptions: TaskOptions = {
+  name: '',
+  intervalTime: '1',
+  intervalUnit: 'd',
+  delayTime: '20',
+  delayUnit: 'm',
+  cron: '',
+  taskScheduleType: TaskSchedule.interval,
+  orgID: null,
 }
 
 const defaultState: State = {
@@ -18,29 +32,50 @@ const defaultState: State = {
   searchTerm: '',
   showInactive: true,
   dropdownOrgID: null,
+  interval: '1d',
+  taskOptions: defaultTaskOptions,
 }
 
 export default (state: State = defaultState, action: Action): State => {
   switch (action.type) {
-    case ActionTypes.SetNewScript:
+    case 'CLEAR_TASK_OPTIONS':
+      return {
+        ...state,
+        taskOptions: defaultTaskOptions,
+      }
+    case 'SET_TASK_OPTION':
+      const {key, value} = action.payload
+
+      return {
+        ...state,
+        taskOptions: {...state.taskOptions, [key]: value},
+      }
+    case 'SET_SCHEDULE_UNIT':
+      const {unit, schedule} = action.payload
+
+      return {
+        ...state,
+        taskOptions: {...state.taskOptions, [schedule]: unit},
+      }
+    case 'SET_NEW_SCRIPT':
       return {...state, newScript: action.payload.script}
-    case ActionTypes.SetCurrentScript:
+    case 'SET_CURRENT_SCRIPT':
       return {...state, currentScript: action.payload.script}
-    case ActionTypes.SetCurrentTask:
+    case 'SET_CURRENT_TASK':
       const {task} = action.payload
       let currentScript = ''
       if (task) {
         currentScript = task.flux
       }
       return {...state, currentScript, currentTask: task}
-    case ActionTypes.SetTasks:
+    case 'SET_TASKS':
       return {...state, tasks: action.payload.tasks}
-    case ActionTypes.SetSearchTerm:
+    case 'SET_SEARCH_TERM':
       const {searchTerm} = action.payload
       return {...state, searchTerm}
-    case ActionTypes.SetShowInactive:
+    case 'SET_SHOW_INACTIVE':
       return {...state, showInactive: !state.showInactive}
-    case ActionTypes.SetDropdownOrgID:
+    case 'SET_DROPDOWN_ORG_ID':
       const {dropdownOrgID} = action.payload
       return {...state, dropdownOrgID}
     default:

--- a/ui/src/utils/taskOptionsToFluxScript.ts
+++ b/ui/src/utils/taskOptionsToFluxScript.ts
@@ -1,0 +1,31 @@
+export interface TaskOptions {
+  name: string
+  intervalTime: string
+  intervalUnit: string
+  delayTime: string
+  delayUnit: string
+  cron: string
+  taskScheduleType: TaskSchedule
+  orgID: string
+}
+
+export enum TaskSchedule {
+  interval = 'INTERVAL',
+  cron = 'CRON',
+}
+
+export const taskOptionsToFluxScript = (options: TaskOptions): string => {
+  let fluxScript = `option task = { \n  name: "${options.name}",\n`
+
+  if (options.taskScheduleType === TaskSchedule.interval) {
+    fluxScript = `${fluxScript}  every: ${options.intervalTime}${
+      options.intervalUnit
+    },\n`
+  } else if (options.taskScheduleType === TaskSchedule.cron) {
+    fluxScript = `${fluxScript}  cron: "${options.cron}",\n`
+  }
+  fluxScript = `${fluxScript}  delay: ${options.delayTime}${options.delayUnit},`
+
+  fluxScript = `${fluxScript}\n}`
+  return fluxScript
+}


### PR DESCRIPTION
Closes: #1305 
Closes: #1469

_What was the problem?_
Previously, the only way to create a task was to type in the options into the Flux script field, like so: 

<img width="444" alt="screen shot 2018-11-15 at 2 06 50 pm" src="https://user-images.githubusercontent.com/15273162/48584856-beb9d180-e8df-11e8-843a-a6bdfea2a414.png">

_What was the solution?_
This PR introduces a UI for updating task options, shown here: 

<img width="1594" alt="screen shot 2018-11-15 at 1 57 40 pm" src="https://user-images.githubusercontent.com/15273162/48589790-eb76e480-e8f1-11e8-8d69-96fd62e8fa92.png">

Once the user has selected the options they want, the options are converted into a string and attached to the flux script. When they open the "update script" page, they will then see the full Flux script with the options prepended, as in the first picture.

NOTE THAT: the "retry attempts" field does not save to the new task, and that updating options on an already created script with the options UI is not supported in this PR. That will be addressed in: https://github.com/influxdata/platform/issues/1306. Also, this UI does not contain a field to set the task as active/inactive, that will also be addressed in another PR.

  - [x] Rebased/mergeable
  - [x] Tests pass