### PR TITLE
Properly handle queries without `_time`

### DIFF
--- a/ui/src/shared/components/DygraphTransformation.tsx
+++ b/ui/src/shared/components/DygraphTransformation.tsx
@@ -1,5 +1,6 @@
 import {PureComponent} from 'react'
 import {FluxTable} from 'src/types'
+import {ErrorHandling} from 'src/shared/decorators/errors'
 
 import {
   fluxTablesToDygraph,
@@ -11,6 +12,7 @@ interface Props {
   children: (result: FluxTablesToDygraphResult) => JSX.Element
 }
 
+@ErrorHandling
 class DygraphTransformation extends PureComponent<
   Props,
   FluxTablesToDygraphResult

--- a/ui/src/shared/parsing/flux/dygraph.ts
+++ b/ui/src/shared/parsing/flux/dygraph.ts
@@ -22,6 +22,26 @@ export interface FluxTablesToDygraphResult {
   nonNumericColumns: string[]
 }
 
+const getTimeIndex = header => {
+  let timeIndex = header.indexOf('_time')
+
+  if (timeIndex >= 0) {
+    return timeIndex
+  }
+
+  timeIndex = header.indexOf('_start')
+  if (timeIndex >= 0) {
+    return timeIndex
+  }
+
+  timeIndex = header.indexOf('_end')
+  if (timeIndex >= 0) {
+    return timeIndex
+  }
+
+  return -1
+}
+
 export const fluxTablesToDygraph = (
   tables: FluxTable[]
 ): FluxTablesToDygraphResult => {
@@ -59,7 +79,7 @@ export const fluxTablesToDygraph = (
       allColumnNames.push(uniqueColumnName)
     }
 
-    const timeIndex = header.indexOf('_time')
+    const timeIndex = getTimeIndex(header)
 
     if (timeIndex < 0) {
       throw new Error('Could not find time index in FluxTable')


### PR DESCRIPTION
Closes #1758 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)