### PR TITLE
fix(platform): keep authorization struct on proxy query request

### DIFF
--- a/authz.go
+++ b/authz.go
@@ -1,6 +1,14 @@
 package platform
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrAuthorizerNotSupported notes that the provided authorizer is not supported for the action you are trying to perform.
+	ErrAuthorizerNotSupported = errors.New("your authorizer is not supported, please use *platform.Authorization as authorizer")
+)
 
 // Authorizer will authorize a permission.
 type Authorizer interface {

--- a/http/query.go
+++ b/http/query.go
@@ -233,6 +233,12 @@ func decodeProxyQueryRequest(ctx context.Context, r *http.Request, auth platform
 		return nil, err
 	}
 
-	pr.Request.Authorizer = auth
+	a, ok := auth.(*platform.Authorization)
+	if !ok {
+		// TODO(desa): this should go away once we're using platform.Authorizers everywhere.
+		return pr, platform.ErrAuthorizerNotSupported
+	}
+
+	pr.Request.Authorization = a
 	return pr, nil
 }

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -67,7 +67,7 @@ func (h *FluxHandler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req, err := decodeProxyQueryRequest(ctx, r, a, h.OrganizationService)
-	if err != nil {
+	if err != nil && err != platform.ErrAuthorizerNotSupported {
 		EncodeError(ctx, err, w)
 		return
 	}

--- a/http/query_test.go
+++ b/http/query_test.go
@@ -466,7 +466,6 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 	var cmpOptions = cmp.Options{
 		cmpopts.IgnoreUnexported(query.ProxyRequest{}),
 		cmpopts.IgnoreUnexported(query.Request{}),
-		cmpopts.IgnoreFields(query.Request{}, "Authorizer"),
 		cmpopts.EquateEmpty(),
 	}
 	for _, tt := range tests {

--- a/query/bridges.go
+++ b/query/bridges.go
@@ -47,7 +47,7 @@ type REPLQuerier struct {
 
 func (q *REPLQuerier) Query(ctx context.Context, compiler flux.Compiler) (flux.ResultIterator, error) {
 	req := &Request{
-		Authorizer:     q.Authorization,
+		Authorization:  q.Authorization,
 		OrganizationID: q.OrganizationID,
 		Compiler:       compiler,
 	}

--- a/query/logger.go
+++ b/query/logger.go
@@ -31,31 +31,19 @@ type Log struct {
 
 // Redact removes any sensitive information before logging
 func (q *Log) Redact() {
-	if q.ProxyRequest != nil && q.ProxyRequest.Request.Authorizer != nil {
+	if q.ProxyRequest != nil && q.ProxyRequest.Request.Authorization != nil {
 		// Make shallow copy of request
 		request := new(ProxyRequest)
 		*request = *q.ProxyRequest
 
-		var az platform.Authorizer
-		switch a := q.ProxyRequest.Request.Authorizer.(type) {
-		case *platform.Authorization:
-			// Make shallow copy of authorization
-			auth := new(platform.Authorization)
-			*auth = *a
-			// Redact authorization token
-			auth.Token = ""
-			az = auth
-		case *platform.Session:
-			// Make shallow copy of Session
-			sess := new(platform.Session)
-			*sess = *a
-			// Redact session key
-			sess.Key = ""
-			az = sess
-		}
+		// Make shallow copy of authorization
+		auth := new(platform.Authorization)
+		*auth = *q.ProxyRequest.Request.Authorization
+		// Redact authorization token
+		auth.Token = ""
 
-		// Apply redacted autorizer
-		request.Request.Authorizer = az
+		// Apply redacted authorization
+		request.Request.Authorization = auth
 
 		// Apply redacted request
 		q.ProxyRequest = request

--- a/query/request.go
+++ b/query/request.go
@@ -12,8 +12,8 @@ import (
 // Request respresents the query to run.
 type Request struct {
 	// Scope
-	Authorizer     platform.Authorizer `json:"authorization,omitempty"`
-	OrganizationID platform.ID         `json:"organization_id"`
+	Authorization  *platform.Authorization `json:"authorization,omitempty"`
+	OrganizationID platform.ID             `json:"organization_id"`
 
 	// Command
 

--- a/task/backend/query_logreader.go
+++ b/task/backend/query_logreader.go
@@ -16,8 +16,6 @@ import (
 	"github.com/influxdata/platform/query"
 )
 
-var errAuthorizerNotSupported = errors.New("your authorizer is not supported, please use *platform.Authorization as authorizer")
-
 type QueryLogReader struct {
 	queryService query.QueryService
 }
@@ -56,9 +54,9 @@ func (qlr *QueryLogReader) ListLogs(ctx context.Context, logFilter platform.LogF
 		return nil, err
 	}
 	if auth.Kind() != "authorization" {
-		return nil, errAuthorizerNotSupported
+		return nil, platform.ErrAuthorizerNotSupported
 	}
-	request := &query.Request{Authorizer: auth.(*platform.Authorization), OrganizationID: *logFilter.Org, Compiler: lang.FluxCompiler{Query: listScript}}
+	request := &query.Request{Authorization: auth.(*platform.Authorization), OrganizationID: *logFilter.Org, Compiler: lang.FluxCompiler{Query: listScript}}
 
 	ittr, err := qlr.queryService.Query(ctx, request)
 	if err != nil {
@@ -134,9 +132,9 @@ join(tables: {main: main, supl: supl}, on: ["_start", "_stop", "orgID", "taskID"
 		return nil, err
 	}
 	if auth.Kind() != "authorization" {
-		return nil, errAuthorizerNotSupported
+		return nil, platform.ErrAuthorizerNotSupported
 	}
-	request := &query.Request{Authorizer: auth.(*platform.Authorization), OrganizationID: *runFilter.Org, Compiler: lang.FluxCompiler{Query: listScript}}
+	request := &query.Request{Authorization: auth.(*platform.Authorization), OrganizationID: *runFilter.Org, Compiler: lang.FluxCompiler{Query: listScript}}
 
 	ittr, err := qlr.queryService.Query(ctx, request)
 	if err != nil {
@@ -182,9 +180,9 @@ logs |> yield(name: "logs")
 		return nil, err
 	}
 	if auth.Kind() != "authorization" {
-		return nil, errAuthorizerNotSupported
+		return nil, platform.ErrAuthorizerNotSupported
 	}
-	request := &query.Request{Authorizer: auth.(*platform.Authorization), OrganizationID: orgID, Compiler: lang.FluxCompiler{Query: showScript}}
+	request := &query.Request{Authorization: auth.(*platform.Authorization), OrganizationID: orgID, Compiler: lang.FluxCompiler{Query: showScript}}
 
 	ittr, err := qlr.queryService.Query(ctx, request)
 	if err != nil {


### PR DESCRIPTION
As a result of pr https://github.com/influxdata/platform/pull/1494, idpe
broke. This PR undoes some of the work done from that PR, but fixes the
underlying issue with #1494.

  - [ ] Rebased/mergeable
  - [x] Tests pass