### PR TITLE
feat(http): self sources now return links to /api/v2

### DIFF
--- a/http/source_service.go
+++ b/http/source_service.go
@@ -32,6 +32,19 @@ type sourceResponse struct {
 func newSourceResponse(s *platform.Source) *sourceResponse {
 	s.Password = ""
 	s.SharedSecret = ""
+
+	if s.Type == platform.SelfSourceType {
+		return &sourceResponse{
+			Source: s,
+			Links: map[string]interface{}{
+				"self":    fmt.Sprintf("%s/%s", sourceHTTPPath, s.ID.String()),
+				"query":   "/api/v2/query",
+				"buckets": "/api/v2/buckets",
+				"health":  "/api/v2/health",
+			},
+		}
+	}
+
 	return &sourceResponse{
 		Source: s,
 		Links: map[string]interface{}{

--- a/http/source_service_test.go
+++ b/http/source_service_test.go
@@ -1,0 +1,74 @@
+package http
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/platform"
+)
+
+func Test_newSourceResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		s *platform.Source
+		want *sourceResponse
+	}{
+		{
+			name: "self source returns links to this instance",
+			s: &platform.Source {
+				ID: platform.ID(1),
+				OrganizationID: platform.ID(1),
+				Name: "Hi",
+				Type: platform.SelfSourceType,
+				URL: "/",
+			},
+			want: &sourceResponse{
+Source: &platform.Source {
+				ID: platform.ID(1),
+				OrganizationID: platform.ID(1),
+				Name: "Hi",
+				Type: platform.SelfSourceType,
+				URL: "/",
+			},
+				Links: map[string]interface{}{
+					"self":   "/api/v2/sources/0000000000000001",
+					"query":   "/api/v2/query",
+					"buckets": "/api/v2/buckets",
+					"health":  "/api/v2/health",
+				},
+			},
+		},
+		{
+			name: "v1 sources have proxied links",
+			s: &platform.Source {
+				ID: platform.ID(1),
+				OrganizationID: platform.ID(1),
+				Name: "Hi",
+				Type: platform.V1SourceType,
+				URL: "/",
+			},
+			want: &sourceResponse{
+Source: &platform.Source {
+				ID: platform.ID(1),
+				OrganizationID: platform.ID(1),
+				Name: "Hi",
+				Type: platform.V1SourceType,
+				URL: "/",
+			},
+				Links: map[string]interface{}{
+					"self":   "/api/v2/sources/0000000000000001",
+					"query":   "/api/v2/sources/0000000000000001/query",
+					"buckets": "/api/v2/sources/0000000000000001/buckets",
+					"health":  "/api/v2/sources/0000000000000001/health",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newSourceResponse(tt.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newSourceResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1425

_Briefly describe your proposed changes:_
Sources that are "self" link to /api/v2

_What was the problem?_
Self-sources links did not resolve

_What was the solution?_
Linking back to the top-level API

Now, we could remove self-sources altogether and rename sources to remotes.  For now this will solve the bug.

Here is an example of the response:

```json
{
  "sources": [
    {
      "id": "020f755c3c082000",
      "organizationID": "50616e67652c206c",
      "default": true,
      "name": "autogen",
      "type": "self",
      "url": "",
      "telegraf": "",
      "token": "",
      "defaultRP": "",
      "links": {
        "buckets": "/api/v2/buckets",
        "health": "/api/v2/health",
        "query": "/api/v2/query",
        "self": "/api/v2/sources/020f755c3c082000"
      }
    }
  ],
  "links": {
    "self": "/api/v2/sources"
  }
}
```

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)