### PR TITLE
fix(Makefile): remove old clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #    * All cmds must be added to this top level Makefile.
 #    * All binaries are placed in ./bin, its recommended to add this directory to your PATH.
 #    * Each package that has a need to run go generate, must have its own Makefile for that purpose.
-#    * All recursive Makefiles must support the targets: all and clean.
+#    * All recursive Makefiles must support the all target
 #
 
 SUBDIRS := query task
@@ -127,9 +127,7 @@ bench:
 nightly: all
 	env GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot --rm-dist --publish-snapshots
 
-# Recursively clean all subdirs
-clean: $(SUBDIRS)
-	@for d in $^; do $(MAKE) -C $$d $(MAKECMDGOALS); done
+clean:
 	$(MAKE) -C ui $(MAKECMDGOALS)
 	rm -rf bin
 

--- a/query/Makefile
+++ b/query/Makefile
@@ -8,7 +8,5 @@ $(SUBDIRS):
 
 all: $(SUBDIRS)
 
-clean: $(SUBDIRS)
-
-.PHONY: all clean subdirs $(SUBDIRS)
+.PHONY: all subdirs $(SUBDIRS)
 

--- a/query/promql/Makefile
+++ b/query/promql/Makefile
@@ -5,7 +5,4 @@ GO_GENERATE := go generate
 promql.go: promql.peg gen.go
 	$(GO_GENERATE) -x
 
-clean:
-	rm -f promql.go
-
-.PHONY: all clean
+.PHONY: all

--- a/task/Makefile
+++ b/task/Makefile
@@ -7,7 +7,4 @@ $(SUBDIRS):
 
 all: $(SUBDIRS)
 
-clean: $(SUBDIRS)
-
-
-.PHONY: all clean subdirs $(SUBDIRS)
+.PHONY: all subdirs $(SUBDIRS)

--- a/task/backend/Makefile
+++ b/task/backend/Makefile
@@ -7,7 +7,4 @@ all: $(targets)
 $(targets): meta.proto
 	$(GO_GENERATE) -x
 
-clean:
-	rm -f $(targets)
-
-.PHONY: all clean
+.PHONY: all


### PR DESCRIPTION
Closes #1451 

_Briefly describe your proposed changes:_
Remove clean targets for autogenerated code 
_What was the problem?_
We used to not have the files in source control and these targets went stale.
_What was the solution?_
Remove all the cleaning of those autogenerated files.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)