### PR TITLE
Improve bulk series file writes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor
 .vs
 .tern-project
 .DS_Store
+*.test
 
 # binary databases
 influxd.bolt

--- a/pkg/rhh/rhh.go
+++ b/pkg/rhh/rhh.go
@@ -41,6 +41,8 @@ func (m *HashMap) Reset() {
 	m.n = 0
 }
 
+func (m *HashMap) LoadFactor() int { return m.loadFactor }
+
 func (m *HashMap) Get(key []byte) interface{} {
 	i := m.index(key)
 	if i == -1 {
@@ -53,7 +55,7 @@ func (m *HashMap) Put(key []byte, val interface{}) {
 	// Grow the map if we've run out of slots.
 	m.n++
 	if m.n > m.threshold {
-		m.grow()
+		m.Grow(m.capacity * 2)
 	}
 
 	// If the key was overwritten then decrement the size.
@@ -120,14 +122,20 @@ func (m *HashMap) alloc() {
 	m.mask = int64(m.capacity - 1)
 }
 
-// grow doubles the capacity and reinserts all existing hashes & elements.
-func (m *HashMap) grow() {
+// Grow increases the capacity and reinserts all existing hashes & elements.
+func (m *HashMap) Grow(sz int64) {
+	// Ensure new capacity is a power of two and greater than current capacity.
+	sz = pow2(sz)
+	if sz <= m.capacity {
+		return
+	}
+
 	// Copy old elements and hashes.
 	elems, hashes := m.elems, m.hashes
 	capacity := m.capacity
 
-	// Double capacity & reallocate.
-	m.capacity *= 2
+	// Increase capacity & reallocate.
+	m.capacity = sz
 	m.alloc()
 
 	// Copy old elements to new hash/elem list.

--- a/tsdb/series_index.go
+++ b/tsdb/series_index.go
@@ -133,6 +133,14 @@ func (idx *SeriesIndex) Recover(segments []*SeriesSegment) error {
 	return nil
 }
 
+// GrowBy preallocates the in-memory hashmap to a larger size.
+func (idx *SeriesIndex) GrowBy(delta int) {
+	if delta < 0 {
+		return
+	}
+	idx.keyIDMap.Grow(((idx.keyIDMap.Len() + int64(delta)) * 100) / int64(idx.keyIDMap.LoadFactor()))
+}
+
 // Count returns the number of series in the index.
 func (idx *SeriesIndex) Count() uint64 {
 	return idx.OnDiskCount() + idx.InMemCount()

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -176,9 +176,7 @@ func (p *SeriesPartition) IndexPath() string { return filepath.Join(p.path, "ind
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
 // The ids parameter is modified to contain series IDs for all keys belonging to this partition.
 // If the type does not match the existing type for the key, a zero id is stored.
-func (p *SeriesPartition) CreateSeriesListIfNotExists(collection *SeriesCollection,
-	keyPartitionIDs []int) error {
-
+func (p *SeriesPartition) CreateSeriesListIfNotExists(collection *SeriesCollection, keyPartitionIDs []int) error {
 	p.mu.RLock()
 	if p.closed {
 		p.mu.RUnlock()
@@ -219,6 +217,13 @@ func (p *SeriesPartition) CreateSeriesListIfNotExists(collection *SeriesCollecti
 	// Preallocate the space we'll need before grabbing the lock.
 	newKeyRanges := make([]keyRange, 0, writeRequired)
 	newIDs := make(map[string]SeriesIDTyped, writeRequired)
+
+	// Pre-grow index for large writes.
+	if writeRequired >= 10000 {
+		p.mu.Lock()
+		p.index.GrowBy(writeRequired)
+		p.mu.Unlock()
+	}
 
 	// Obtain write lock to create new series.
 	p.mu.Lock()

--- a/tsdb/series_partition_test.go
+++ b/tsdb/series_partition_test.go
@@ -1,0 +1,75 @@
+package tsdb_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/influxdata/platform/logger"
+	"github.com/influxdata/platform/models"
+	"github.com/influxdata/platform/tsdb"
+)
+
+func BenchmarkSeriesPartition_CreateSeriesListIfNotExists(b *testing.B) {
+	for _, n := range []int{1000, 10000, 100000, 1000000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			var collection tsdb.SeriesCollection
+			for i := 0; i < n; i++ {
+				collection.Names = append(collection.Names, []byte("cpu"))
+				collection.Tags = append(collection.Tags, models.Tags{
+					{Key: []byte("tag0"), Value: []byte("value0")},
+					{Key: []byte("tag1"), Value: []byte("value1")},
+					{Key: []byte("tag2"), Value: []byte("value2")},
+					{Key: []byte("tag3"), Value: []byte("value3")},
+					{Key: []byte("tag4"), Value: []byte(fmt.Sprintf("value%d", i))},
+				})
+				collection.Types = append(collection.Types, models.Integer)
+			}
+			collection.SeriesKeys = tsdb.GenerateSeriesKeys(collection.Names, collection.Tags)
+			collection.SeriesIDs = make([]tsdb.SeriesID, len(collection.SeriesKeys))
+			keyPartitionIDs := make([]int, n)
+
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				p := MustOpenSeriesPartition()
+				if err := p.CreateSeriesListIfNotExists(&collection, keyPartitionIDs); err != nil {
+					b.Fatal(err)
+				} else if err := p.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// SeriesPartition is a test wrapper for tsdb.SeriesPartition.
+type SeriesPartition struct {
+	*tsdb.SeriesPartition
+}
+
+// NewSeriesPartition returns a new instance of SeriesPartition with a temporary file path.
+func NewSeriesPartition() *SeriesPartition {
+	dir, err := ioutil.TempDir("", "tsdb-series-partition-")
+	if err != nil {
+		panic(err)
+	}
+	return &SeriesPartition{SeriesPartition: tsdb.NewSeriesPartition(0, dir)}
+}
+
+// MustOpenSeriesPartition returns a new, open instance of SeriesPartition. Panic on error.
+func MustOpenSeriesPartition() *SeriesPartition {
+	f := NewSeriesPartition()
+	f.Logger = logger.New(os.Stdout)
+	if err := f.Open(); err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// Close closes the partition and removes it from disk.
+func (f *SeriesPartition) Close() error {
+	defer os.RemoveAll(f.Path())
+	return f.SeriesPartition.Close()
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This pull request preallocates space in the RHH hashmap before we bulk import into a partition. Normally the hashmap would keep doubling in space but that can take many iterations for large imports.

Previous benchmark:

```
BenchmarkSeriesPartition_CreateSeriesListIfNotExists/1000000-4         	       1	3611973385 ns/op
```

New benchmark:

```
BenchmarkSeriesPartition_CreateSeriesListIfNotExists/1000000-4         	       1	2519296210 ns/op
```

There is an approximately 30% improvement per partition (`3.6s` to `2.5s`) when performing a large import. The preallocation also occurs in a staggered lock so that the continuous lock time is broken up.

_What was the problem?_

We wanted to improve bulk import performance.

_What was the solution?_

Preallocate hashmap space and remove duplicate effort caused by constantly resizing the hashmap.


  - [x] Rebased/mergeable
  - [x] Tests pass
