### PR TITLE
Allow stats files to be observed for finishing/unlinking.

### DIFF
--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -745,6 +745,14 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 			return err
 		}
 
+		// Observe the associated statistics file, if available.
+		statsFile := StatsFilename(file)
+		if _, err := os.Stat(statsFile); err == nil {
+			if err := f.obs.FileFinishing(statsFile); err != nil {
+				return err
+			}
+		}
+
 		var newName = file
 		if strings.HasSuffix(file, tsmTmpExt) {
 			// The new TSM files have a tmp extension.  First rename them.
@@ -800,6 +808,14 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 				// give the observer a chance to process the file first.
 				if err := f.obs.FileUnlinking(file.Path()); err != nil {
 					return err
+				}
+
+				// Remove associated stats file.
+				statsFile := StatsFilename(file.Path())
+				if _, err := os.Stat(statsFile); err == nil {
+					if err := f.obs.FileUnlinking(statsFile); err != nil {
+						return err
+					}
 				}
 
 				for _, t := range file.TombstoneFiles() {


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This commit adds the `.tss` files generated for TSM statistics to the `FileObserver` so that package users can be notified when new stats files are created and removed.


_What was the problem?_

TSS files were not being notified for backup storage.

_What was the solution?_

Add TSS files to the `FileObserver` calls.


  - [x] Rebased/mergeable
  - [x] Tests pass
