### PR TITLE
add /query/analyze endpoint query http handler

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -160,6 +160,7 @@ var apiLinks = map[string]interface{}{
 	"query": map[string]string{
 		"self":        "/api/v2/query",
 		"ast":         "/api/v2/query/ast",
+		"analyze":     "/api/v2/query/analyze",
 		"plan":        "/api/v2/query/plan",
 		"spec":        "/api/v2/query/spec",
 		"suggestions": "/api/v2/query/suggestions",

--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -1785,6 +1785,51 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /query/analyze:
+   post:
+    tags:
+      - Query
+    summary: analyze an influxql or flux query
+    parameters:
+      - in: header
+        name: Content-Type
+        schema:
+          type: string
+          enum:
+            - application/json
+      - in: header
+        name: Authorization
+        description: the authorization header should be in the format of `Token <key>`
+        schema:
+          type: string
+    requestBody:
+        description: flux or influxql query to analyze
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Query"
+    responses:
+        '200':
+          description: query analyze results. Errors will be empty if the query is valid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnalyzeQueryResponse"
+        default:
+          description: internal server error
+          headers:
+            X-Influx-Error:
+              description: error string describing the problem
+              schema:
+                type: string
+            X-Influx-Reference:
+              description: reference code unique to the error type
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /query:
     get:
       tags:
@@ -4630,6 +4675,22 @@ components:
         usingView:
           type: string
           description: makes a copy of the provided view
+    AnalyzeQueryResponse:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              line:
+                type: integer
+              column:
+                type: integer
+              character:
+                type: integer
+              message:
+                type: string
     Cell:
       type: object
       properties:
@@ -4782,16 +4843,16 @@ components:
             $ref: "#/components/schemas/TelegrafRequestPlugin"
     TelegrafRequestPlugin:
       type: object
-      discriminator: 
+      discriminator:
         propertyName: "name"
-      required: 
+      required:
         - name
       properties:
         name:
           type: string
     TelegrafPluginInputCpu:
       type: object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4836,7 +4897,7 @@ components:
     TelegrafPluginInputDiskio:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4851,15 +4912,15 @@ components:
           type: string
         config:
           $ref: "#/components/schemas/TelegrafPluginConfig"
-    TelegrafPluginInputDiskioRequest: 
+    TelegrafPluginInputDiskioRequest:
       type: object
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
         - $ref: "#/components/schemas/TelegrafPluginInputDiskio"
-    TelegrafPluginInputDocker: 
-      type: 
+    TelegrafPluginInputDocker:
+      type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4882,7 +4943,7 @@ components:
     TelegrafPluginInputFile:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4905,7 +4966,7 @@ components:
     TelegrafPluginInputKernel:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4928,7 +4989,7 @@ components:
     TelegrafPluginInputKubernetes:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4951,7 +5012,7 @@ components:
     TelegrafPluginInputLogParser:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4974,7 +5035,7 @@ components:
     TelegrafPluginInputMem:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -4997,7 +5058,7 @@ components:
     TelegrafPluginInputNetResponse:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5017,10 +5078,10 @@ components:
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
         - $ref: "#/components/schemas/TelegrafPluginInputNetResponse"
-    TelegrafPluginInputNet: 
+    TelegrafPluginInputNet:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5043,7 +5104,7 @@ components:
     TelegrafPluginInputNgnix:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5066,7 +5127,7 @@ components:
     TelegrafPluginInputProcesses:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5089,7 +5150,7 @@ components:
     TelegrafPluginInputProcstat:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5112,7 +5173,7 @@ components:
     TelegrafPluginInputPrometheus:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5135,7 +5196,7 @@ components:
     TelegrafPluginInputRedis:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5158,7 +5219,7 @@ components:
     TelegrafPluginInputSyslog:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5181,7 +5242,7 @@ components:
     TelegrafPluginInputSwap:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5204,7 +5265,7 @@ components:
     TelegrafPluginInputSystem:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5227,7 +5288,7 @@ components:
     TelegrafPluginInputTail:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5250,7 +5311,7 @@ components:
     TelegrafPluginOutputFile:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5273,7 +5334,7 @@ components:
     TelegrafPluginOutputInfluxDBV2:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5332,7 +5393,7 @@ components:
       type: object
     TelegrafPluginInputDockerConfig:
       type: object
-      required: 
+      required:
         - endpoint
       properties:
         endpoint:

--- a/http/query.go
+++ b/http/query.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -12,8 +14,10 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxql"
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/kit/errors"
 	"github.com/influxdata/platform/query"
@@ -96,6 +100,131 @@ func (r QueryRequest) Validate() error {
 
 	return nil
 }
+
+// QueryAnalysis is a structured response of errors.
+type QueryAnalysis struct {
+	Errors []queryParseError `json:"errors"`
+}
+
+type queryParseError struct {
+	Line      int    `json:"line"`
+	Column    int    `json:"column"`
+	Character int    `json:"character"`
+	Message   string `json:"message"`
+}
+
+// Analyze attempts to parse the query request and returns any errors
+// encountered in a structured way.
+func (r QueryRequest) Analyze() (*QueryAnalysis, error) {
+	switch r.Type {
+	case "flux":
+		return r.analyzeFluxQuery()
+	case "influxql":
+		return r.analyzeInfluxQLQuery()
+	}
+
+	return nil, fmt.Errorf("unknown query request type %s", r.Type)
+}
+
+func (r QueryRequest) analyzeFluxQuery() (*QueryAnalysis, error) {
+	a := &QueryAnalysis{}
+	_, err := parser.NewAST(r.Query)
+	if err == nil {
+		a.Errors = []queryParseError{}
+		return a, nil
+	}
+
+	ms := fluxParseErrorRE.FindAllStringSubmatch(err.Error(), -1)
+	a.Errors = make([]queryParseError, 0, len(ms))
+	for _, m := range ms {
+		if len(m) != 5 {
+			return nil, fmt.Errorf("flux query error is not formatted as expected: got %d matches expected 5", len(m))
+		}
+		lineStr := m[1]
+		line, err := strconv.Atoi(lineStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse line number from error mesage: %s -> %v", lineStr, err)
+		}
+		colStr := m[2]
+		col, err := strconv.Atoi(colStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse column number from error mesage: %s -> %v", colStr, err)
+		}
+		charStr := m[3]
+		char, err := strconv.Atoi(charStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse character number from error mesage: %s -> %v", charStr, err)
+		}
+		msg := m[4]
+
+		a.Errors = append(a.Errors, queryParseError{
+			Line:      line,
+			Column:    col,
+			Character: char,
+			Message:   msg,
+		})
+
+	}
+
+	return a, nil
+}
+
+var fluxParseErrorRE = regexp.MustCompile(`(\d+):(\d+) \((\d+)\): ([[:graph:] ]+)`)
+
+func (r QueryRequest) analyzeInfluxQLQuery() (*QueryAnalysis, error) {
+	a := &QueryAnalysis{}
+	_, err := influxql.ParseQuery(r.Query)
+	if err == nil {
+		a.Errors = []queryParseError{}
+		return a, nil
+	}
+
+	ms := influxqlParseErrorRE.FindAllStringSubmatch(err.Error(), -1)
+	a.Errors = make([]queryParseError, 0, len(ms))
+	for _, m := range ms {
+		if len(m) != 4 {
+			return nil, fmt.Errorf("influxql query error is not formatted as expected: got %d matches expected 4", len(m))
+		}
+		msg := m[1]
+		lineStr := m[2]
+		line, err := strconv.Atoi(lineStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse line number from error mesage: %s -> %v", lineStr, err)
+		}
+		charStr := m[3]
+		char, err := strconv.Atoi(charStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse character number from error mesage: %s -> %v", charStr, err)
+		}
+
+		a.Errors = append(a.Errors, queryParseError{
+			Line:      line,
+			Column:    columnFromCharacter(r.Query, char),
+			Character: char,
+			Message:   msg,
+		})
+	}
+
+	return a, nil
+}
+
+func columnFromCharacter(q string, char int) int {
+	col := 0
+	for i, c := range q {
+		if c == '\n' {
+			col = 0
+		}
+
+		if i == char {
+			break
+		}
+		col++
+	}
+
+	return col
+}
+
+var influxqlParseErrorRE = regexp.MustCompile(`^(.+) at line (\d+), char (\d+)$`)
 
 func nowFunc(now time.Time) values.Function {
 	timeVal := values.NewTime(values.ConvertTime(now))

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2237,6 +2237,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /query/analyze:
+   post:
+    tags:
+      - Query
+    summary: analyze an influxql or flux query
+    parameters:
+      - in: header
+        name: Content-Type
+        schema:
+          type: string
+          enum:
+            - application/json
+    requestBody:
+        description: flux or influxql query to analyze
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Query"
+    responses:
+        '200':
+          description: query analyze results. Errors will be empty if the query is valid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnalyzeQueryResponse"
+        default:
+          description: internal server error
+          headers:
+            X-Influx-Error:
+              description: error string describing the problem
+              schema:
+                type: string
+            X-Influx-Reference:
+              description: reference code unique to the error type
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /query:
    get:
     tags:
@@ -5360,6 +5400,22 @@ components:
         usingView:
           type: string
           description: makes a copy of the provided view
+    AnalyzeQueryResponse:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              line:
+                type: integer
+              column:
+                type: integer
+              character:
+                type: integer
+              message:
+                type: string
     Cell:
       type: object
       properties:
@@ -5520,20 +5576,20 @@ components:
               type: integer
         plugins:
           type: array
-          items: 
+          items:
             $ref: "#/components/schemas/TelegrafRequestPlugin"
     TelegrafRequestPlugin:
       type: object
-      discriminator: 
+      discriminator:
         propertyName: "name"
-      required: 
+      required:
         - name
       properties:
         name:
           type: string
     TelegrafPluginInputCpu:
       type: object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5578,7 +5634,7 @@ components:
     TelegrafPluginInputDiskio:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5593,15 +5649,15 @@ components:
           type: string
         config:
           $ref: "#/components/schemas/TelegrafPluginConfig"
-    TelegrafPluginInputDiskioRequest: 
+    TelegrafPluginInputDiskioRequest:
       type: object
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
         - $ref: "#/components/schemas/TelegrafPluginInputDiskio"
-    TelegrafPluginInputDocker: 
-      type: 
+    TelegrafPluginInputDocker:
+      type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5624,7 +5680,7 @@ components:
     TelegrafPluginInputFile:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5647,7 +5703,7 @@ components:
     TelegrafPluginInputKernel:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5670,7 +5726,7 @@ components:
     TelegrafPluginInputKubernetes:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5693,7 +5749,7 @@ components:
     TelegrafPluginInputLogParser:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5716,7 +5772,7 @@ components:
     TelegrafPluginInputMem:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5739,7 +5795,7 @@ components:
     TelegrafPluginInputNetResponse:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5759,10 +5815,10 @@ components:
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
         - $ref: "#/components/schemas/TelegrafPluginInputNetResponse"
-    TelegrafPluginInputNet: 
+    TelegrafPluginInputNet:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5785,7 +5841,7 @@ components:
     TelegrafPluginInputNgnix:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5808,7 +5864,7 @@ components:
     TelegrafPluginInputProcesses:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5831,7 +5887,7 @@ components:
     TelegrafPluginInputProcstat:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5854,7 +5910,7 @@ components:
     TelegrafPluginInputPrometheus:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5877,7 +5933,7 @@ components:
     TelegrafPluginInputRedis:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5900,7 +5956,7 @@ components:
     TelegrafPluginInputSyslog:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5923,7 +5979,7 @@ components:
     TelegrafPluginInputSwap:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5946,7 +6002,7 @@ components:
     TelegrafPluginInputSystem:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5969,7 +6025,7 @@ components:
     TelegrafPluginInputTail:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -5992,7 +6048,7 @@ components:
     TelegrafPluginOutputFile:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -6015,7 +6071,7 @@ components:
     TelegrafPluginOutputInfluxDBV2:
       type:
         object
-      required: 
+      required:
         - name
         - type
         - config
@@ -6074,7 +6130,7 @@ components:
       type: object
     TelegrafPluginInputDockerConfig:
       type: object
-      required: 
+      required:
         - endpoint
       properties:
         endpoint:


### PR DESCRIPTION
Backend Portion of #1530

_What was the problem?_
Wasn't able to analyze query request without actually executing the query.

_What was the solution?_
Add an analyze endpoint that returns friendly json like
```json
{
  "errors": [
    {
      "line": 11,
      "column": 41,
      "character": 674,
      "message": "rule StringLiteral: string literal not terminated"
    },
    {
      "line": 11,
      "column": 48,
      "character": 681,
      "message": "rule ArrayElements: interface conversion: string is not ast.Expression: missing method Copy"
    }
  ]
}
```

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)