### PR TITLE
Fixed the task id path, Added RunController instance to pAdapter

### DIFF
--- a/http/task_service.go
+++ b/http/task_service.go
@@ -34,18 +34,18 @@ type TaskHandler struct {
 
 const (
 	tasksPath              = "/api/v2/tasks"
-	tasksIDPath            = "/api/v2/tasks/:tid"
-	tasksIDLogsPath        = "/api/v2/tasks/:tid/logs"
-	tasksIDMembersPath     = "/api/v2/tasks/:tid/members"
-	tasksIDMembersIDPath   = "/api/v2/tasks/:tid/members/:userID"
-	tasksIDOwnersPath      = "/api/v2/tasks/:tid/owners"
-	tasksIDOwnersIDPath    = "/api/v2/tasks/:tid/owners/:userID"
-	tasksIDRunsPath        = "/api/v2/tasks/:tid/runs"
-	tasksIDRunsIDPath      = "/api/v2/tasks/:tid/runs/:rid"
-	tasksIDRunsIDLogsPath  = "/api/v2/tasks/:tid/runs/:rid/logs"
-	tasksIDRunsIDRetryPath = "/api/v2/tasks/:tid/runs/:rid/retry"
-	tasksIDLabelsPath      = "/api/v2/tasks/:tid/labels"
-	tasksIDLabelsNamePath  = "/api/v2/tasks/:tid/labels/:name"
+	tasksIDPath            = "/api/v2/tasks/:id"
+	tasksIDLogsPath        = "/api/v2/tasks/:id/logs"
+	tasksIDMembersPath     = "/api/v2/tasks/:id/members"
+	tasksIDMembersIDPath   = "/api/v2/tasks/:id/members/:userID"
+	tasksIDOwnersPath      = "/api/v2/tasks/:id/owners"
+	tasksIDOwnersIDPath    = "/api/v2/tasks/:id/owners/:userID"
+	tasksIDRunsPath        = "/api/v2/tasks/:id/runs"
+	tasksIDRunsIDPath      = "/api/v2/tasks/:id/runs/:rid"
+	tasksIDRunsIDLogsPath  = "/api/v2/tasks/:id/runs/:rid/logs"
+	tasksIDRunsIDRetryPath = "/api/v2/tasks/:id/runs/:rid/retry"
+	tasksIDLabelsPath      = "/api/v2/tasks/:id/labels"
+	tasksIDLabelsNamePath  = "/api/v2/tasks/:id/labels/:name"
 )
 
 // NewTaskHandler returns a new instance of TaskHandler.
@@ -333,7 +333,7 @@ type getTaskRequest struct {
 
 func decodeGetTaskRequest(ctx context.Context, r *http.Request) (*getTaskRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("tid")
+	id := params.ByName("id")
 	if id == "" {
 		return nil, kerrors.InvalidDataf("url missing id")
 	}
@@ -378,7 +378,7 @@ type updateTaskRequest struct {
 
 func decodeUpdateTaskRequest(ctx context.Context, r *http.Request) (*updateTaskRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("tid")
+	id := params.ByName("id")
 	if id == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}
@@ -422,7 +422,7 @@ type deleteTaskRequest struct {
 
 func decodeDeleteTaskRequest(ctx context.Context, r *http.Request) (*deleteTaskRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("tid")
+	id := params.ByName("id")
 	if id == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}
@@ -464,7 +464,7 @@ type getLogsRequest struct {
 
 func decodeGetLogsRequest(ctx context.Context, r *http.Request, orgs platform.OrganizationService) (*getLogsRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("tid")
+	id := params.ByName("id")
 	if id == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}
@@ -531,7 +531,7 @@ type getRunsRequest struct {
 
 func decodeGetRunsRequest(ctx context.Context, r *http.Request, orgs platform.OrganizationService) (*getRunsRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("tid")
+	id := params.ByName("id")
 	if id == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}
@@ -634,7 +634,7 @@ type getRunRequest struct {
 
 func decodeGetRunRequest(ctx context.Context, r *http.Request) (*getRunRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	tid := params.ByName("tid")
+	tid := params.ByName("id")
 	if tid == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}
@@ -668,7 +668,7 @@ func decodeCancelRunRequest(ctx context.Context, r *http.Request) (*cancelRunReq
 	if rid == "" {
 		return nil, kerrors.InvalidDataf("you must provide a run ID")
 	}
-	tid := params.ByName("tid")
+	tid := params.ByName("id")
 	if tid == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}
@@ -730,7 +730,7 @@ type retryRunRequest struct {
 
 func decodeRetryRunRequest(ctx context.Context, r *http.Request) (*retryRunRequest, error) {
 	params := httprouter.ParamsFromContext(ctx)
-	tid := params.ByName("tid")
+	tid := params.ByName("id")
 	if tid == "" {
 		return nil, kerrors.InvalidDataf("you must provide a task ID")
 	}

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -17,7 +17,7 @@ type RunController interface {
 
 // PlatformAdapter wraps a task.Store into the platform.TaskService interface.
 func PlatformAdapter(s backend.Store, r backend.LogReader, rc RunController) platform.TaskService {
-	return pAdapter{s: s, r: r}
+	return pAdapter{s: s, r: r, rc: rc}
 }
 
 type pAdapter struct {


### PR DESCRIPTION
_What was the problem?_
1. The `pAdapter` did not have a `RunController`.
2. The `task_service` memberHandlers doesn't work and the `url missing member id` error is produce.

_What was the solution?_
1. Pass the `RunController` to the `pAdapter`.
2. Changing the mapping from a `tid` to a `id` according to implementation of [decodeDeleteMemberRequest](https://github.com/influxdata/platform/blob/b2afb98f7c2d4dfbce12757c0beb37705e585223/http/user_resource_mapping_service.go#L206).

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)