### PR TITLE
Support for median in transpiler

### DIFF
--- a/query/influxql/transpiler_test.go
+++ b/query/influxql/transpiler_test.go
@@ -104,6 +104,7 @@ func TestTranspiler_Compile(t *testing.T) {
 		{s: `SELECT max(bottom) FROM (SELECT bottom(value, host, 1) FROM cpu) GROUP BY region`},
 		{s: `SELECT percentile(value, 75) FROM cpu`},
 		{s: `SELECT percentile(value, 75.0) FROM cpu`},
+		{s: `SELECT median(value) FROM cpu`},
 		{s: `SELECT sample(value, 2) FROM cpu`},
 		{s: `SELECT sample(*, 2) FROM cpu`},
 		{s: `SELECT sample(/val/, 2) FROM cpu`},


### PR DESCRIPTION
Closes #1488 

_What was the problem?_
No support for median in transpiler
_What was the solution?_
Fake the median for a 50th percentile.  
The side effect on the AST could cause problems. In that case, I will update the code to treat the median as a percentile only when creating the opSpec in `createCursor`

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)