### PR TITLE
Introduce Permissions Widget

### DIFF
--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -16,6 +16,10 @@ import {
   IconFont,
 } from 'src/clockface'
 import ImportDashboardOverlay from 'src/dashboards/components/ImportDashboardOverlay'
+import PermissionsWidget, {
+  PermissionsWidgetMode,
+  PermissionsWidgetSelection,
+} from 'src/shared/components/permissionsWidget/PermissionsWidget'
 
 // Utils
 import {getDeep} from 'src/utils/wrappers'
@@ -127,6 +131,7 @@ class DashboardIndex extends PureComponent<Props, State> {
               notify={notify}
               searchTerm={searchTerm}
             />
+            <div className="col-xs-6">{this.permissions}</div>
           </Page.Contents>
         </Page>
         {this.renderImportOverlay}
@@ -249,6 +254,100 @@ class DashboardIndex extends PureComponent<Props, State> {
           notify={notify}
         />
       </OverlayTechnology>
+    )
+  }
+
+  private get permissions() {
+    return (
+      <PermissionsWidget
+        mode={PermissionsWidgetMode.Write}
+        className="testtt"
+        heightPixels={300}
+      >
+        <PermissionsWidget.Section id="apples" title="Apples">
+          <PermissionsWidget.Item
+            label="Pick from tree"
+            id="apples-pick"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Eat"
+            id="apples-eat"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Cook"
+            id="apples-cook"
+            selected={PermissionsWidgetSelection.Unselected}
+          />
+        </PermissionsWidget.Section>
+        <PermissionsWidget.Section id="limes" title="Limes">
+          <PermissionsWidget.Item
+            label="Pick from tree"
+            id="limes-pick"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Peel"
+            id="limes-peel"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Slice"
+            id="limes-slice"
+            selected={PermissionsWidgetSelection.Unselected}
+          />
+        </PermissionsWidget.Section>
+        <PermissionsWidget.Section id="bananas" title="Bananas">
+          <PermissionsWidget.Item
+            label="Pick from tree"
+            id="bananas-pick"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Eat"
+            id="bananas-eat"
+            selected={PermissionsWidgetSelection.Unselected}
+          />
+          <PermissionsWidget.Item
+            label="Cook"
+            id="bananas-cook"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+        </PermissionsWidget.Section>
+        <PermissionsWidget.Section id="fashion" title="Fashion Sense">
+          <PermissionsWidget.Item
+            label="Improve own swagger"
+            id="fashion-improve-swagger"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Locate cool shoes"
+            id="fashion-shoes"
+            selected={PermissionsWidgetSelection.Unselected}
+          />
+          <PermissionsWidget.Item
+            label="Locate fresh jacket"
+            id="fashion-jacket"
+            selected={PermissionsWidgetSelection.Unselected}
+          />
+          <PermissionsWidget.Item
+            label="Locate rad pants"
+            id="fashion-pants"
+            selected={PermissionsWidgetSelection.Unselected}
+          />
+          <PermissionsWidget.Item
+            label="Locate bling bling"
+            id="fashion-bling"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+          <PermissionsWidget.Item
+            label="Odd flex"
+            id="fashion-flex"
+            selected={PermissionsWidgetSelection.Selected}
+          />
+        </PermissionsWidget.Section>
+      </PermissionsWidget>
     )
   }
 }

