### PR TITLE
remove make test-integration call from deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ jobs:
             - chronograf-npm-packages-{{ checksum "ui/package-lock.json" }}
 
       - setup_remote_docker
-      - run: make test-integration
       - run: |
           docker login -u "$QUAY_USER" -p $QUAY_PASS quay.io
           make nightly


### PR DESCRIPTION
See https://github.com/influxdata/platform/pull/1672 for background

Temporarily remove the call to make test-integration so that nightly
builds are not broken.

Related to https://github.com/influxdata/platform/issues/1676


  - [ ] Rebased/mergeable
  - [ ] Tests pass