### PR TITLE
remove requestedAt param from retry call

### DIFF
--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/influxdata/flux/repl"
 	"github.com/influxdata/platform"
@@ -625,7 +624,7 @@ func runRetryF(cmd *cobra.Command, args []string) {
 	}
 
 	ctx := context.TODO()
-	newRun, err := s.RetryRun(ctx, taskID, runID, time.Now().Unix())
+	newRun, err := s.RetryRun(ctx, taskID, runID)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/inmem/onboarding.go
+++ b/inmem/onboarding.go
@@ -97,7 +97,7 @@ func (s *Service) Generate(ctx context.Context, req *platform.OnboardingRequest)
 		Permissions: []platform.Permission{
 			platform.CreateUserPermission,
 			platform.DeleteUserPermission,
-			platform.Permission{
+			{
 				Resource: platform.OrganizationResource,
 				Action:   platform.WriteAction,
 			},

--- a/mock/task_service.go
+++ b/mock/task_service.go
@@ -18,7 +18,7 @@ type TaskService struct {
 	FindRunsFn     func(context.Context, platform.RunFilter) ([]*platform.Run, int, error)
 	FindRunByIDFn  func(context.Context, platform.ID, platform.ID) (*platform.Run, error)
 	CancelRunFn    func(context.Context, platform.ID, platform.ID) error
-	RetryRunFn     func(context.Context, platform.ID, platform.ID, int64) (*platform.Run, error)
+	RetryRunFn     func(context.Context, platform.ID, platform.ID) (*platform.Run, error)
 }
 
 func (s *TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
@@ -58,6 +58,6 @@ func (s *TaskService) CancelRun(ctx context.Context, taskID, runID platform.ID) 
 	return s.CancelRunFn(ctx, taskID, runID)
 }
 
-func (s *TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID, requestedAt int64) (*platform.Run, error) {
-	return s.RetryRunFn(ctx, taskID, runID, requestedAt)
+func (s *TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
+	return s.RetryRunFn(ctx, taskID, runID)
 }

--- a/task.go
+++ b/task.go
@@ -68,8 +68,7 @@ type TaskService interface {
 	CancelRun(ctx context.Context, taskID, runID ID) error
 
 	// RetryRun creates and returns a new run (which is a retry of another run).
-	// The requestedAt parameter is the Unix timestamp that will be recorded for the retry.
-	RetryRun(ctx context.Context, taskID, runID ID, requestedAt int64) (*Run, error)
+	RetryRun(ctx context.Context, taskID, runID ID) (*Run, error)
 }
 
 // TaskUpdate represents updates to a task

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -172,7 +172,7 @@ func (p pAdapter) FindRunByID(ctx context.Context, taskID, id platform.ID) (*pla
 	return p.r.FindRunByID(ctx, task.Org, id)
 }
 
-func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID, requestedAt int64) (*platform.Run, error) {
+func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID) (*platform.Run, error) {
 	task, err := p.s.FindTaskByID(ctx, taskID)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID, requeste
 		return nil, err
 	}
 	t := scheduledTime.UTC().Unix()
-
+	requestedAt := time.Now().Unix()
 	m, err := p.s.ManuallyRunTimeRange(ctx, run.TaskID, t, t, requestedAt)
 	if err != nil {
 		return nil, err

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -369,7 +369,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Non-existent ID should return the right error.
-		_, err = sys.ts.RetryRun(sys.Ctx, task.ID, platform.ID(math.MaxUint64), 0)
+		_, err = sys.ts.RetryRun(sys.Ctx, task.ID, platform.ID(math.MaxUint64))
 		if err != backend.ErrRunNotFound {
 			t.Errorf("expected retrying run that doesn't exist to return %v, got %v", backend.ErrRunNotFound, err)
 		}
@@ -404,7 +404,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Now retry the run.
-		m, err := sys.ts.RetryRun(sys.Ctx, task.ID, rlb.RunID, requestedAtUnix)
+		m, err := sys.ts.RetryRun(sys.Ctx, task.ID, rlb.RunID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -430,7 +430,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 
 		found := false
 		for _, mr := range meta.ManualRuns {
-			if mr.Start == mr.End && mr.Start == rc.Created.Now && mr.RequestedAt == requestedAtUnix {
+			if mr.Start == mr.End && mr.Start == rc.Created.Now {
 				found = true
 				break
 			}
@@ -442,7 +442,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		exp := backend.RetryAlreadyQueuedError{Start: rc.Created.Now, End: rc.Created.Now}
 
 		// Retrying a run which has been queued but not started, should be rejected.
-		if _, err = sys.ts.RetryRun(sys.Ctx, task.ID, rlb.RunID, requestedAtUnix); err != exp {
+		if _, err = sys.ts.RetryRun(sys.Ctx, task.ID, rlb.RunID); err != exp {
 			t.Fatalf("subsequent retry should have been rejected with %v; got %v", exp, err)
 		}
 	})


### PR DESCRIPTION
Remove requestedAt param from the retry api call
closes #1589 