### PR TITLE
Allow TSI cache to be dynamically altered

### DIFF
--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -273,8 +273,10 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	runBenchmark := func(b *testing.B, queryN int) {
-		idx := MustOpenNewIndex(tsi1.NewConfig())
+	runBenchmark := func(b *testing.B, queryN int, cacheSize uint64) {
+		config := tsi1.NewConfig()
+		config.SeriesIDSetCacheSize = cacheSize
+		idx := MustOpenNewIndex(config)
 		var wg sync.WaitGroup
 		begin := make(chan struct{})
 
@@ -343,13 +345,11 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 	for _, queryN := range queries {
 		b.Run(fmt.Sprintf("queries %d", queryN), func(b *testing.B) {
 			b.Run("cache", func(b *testing.B) {
-				tsi1.EnableBitsetCache = true
-				runBenchmark(b, queryN)
+				runBenchmark(b, queryN, tsi1.DefaultSeriesIDSetCacheSize)
 			})
 
 			b.Run("no cache", func(b *testing.B) {
-				tsi1.EnableBitsetCache = false
-				runBenchmark(b, queryN)
+				runBenchmark(b, queryN, 0)
 			})
 		})
 	}

--- a/tsdb/tsi1/cache.go
+++ b/tsdb/tsi1/cache.go
@@ -26,11 +26,11 @@ type TagValueSeriesIDCache struct {
 	evictor *list.List
 
 	tracker  *cacheTracker
-	capacity int
+	capacity uint64
 }
 
 // NewTagValueSeriesIDCache returns a TagValueSeriesIDCache with capacity c.
-func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
+func NewTagValueSeriesIDCache(c uint64) *TagValueSeriesIDCache {
 	return &TagValueSeriesIDCache{
 		cache:    map[string]map[string]map[string]*list.Element{},
 		evictor:  list.New(),
@@ -172,8 +172,8 @@ func (c *TagValueSeriesIDCache) delete(name, key, value []byte, x tsdb.SeriesID)
 // checkEviction checks if the cache is too big, and evicts the least recently used
 // item if it is.
 func (c *TagValueSeriesIDCache) checkEviction() {
-	l := c.evictor.Len()
-	c.tracker.SetSize(uint64(l))
+	l := uint64(c.evictor.Len())
+	c.tracker.SetSize(l)
 	if l <= c.capacity {
 		return
 	}

--- a/tsdb/tsi1/config.go
+++ b/tsdb/tsi1/config.go
@@ -6,6 +6,9 @@ import "github.com/influxdata/platform/toml"
 // write-ahead log file will compact into an index file.
 const DefaultMaxIndexLogFileSize = 1 * 1024 * 1024 // 1MB
 
+// DefaultSeriesIDSetCacheSize is the default number of series ID sets to cache.
+const DefaultSeriesIDSetCacheSize = 1000
+
 // Config holds configurable Index options.
 type Config struct {
 	// MaxIndexLogFileSize is the threshold, in bytes, when an index write-ahead log file will
@@ -13,11 +16,21 @@ type Config struct {
 	// and result in lower heap usage at the expense of write throughput. Higher sizes will
 	// be compacted less frequently, store more series in-memory, and provide higher write throughput.
 	MaxIndexLogFileSize toml.Size `toml:"max-index-log-file-size"`
+
+	// SeriesIDSetCacheSize determines the size taken up by the cache of series ID
+	// sets in the index. Since a series id set is a compressed bitmap of all series ids
+	// matching a tag key/value pair, setting this size does not necessarily limit the
+	// size on heap the cache takes up. Care should be taken.
+	//
+	// The cache uses an LRU strategy for eviction. Setting the value to 0 will
+	// disable the cache.
+	SeriesIDSetCacheSize uint64
 }
 
 // NewConfig returns a new Config.
 func NewConfig() Config {
 	return Config{
-		MaxIndexLogFileSize: toml.Size(DefaultMaxIndexLogFileSize),
+		MaxIndexLogFileSize:  toml.Size(DefaultMaxIndexLogFileSize),
+		SeriesIDSetCacheSize: DefaultSeriesIDSetCacheSize,
 	}
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This PR allows the TSI cache (which caches bitsets of series IDs for key/value pairs) to have its size altered.

_What was the problem?_

The cache size was fixed at 100.

_What was the solution?_

Make it a configuration variable and increase the default size.