--- a/ui/src/shared/components/permissionsWidget/PermissionsWidget.scss
+++ b/ui/src/shared/components/permissionsWidget/PermissionsWidget.scss
@@ -1,0 +1,162 @@
+/*
+  Permissions Widget Styles
+  ------------------------------------------------------------------------------
+*/
+
+@import 'src/style/modules';
+
+$permissions-widget--header-height: 54px;
+$permissions-widget--border: $g5-pepper;
+$permissions-widget--item-height: 28px;
+
+.permissions-widget {
+  width: 100%;
+  border: $ix-border solid $permissions-widget--border;
+  border-radius: $ix-radius;
+  background-color: $g3-castle;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-wrap: nowrap;
+}
+
+.permissions-widget--header {
+  @include no-user-select();
+  flex: 0 0 $permissions-widget--header-height;
+  background-color: $g4-onyx;
+  color: $g13-mist;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: $permissions-widget--header-height;
+  padding: 0 $ix-marg-c;
+  border-bottom: $ix-border solid $permissions-widget--border;
+}
+
+.permissions-widget--body {
+  flex: 0 0 calc(100% - #{$permissions-widget--header-height});
+  position: relative;
+}
+
+.permissions-widget--section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  border-bottom: $ix-border solid $permissions-widget--border;
+  padding: 0 $ix-marg-c;
+  padding-bottom: $ix-marg-b;
+
+  &:last-child {
+    border-bottom: 0;
+  }
+}
+
+.permissions-widget--section-heading {
+  @include no-user-select();
+  flex: 0 0 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.permissions-widget--section-title {
+  margin: 0;
+  margin-right: $ix-marg-b;
+  color: $g13-mist;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 13px;
+  white-space: nowrap;
+}
+
+.permissions-widget--section-list {
+  list-style: none;
+  padding-left: $ix-marg-b;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.permissions-widget--item {
+  user-select: none;
+  flex: 0 0 $permissions-widget--item-height;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  
+  &.selectable:hover,
+  &.selectable:hover * {
+    cursor: pointer !important;
+  }
+}
+
+.permissions-widget--item-label {
+  font-size: 13px;
+  transition: color 0.25s ease;
+  margin: 0;
+  
+  .selected & {
+    font-weight: 600;
+    color: $g13-mist;
+  }
+
+  .unselected & {
+    font-weight: 500;
+    color: $g8-storm;
+  }
+
+  .selectable:hover & {
+    color: $g15-platinum;
+  }
+}
+
+.permissions-widget--icon {
+  width: 20px;
+  position: relative;
+  top: -1px;
+
+  .selected & {
+    color: $c-rainforest;
+  }
+
+  .unselected & {
+    color: $g8-storm;
+  }
+}
+
+.permissions-widget--checkbox {
+  width: 18px;
+  height: 18px;
+  border-radius: 3px;
+  background-color: $g2-kevlar;
+  border: $ix-border solid $g5-pepper;
+  position: relative;
+  margin-right: $ix-marg-b;
+  transition: border-color 0.25s ease;
+
+  & > span.icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transition: opacity 0.25s ease;
+    color: $c-rainforest;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+  }
+
+  .selected & {
+    > span.icon {
+      opacity: 1;
+    }
+  }
+
+  .selectable:hover & {
+    border-color: $g7-graphite;
+  }
+}
+
+.testtt {
+  margin-top: 100px;
+}

--- a/ui/src/shared/components/permissionsWidget/PermissionsWidget.tsx
+++ b/ui/src/shared/components/permissionsWidget/PermissionsWidget.tsx
@@ -1,0 +1,87 @@
+// Libraries
+import React, {Component, CSSProperties} from 'react'
+
+// Components
+import PermissionsWidgetSection from 'src/shared/components/permissionsWidget/PermissionsWidgetSection'
+import PermissionsWidgetItem from 'src/shared/components/permissionsWidget/PermissionsWidgetItem'
+import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
+
+// Styles
+import './PermissionsWidget.scss'
+
+export enum PermissionsWidgetMode {
+  Read = 'read',
+  Write = 'write',
+}
+
+export enum PermissionsWidgetSelection {
+  Selected = 'selected',
+  Unselected = 'unselected',
+}
+
+interface Props {
+  children: JSX.Element[] | JSX.Element
+  mode: PermissionsWidgetMode
+  heightPixels?: number
+  className?: string
+}
+
+class PermissionsWidget extends Component<Props> {
+  public static defaultProps: Partial<Props> = {
+    heightPixels: 500,
+  }
+
+  public static Section = PermissionsWidgetSection
+  public static Item = PermissionsWidgetItem
+
+  public render() {
+    return (
+      <div className={this.className} style={this.style}>
+        <div className="permissions-widget--header">{this.headerText}</div>
+        <div className="permissions-widget--body">
+          <FancyScrollbar autoHide={false}>{this.sections}</FancyScrollbar>
+        </div>
+      </div>
+    )
+  }
+
+  private get className(): string {
+    const {className} = this.props
+
+    if (className) {
+      return `permissions-widget ${className}`
+    }
+
+    return 'permissions-widget'
+  }
+
+  private get sections() {
+    const {children, mode} = this.props
+
+    return React.Children.map(children, (child: JSX.Element) => {
+      if (child.type !== PermissionsWidgetSection) {
+        return null
+      }
+
+      return <PermissionsWidgetSection {...child.props} mode={mode} />
+    })
+  }
+
+  private get style(): CSSProperties {
+    const {heightPixels} = this.props
+
+    return {height: `${heightPixels}px`}
+  }
+
+  private get headerText(): string {
+    const {mode} = this.props
+
+    if (mode === PermissionsWidgetMode.Read) {
+      return 'Summary of access permissions'
+    } else if (mode === PermissionsWidgetMode.Write) {
+      return 'Summary of access permissions, each item can be toggled ON or OFF'
+    }
+  }
+}
+
+export default PermissionsWidget

--- a/ui/src/shared/components/permissionsWidget/PermissionsWidgetItem.tsx
+++ b/ui/src/shared/components/permissionsWidget/PermissionsWidgetItem.tsx
@@ -1,0 +1,86 @@
+// Libraries
+import React, {Component} from 'react'
+import classnames from 'classnames'
+
+// Types
+import {
+  PermissionsWidgetMode,
+  PermissionsWidgetSelection,
+} from 'src/shared/components/permissionsWidget/PermissionsWidget'
+import {IconFont} from 'src/clockface'
+
+interface Props {
+  mode?: PermissionsWidgetMode
+  id: string
+  label: string
+  selected: PermissionsWidgetSelection
+  onToggle?: (
+    permissionID: string,
+    newState: PermissionsWidgetSelection
+  ) => void
+}
+
+class PermissionsWidgetItem extends Component<Props> {
+  public render() {
+    const {label} = this.props
+
+    return (
+      <li className={this.className} onClick={this.handleClick}>
+        {this.checkbox}
+        <label className="permissions-widget--item-label">{label}</label>
+      </li>
+    )
+  }
+
+  private get checkbox(): JSX.Element {
+    const {mode, selected} = this.props
+
+    if (mode === PermissionsWidgetMode.Write) {
+      return (
+        <div className="permissions-widget--checkbox">
+          <span className={`icon ${IconFont.Checkmark}`} />
+        </div>
+      )
+    }
+
+    if (selected === PermissionsWidgetSelection.Selected) {
+      return (
+        <div className="permissions-widget--icon">
+          <span className={`icon ${IconFont.Checkmark}`} />
+        </div>
+      )
+    }
+
+    return (
+      <div className="permissions-widget--icon">
+        <span className={`icon ${IconFont.Remove}`} />
+      </div>
+    )
+  }
+
+  private get className(): string {
+    const {selected, mode} = this.props
+
+    return classnames('permissions-widget--item', {
+      selected: selected === PermissionsWidgetSelection.Selected,
+      unselected: selected === PermissionsWidgetSelection.Unselected,
+      selectable: mode === PermissionsWidgetMode.Write,
+    })
+  }
+
+  private handleClick = (): void => {
+    const {id, mode, selected, onToggle} = this.props
+
+    if (mode === PermissionsWidgetMode.Read || !onToggle) {
+      return
+    }
+
+    if (selected === PermissionsWidgetSelection.Selected) {
+      onToggle(id, PermissionsWidgetSelection.Unselected)
+    } else if (selected === PermissionsWidgetSelection.Unselected) {
+      onToggle(id, PermissionsWidgetSelection.Selected)
+    }
+  }
+}
+
+export default PermissionsWidgetItem

--- a/ui/src/shared/components/permissionsWidget/PermissionsWidgetSection.tsx
+++ b/ui/src/shared/components/permissionsWidget/PermissionsWidgetSection.tsx
@@ -1,0 +1,89 @@
+// Libraries
+import React, {Component} from 'react'
+
+// Components
+import {Button, ComponentSpacer, Alignment, ComponentSize} from 'src/clockface'
+import PermissionsWidgetItem from 'src/shared/components/permissionsWidget/PermissionsWidgetItem'
+
+// Types
+import {PermissionsWidgetMode} from 'src/shared/components/permissionsWidget/PermissionsWidget'
+
+interface Props {
+  children: JSX.Element[] | JSX.Element
+  mode?: PermissionsWidgetMode
+  id: string
+  title: string
+  onSelectAll?: (sectionID: string) => void
+  onDeselectAll?: (sectionID: string) => void
+}
+
+class PermissionsWidgetSection extends Component<Props> {
+  public render() {
+    const {title} = this.props
+
+    return (
+      <section className="permissions-widget--section">
+        <header className="permissions-widget--section-heading">
+          <h3 className="permissions-widget--section-title">{title}</h3>
+          {this.selectionButtons}
+        </header>
+        <ul className="permissions-widget--section-list">
+          {this.sectionItems}
+        </ul>
+      </section>
+    )
+  }
+
+  private get sectionItems(): JSX.Element[] {
+    const {children, mode} = this.props
+
+    return React.Children.map(children, (child: JSX.Element) => {
+      if (child.type !== PermissionsWidgetItem) {
+        return null
+      }
+
+      return <PermissionsWidgetItem {...child.props} mode={mode} />
+    })
+  }
+
+  private get selectionButtons(): JSX.Element {
+    const {mode, title} = this.props
+
+    if (mode === PermissionsWidgetMode.Write) {
+      return (
+        <ComponentSpacer align={Alignment.Left}>
+          <Button
+            text="Select All"
+            size={ComponentSize.ExtraSmall}
+            titleText={`Select all permissions within ${title}`}
+            onClick={this.handleSelectAll}
+          />
+          <Button
+            text="Deselect All"
+            size={ComponentSize.ExtraSmall}
+            titleText={`Deselect all permissions within ${title}`}
+            onClick={this.handleDeselectAll}
+          />
+        </ComponentSpacer>
+      )
+    }
+  }
+
+  private handleSelectAll = (): void => {
+    const {id, onSelectAll} = this.props
+
+    if (onSelectAll) {
+      onSelectAll(id)
+    }
+  }
+
+  private handleDeselectAll = (): void => {
+    const {id, onDeselectAll} = this.props
+
+    if (onDeselectAll) {
+      onDeselectAll(id)
+    }
+  }
+}
+
+export default PermissionsWidgetSection


### PR DESCRIPTION
Intended for use anywhere Chronograf allows a user to read or update permissions

**`Read` mode:**
![permissions-read-mode](https://user-images.githubusercontent.com/2433762/49555252-1a122a80-f8b4-11e8-8234-aab3d6c1be31.gif)

**`Write` mode:**
![screen shot 2018-12-05 at 5 29 59 pm](https://user-images.githubusercontent.com/2433762/49555281-31e9ae80-f8b4-11e8-97c6-190f057fa199.png)

### Proposed API

```
import PermissionsWidget, {PermissionsWidgetMode, PermissionsWidgetSelection} from 'src/shared/components/permissionsWidget/PermissionsWidget'
```
If using **Read** mode:
```
<PermissionsWidget
  mode={PermissionsWidgetMode.Read}
  heightPixels={300}
>
  <PermissionsWidget.Section id="apples" title="Apples">
    <PermissionsWidget.Item
      label="Pick from tree"
      id="apples-pick"
      selected={PermissionsWidgetSelection.Selected}
    />
    <PermissionsWidget.Item
      label="Eat"
      id="apples-eat"
      selected={PermissionsWidgetSelection.Selected}
    />
  </PermissionsWidget.Section>
  <PermissionsWidget.Section id="limes" title="Limes">
    <PermissionsWidget.Item
      label="Pick from tree"
      id="limes-pick"
      selected={PermissionsWidgetSelection.Selected}
    />
    <PermissionsWidget.Item
      label="Peel"
      id="limes-peel"
      selected={PermissionsWidgetSelection.Selected}
    />
  </PermissionsWidget.Section>
</PermissionsWidget>
```
`heightPixels` is optional and is set to `500` by default. The design of this component is not intended to fill available space.

If using **Write** mode, pass state into these components:
```
<PermissionsWidget
  mode={PermissionsWidgetMode.Write}
  heightPixels={300}
>
  <PermissionsWidget.Section id="apples" title="Apples" onSelectAll={this.handleSelectSection} onSelectAll={this.handleDeselectSection} >
    <PermissionsWidget.Item
      label="Pick from tree"
      id="apples-pick"
      selected={PermissionsWidgetSelection.Selected}
      onToggle={this.handleToggleItem}
    />
    <PermissionsWidget.Item
      label="Eat"
      id="apples-eat"
      selected={PermissionsWidgetSelection.Selected}
      onToggle={this.handleToggleItem}
    />
  </PermissionsWidget.Section>
  <PermissionsWidget.Section id="limes" title="Limes" onSelectAll={this.handleSelectSection} onSelectAll={this.handleDeselectSection}>
    <PermissionsWidget.Item
      label="Pick from tree"
      id="limes-pick"
      selected={PermissionsWidgetSelection.Selected}
      onToggle={this.handleToggleItem}
    />
    <PermissionsWidget.Item
      label="Peel"
      id="limes-peel"
      selected={PermissionsWidgetSelection.Selected}
      onToggle={this.handleToggleItem}
    />
  </PermissionsWidget.Section>
</PermissionsWidget>
```
```
private handleSelectSection = (sectionID: string): void => {
  // do some state setting here
}

private handleDeselectSection = (sectionID: string): void => {
  // do some state setting here
}
```
```
private handleToggleItem = (itemID: string, selection: PermissionsWidgetSelection): void => {
  // do some state setting here
}
```

### Gotchas

The `mode` prop passed into the container component gets passed down to the children via re-instantiating the children with the additional `mode` prop. This is intended to remove the need to specify `mode` on each child individually. However if any of the children are wrapped in another component it may not render correctly.

It might make more sense to use a context and have the children consume the context to avoid disrupting rendering

### Checklist

  - [x] Rebased/mergeable
  - [x] Tests pass