### PR TITLE
Handle routing from onboarding sidebar

### DIFF
--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -59,6 +59,7 @@ interface OwnProps {
   onIncrementCurrentStepIndex: () => void
   onDecrementCurrentStepIndex: () => void
   onSetCurrentStepIndex: (stepNumber: number) => void
+  onSetCurrentSubStepIndex: (stepNumber: number, substepNumber: number) => void
 }
 
 interface DispatchProps {
@@ -184,8 +185,20 @@ class OnboardingWizard extends PureComponent<Props> {
   }
 
   private handleClickSideBarTab = (telegrafPluginID: string) => {
-    const {onSetCurrentStepIndex, onSetActiveTelegrafPlugin} = this.props
-    onSetCurrentStepIndex(3)
+    const {
+      onSetCurrentSubStepIndex,
+      onSetActiveTelegrafPlugin,
+      dataLoaders: {telegrafPlugins},
+    } = this.props
+
+    const index = Math.max(
+      _.findIndex(telegrafPlugins, plugin => {
+        return plugin.name === telegrafPluginID
+      }),
+      0
+    )
+
+    onSetCurrentSubStepIndex(3, index)
     onSetActiveTelegrafPlugin(telegrafPluginID)
   }
 

--- a/ui/src/onboarding/containers/OnboardingWizardPage.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizardPage.tsx
@@ -61,6 +61,7 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
           onDecrementCurrentStepIndex={this.handleDecrementStepIndex}
           onIncrementCurrentStepIndex={this.handleIncrementStepIndex}
           onSetCurrentStepIndex={this.setStepIndex}
+          onSetCurrentSubStepIndex={this.setSubstepIndex}
           currentStepIndex={+params.stepID}
           onCompleteSetup={this.handleCompleteSetup}
         />
@@ -90,6 +91,12 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
     const {router} = this.props
 
     router.push(`/onboarding/${index}`)
+  }
+
+  private setSubstepIndex = (index: number, subIndex: number) => {
+    const {router} = this.props
+
+    router.push(`/onboarding/${index}/${subIndex}`)
   }
 }
 


### PR DESCRIPTION
Clicking a telegraf plugin in the sidebar now changes the url to reflect that sub step

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)