### PR TITLE
fix(task): add limit field to TaskFilter

### DIFF
--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -173,6 +173,7 @@ type TaskFindFlags struct {
 	user  string
 	id    string
 	orgID string
+	limit int
 }
 
 var taskFindFlags TaskFindFlags
@@ -187,6 +188,7 @@ func init() {
 	taskFindCmd.Flags().StringVarP(&taskFindFlags.id, "id", "i", "", "task ID")
 	taskFindCmd.Flags().StringVarP(&taskFindFlags.user, "user-id", "n", "", "task owner ID")
 	taskFindCmd.Flags().StringVarP(&taskFindFlags.orgID, "org-id", "", "", "task organization ID")
+	taskFindCmd.Flags().IntVarP(&taskFindFlags.limit, "limit", "", platform.TaskDefaultPageSize, "the number of tasks to find")
 
 	taskCmd.AddCommand(taskFindCmd)
 }
@@ -215,6 +217,12 @@ func taskFindF(cmd *cobra.Command, args []string) {
 		}
 		filter.Organization = id
 	}
+
+	if taskFindFlags.limit < 1 || taskFindFlags.limit > platform.TaskMaxPageSize {
+		fmt.Printf("limit must be between 1 and %d \n", platform.TaskMaxPageSize)
+		os.Exit(1)
+	}
+	filter.Limit = taskFindFlags.limit
 
 	var tasks []*platform.Task
 	var err error

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2467,7 +2467,6 @@ paths:
       tags:
         - Tasks
       summary: List tasks.
-      description: Lists tasks, limit 100
       parameters:
         - in: query
           name: after
@@ -2484,6 +2483,14 @@ paths:
           schema:
             type: string
           description: filter tasks to a specific organization ID
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+          description: the number of tasks to return
       responses:
         '200':
           description: A list of tasks

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -225,6 +225,19 @@ func decodeGetTasksRequest(ctx context.Context, r *http.Request) (*getTasksReque
 		req.filter.User = id
 	}
 
+	if limit := qp.Get("limit"); limit != "" {
+		lim, err := strconv.Atoi(limit)
+		if err != nil {
+			return nil, err
+		}
+		if lim < 1 || lim > platform.TaskMaxPageSize {
+			return nil, kerrors.InvalidDataf("limit must be between 1 and %d", platform.TaskMaxPageSize)
+		}
+		req.filter.Limit = lim
+	} else {
+		req.filter.Limit = platform.TaskDefaultPageSize
+	}
+
 	return req, nil
 }
 
@@ -808,6 +821,9 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 	}
 	if filter.User != nil {
 		val.Add("user", filter.User.String())
+	}
+	if filter.Limit != 0 {
+		val.Add("limit", strconv.Itoa(filter.Limit))
 	}
 
 	u.RawQuery = val.Encode()

--- a/task.go
+++ b/task.go
@@ -4,6 +4,11 @@ import (
 	"context"
 )
 
+const (
+	TaskDefaultPageSize = 100
+	TaskMaxPageSize     = 500
+)
+
 // Task is a task. 🎊
 type Task struct {
 	ID           ID     `json:"id,omitempty"`
@@ -78,6 +83,7 @@ type TaskFilter struct {
 	After        *ID
 	Organization *ID
 	User         *ID
+	Limit        int
 }
 
 // RunFilter represents a set of filters that restrict the returned results

--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -283,21 +283,17 @@ func (s *Store) ListTasks(ctx context.Context, params backend.TaskSearchParams) 
 		return nil, errors.New("ListTasks: org and user filters are mutually exclusive")
 	}
 
-	const (
-		defaultPageSize = 100
-		maxPageSize     = 500
-	)
 	if params.PageSize < 0 {
 		return nil, errors.New("ListTasks: PageSize must be positive")
 	}
-	if params.PageSize > maxPageSize {
-		return nil, fmt.Errorf("ListTasks: PageSize exceeds maximum of %d", maxPageSize)
+	if params.PageSize > platform.TaskMaxPageSize {
+		return nil, fmt.Errorf("ListTasks: PageSize exceeds maximum of %d", platform.TaskMaxPageSize)
 	}
 	lim := params.PageSize
 	if lim == 0 {
-		lim = defaultPageSize
+		lim = platform.TaskDefaultPageSize
 	}
-	taskIDs := make([]platform.ID, 0, params.PageSize)
+	taskIDs := make([]platform.ID, 0, lim)
 	var tasks []backend.StoreTaskWithMeta
 
 	if err := s.db.View(func(tx *bolt.Tx) error {

--- a/task/backend/inmem_store.go
+++ b/task/backend/inmem_store.go
@@ -134,21 +134,16 @@ func (s *inmem) ListTasks(_ context.Context, params TaskSearchParams) ([]StoreTa
 		return nil, errors.New("ListTasks: org and user filters are mutually exclusive")
 	}
 
-	const (
-		defaultPageSize = 100
-		maxPageSize     = 500
-	)
-
 	if params.PageSize < 0 {
 		return nil, errors.New("ListTasks: PageSize must be positive")
 	}
-	if params.PageSize > maxPageSize {
-		return nil, fmt.Errorf("ListTasks: PageSize exceeds maximum of %d", maxPageSize)
+	if params.PageSize > platform.TaskMaxPageSize {
+		return nil, fmt.Errorf("ListTasks: PageSize exceeds maximum of %d", platform.TaskMaxPageSize)
 	}
 
 	lim := params.PageSize
 	if lim == 0 {
-		lim = defaultPageSize
+		lim = platform.TaskDefaultPageSize
 	}
 
 	out := make([]StoreTaskWithMeta, 0, lim)

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -43,9 +43,7 @@ func (p pAdapter) FindTaskByID(ctx context.Context, id platform.ID) (*platform.T
 }
 
 func (p pAdapter) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
-	const pageSize = 100 // According to the platform.TaskService.FindTasks API.
-
-	params := backend.TaskSearchParams{PageSize: pageSize}
+	params := backend.TaskSearchParams{PageSize: filter.Limit}
 	if filter.Organization != nil {
 		params.Org = *filter.Organization
 	}
@@ -68,8 +66,7 @@ func (p pAdapter) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]
 		}
 	}
 
-	totalResults := len(pts) // TODO(mr): don't lie about the total results. Update ListTasks signature?
-	return pts, totalResults, nil
+	return pts, len(pts), nil
 }
 
 func (p pAdapter) CreateTask(ctx context.Context, t *platform.Task) error {


### PR DESCRIPTION
https://github.com/influxdata/platform/blob/master/task/platform_adapter.go#L45-L48

_Briefly describe your proposed changes:_


_What was the problem?_
Currently, the `FindTasks` method uses a fixed `pageSize` to filter tasks.
The number of tasks to return should be specified by callers.

_What was the solution?_
Update swagger to include limit param.
Add limit field to `TaskFilter`.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
