### PR TITLE
Dataloader/skip data sources steps

### DIFF
--- a/ui/src/onboarding/OnboardingWizard.scss
+++ b/ui/src/onboarding/OnboardingWizard.scss
@@ -53,6 +53,16 @@
   }
 }
 
+.wizard-button-container {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+
+  .button {
+    width: 50%;
+  }
+}
+
 .splash-logo {
   background-size: 100% 100%;
   background-position: center center;

--- a/ui/src/onboarding/components/configureStep/ConfigureDataSourceStep.tsx
+++ b/ui/src/onboarding/components/configureStep/ConfigureDataSourceStep.tsx
@@ -45,24 +45,46 @@ class ConfigureDataSourceStep extends PureComponent<Props, State> {
           currentIndex={this.state.currentDataSourceIndex}
           dataLoaderType={type}
         />
-        <div className="wizard-button-bar">
-          <Button
-            color={ComponentColor.Default}
-            text="Back"
-            size={ComponentSize.Medium}
-            onClick={this.handlePrevious}
-          />
-          <Button
-            color={ComponentColor.Primary}
-            text="Next"
-            size={ComponentSize.Medium}
-            onClick={this.handleNext}
-            status={ComponentStatus.Default}
-            titleText={'Next'}
-          />
+        <div className="wizard-button-container">
+          <div className="wizard-button-bar">
+            <Button
+              color={ComponentColor.Default}
+              text="Back"
+              size={ComponentSize.Medium}
+              onClick={this.handlePrevious}
+            />
+            <Button
+              color={ComponentColor.Primary}
+              text="Next"
+              size={ComponentSize.Medium}
+              onClick={this.handleNext}
+              status={ComponentStatus.Default}
+              titleText={'Next'}
+            />
+          </div>
+          {this.skipLink}
         </div>
       </div>
     )
+  }
+
+  private get skipLink() {
+    return (
+      <Button
+        color={ComponentColor.Default}
+        text="Skip"
+        size={ComponentSize.Small}
+        onClick={this.jumpToCompletionStep}
+      >
+        skip
+      </Button>
+    )
+  }
+
+  private jumpToCompletionStep = () => {
+    const {onSetCurrentStepIndex, stepStatuses} = this.props
+
+    onSetCurrentStepIndex(stepStatuses.length - 1)
   }
 
   private handleNext = () => {

--- a/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
+++ b/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
@@ -50,21 +50,24 @@ class SelectDataSourceStep extends PureComponent<Props, State> {
           You will be able to configure additional Data Sources later
         </h5>
         {this.selector}
-        <div className="wizard-button-bar">
-          <Button
-            color={ComponentColor.Default}
-            text="Back"
-            size={ComponentSize.Medium}
-            onClick={this.handleClickBack}
-          />
-          <Button
-            color={ComponentColor.Primary}
-            text="Next"
-            size={ComponentSize.Medium}
-            onClick={this.handleClickNext}
-            status={ComponentStatus.Default}
-            titleText={'Next'}
-          />
+        <div className="wizard-button-container">
+          <div className="wizard-button-bar">
+            <Button
+              color={ComponentColor.Default}
+              text="Back"
+              size={ComponentSize.Medium}
+              onClick={this.handleClickBack}
+            />
+            <Button
+              color={ComponentColor.Primary}
+              text="Next"
+              size={ComponentSize.Medium}
+              onClick={this.handleClickNext}
+              status={ComponentStatus.Default}
+              titleText={'Next'}
+            />
+          </div>
+          {this.skipLink}
         </div>
       </div>
     )
@@ -97,6 +100,25 @@ class SelectDataSourceStep extends PureComponent<Props, State> {
         type={this.props.type}
       />
     )
+  }
+
+  private get skipLink() {
+    return (
+      <Button
+        color={ComponentColor.Default}
+        text="Skip"
+        size={ComponentSize.Small}
+        onClick={this.jumpToCompletionStep}
+      >
+        skip
+      </Button>
+    )
+  }
+
+  private jumpToCompletionStep = () => {
+    const {onSetCurrentStepIndex, stepStatuses} = this.props
+
+    onSetCurrentStepIndex(stepStatuses.length - 1)
   }
 
   private handleClickNext = () => {

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.test.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.test.tsx
@@ -32,7 +32,7 @@ describe('Onboarding.Components.VerifyStep.VerifyDataStep', () => {
     const switcher = wrapper.find(VerifyDataSwitcher)
 
     expect(wrapper.exists()).toBe(true)
-    expect(buttons.length).toBe(2)
+    expect(buttons.length).toBe(3)
     expect(switcher.exists()).toBe(true)
   })
 })

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
@@ -38,24 +38,46 @@ class VerifyDataStep extends PureComponent<Props> {
           username={_.get(setupParams, 'username', '')}
           bucket={_.get(setupParams, 'bucket', '')}
         />
-        <div className="wizard-button-bar">
-          <Button
-            color={ComponentColor.Default}
-            text="Back"
-            size={ComponentSize.Medium}
-            onClick={onDecrementCurrentStepIndex}
-          />
-          <Button
-            color={ComponentColor.Primary}
-            text="Next"
-            size={ComponentSize.Medium}
-            onClick={onIncrementCurrentStepIndex}
-            status={ComponentStatus.Default}
-            titleText={'Next'}
-          />
+        <div className="wizard-button-container">
+          <div className="wizard-button-bar">
+            <Button
+              color={ComponentColor.Default}
+              text="Back"
+              size={ComponentSize.Medium}
+              onClick={onDecrementCurrentStepIndex}
+            />
+            <Button
+              color={ComponentColor.Primary}
+              text="Next"
+              size={ComponentSize.Medium}
+              onClick={onIncrementCurrentStepIndex}
+              status={ComponentStatus.Default}
+              titleText={'Next'}
+            />
+          </div>
+          {this.skipLink}
         </div>
       </div>
     )
+  }
+
+  private get skipLink() {
+    return (
+      <Button
+        color={ComponentColor.Default}
+        text="Skip"
+        size={ComponentSize.Small}
+        onClick={this.jumpToCompletionStep}
+      >
+        skip
+      </Button>
+    )
+  }
+
+  private jumpToCompletionStep = () => {
+    const {onSetCurrentStepIndex, stepStatuses} = this.props
+
+    onSetCurrentStepIndex(stepStatuses.length - 1)
   }
 }
 

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
-
 import {connect} from 'react-redux'
 import _ from 'lodash'
 
@@ -34,7 +33,6 @@ import {
 import {StepStatus} from 'src/clockface/constants/wizard'
 
 // Types
-
 import {Links} from 'src/types/v2/links'
 import {SetupParams} from 'src/onboarding/apis'
 import {TelegrafPlugin, DataLoaderType} from 'src/types/v2/dataLoaders'


### PR DESCRIPTION
Closes #1658 
Closes #1659

Previously, it was impossible to skip the data source steps in the onboarding wizard. This PR adds a skip button to the add, configure, and verify data source steps that takes the user to the completion step.

<img width="585" alt="screen shot 2018-12-04 at 3 57 57 pm" src="https://user-images.githubusercontent.com/15273162/49481075-14e2ac00-f7de-11e8-886c-ccc219c1c9a9.png">

  - [x] Rebased/mergeable
  - [x] Tests pass