### PR TITLE
fix(ci/ui): fix enzyme pkg version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -68,7 +68,7 @@
     "@types/d3-scale": "^2.0.1",
     "@types/dygraphs": "^1.1.6",
     "@types/encoding-down": "^5.0.0",
-    "@types/enzyme": "^3.1.14",
+    "@types/enzyme": "^3.2.0",
     "@types/history": "3.2.2",
     "@types/jest": "^23.3.2",
     "@types/levelup": "^3.1.0",


### PR DESCRIPTION
Closes #1593

`$ yarn info enzyme --json`
```
"versions":
['1.0.0',
 '1.1.0',
 '1.2.0',
 '1.3.0',
 '1.3.1',
 '1.4.0',
 '1.4.1',
 '1.5.0',
 '1.6.0',
 '2.0.0-rc1',
 '2.0.0',
 '2.1.0',
 '2.2.0',
 '2.3.0',
 '2.4.0',
 '2.4.1',
 '2.4.2',
 '2.5.0',
 '2.5.1',
 '2.5.2',
 '2.6.0',
 '2.7.0',
 '2.7.1',
 '2.8.0',
 '2.8.1',
 '2.8.2',
 '2.9.0',
 '2.9.1',
 '3.0.0-alpha.1',
 '3.0.0-beta.1',
 '3.0.0-beta.2',
 '3.0.0-beta.3',
 '3.0.0-beta.4',
 '3.0.0-beta.5',
 '3.0.0-beta.6',
 '3.0.0-beta.7',
 '3.0.0',
 '3.1.0',
 '3.1.1',
 '3.2.0',
 '3.3.0',
 '3.4.0',
 '3.4.1',
 '3.4.2',
 '3.4.3',
 '3.4.4',
 '3.5.0',
 '3.5.1',
 '3.6.0',
 '3.7.0']
```
