### PR TITLE
Fade IndexList Disabled Links to Match Design Spec

### DIFF
--- a/ui/src/clockface/components/index_views/IndexList.scss
+++ b/ui/src/clockface/components/index_views/IndexList.scss
@@ -91,6 +91,13 @@
   background-color: rgba($g3-castle, 0.5);
   color: $g9-mountain;
   font-style: italic;
+
+  a:link,
+  a:visited,
+  a:hover,
+  a:active {
+    opacity: 0.7;
+  }
 }
 
 // Row Disabled Hover State 


### PR DESCRIPTION
<img width="446" alt="screen shot 2018-11-16 at 11 27 53 am" src="https://user-images.githubusercontent.com/2433762/48642818-c8e8d800-e992-11e8-9a7f-bbbc4c0952ce.png">

Fade color of links in disabled IndexList rows to match design spec

  - [ ] Rebased/mergeable
  - [ ] Tests pass