### PR TITLE
Add completion step to progress bar in onboarding wizard

### DIFF
--- a/ui/src/clockface/components/wizard/ProgressBar.tsx
+++ b/ui/src/clockface/components/wizard/ProgressBar.tsx
@@ -30,11 +30,10 @@ class ProgressBar extends PureComponent<Props, null> {
     const {stepStatuses, stepTitles, currentStepIndex} = this.props
 
     const lastIndex = stepStatuses.length - 1
-    const lastEleIndex = stepStatuses.length - 2
 
     const progressBar: JSX.Element[] = stepStatuses.reduce(
       (acc, stepStatus, i) => {
-        if (i === 0 || i === lastIndex) {
+        if (i === 0) {
           return [...acc]
         }
 
@@ -64,7 +63,7 @@ class ProgressBar extends PureComponent<Props, null> {
           </div>
         )
 
-        if (i === lastEleIndex) {
+        if (i === lastIndex) {
           return [...acc, stepEle]
         }
 
@@ -74,7 +73,7 @@ class ProgressBar extends PureComponent<Props, null> {
         if (i === currentStepIndex && stepStatus !== StepStatus.Error) {
           connectorStatus = ConnectorState.Some
         }
-        if (i === lastEleIndex || stepStatus === StepStatus.Complete) {
+        if (i === lastIndex || stepStatus === StepStatus.Complete) {
           connectorStatus = ConnectorState.Full
         }
         const connectorEle = (

--- a/ui/src/onboarding/components/CompletionStep.tsx
+++ b/ui/src/onboarding/components/CompletionStep.tsx
@@ -13,11 +13,14 @@ class CompletionStep extends PureComponent<OnboardingStepProps> {
   public componentDidMount() {
     window.addEventListener('keydown', this.handleKeydown)
   }
+
   public componentWillUnmount() {
     window.removeEventListener('keydown', this.handleKeydown)
   }
+
   public render() {
-    const {onExit} = this.props
+    const {onExit, onDecrementCurrentStepIndex} = this.props
+
     return (
       <div className="onboarding-step">
         <div className="splash-logo secondary" />
@@ -28,7 +31,7 @@ class CompletionStep extends PureComponent<OnboardingStepProps> {
             color={ComponentColor.Default}
             text="Back"
             size={ComponentSize.Medium}
-            onClick={this.props.onDecrementCurrentStepIndex}
+            onClick={onDecrementCurrentStepIndex}
           />
           <Button
             color={ComponentColor.Success}

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -156,10 +156,7 @@ class OnboardingWizard extends PureComponent<Props> {
       onSetCurrentStepIndex,
     } = this.props
 
-    if (
-      currentStepIndex === 0 ||
-      currentStepIndex === stepStatuses.length - 1
-    ) {
+    if (currentStepIndex === 0) {
       return <div className="wizard--progress-header hidden" />
     }
 


### PR DESCRIPTION
Closes #1661

_Briefly describe your proposed changes:_
Previously, the progress bar was hidden for the last step of the onboarding process (the "completion" step). This PR will show the progress bar for this step.

<img width="913" alt="screen shot 2018-12-04 at 12 26 12 pm" src="https://user-images.githubusercontent.com/15273162/49470764-d211db80-f7bf-11e8-9669-9e8f2fb5c586.png">

(Note: displaying the progress on the green bar will be fixed in another PR.)

  - [x] Rebased/mergeable
  - [x] Tests pass