### PR TITLE
Allow metrics to be disabled

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -232,6 +232,7 @@ func IndexShard(sfile *tsdb.SeriesFile, dataDir, walDir string, maxLogFileSize i
 		// Each new series entry in a log file is ~12 bytes so this should
 		// roughly equate to one flush to the file for every batch.
 		tsi1.WithLogFileBufferSize(12*batchSize),
+		tsi1.DisableMetrics(), // Disable metrics when rebuilding an index
 	)
 	tsiIndex.WithLogger(log)
 

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -105,7 +105,6 @@ func NewEngine(path string, c Config, options ...Option) *Engine {
 	e := &Engine{
 		config:              c,
 		path:                path,
-		sfile:               tsdb.NewSeriesFile(c.GetSeriesFilePath(path)),
 		defaultMetricLabels: prometheus.Labels{},
 		logger:              zap.NewNop(),
 	}

--- a/tsdb/series_index.go
+++ b/tsdb/series_index.go
@@ -46,8 +46,9 @@ type SeriesIndex struct {
 
 	// metrics stores a shard instance of some Prometheus metrics. metrics
 	// must be set before Open is called.
-	rhhMetrics *rhh.Metrics
-	rhhLabels  prometheus.Labels
+	rhhMetrics        *rhh.Metrics
+	rhhLabels         prometheus.Labels
+	rhhMetricsEnabled bool
 
 	data         []byte // mmap data
 	keyIDData    []byte // key/id mmap data
@@ -61,7 +62,8 @@ type SeriesIndex struct {
 
 func NewSeriesIndex(path string) *SeriesIndex {
 	return &SeriesIndex{
-		path: path,
+		path:              path,
+		rhhMetricsEnabled: true,
 	}
 }
 
@@ -95,6 +97,7 @@ func (idx *SeriesIndex) Open() (err error) {
 	options := rhh.DefaultOptions
 	options.Metrics = idx.rhhMetrics
 	options.Labels = idx.rhhLabels
+	options.MetricsEnabled = idx.rhhMetricsEnabled
 
 	idx.keyIDMap = rhh.NewHashMap(options)
 	idx.idOffsetMap = make(map[SeriesID]int64)

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -561,12 +561,14 @@ func (p *SeriesPartition) seriesKeyByOffset(offset int64) []byte {
 type seriesPartitionTracker struct {
 	metrics *seriesFileMetrics
 	labels  prometheus.Labels
+	enabled bool
 }
 
 func newSeriesPartitionTracker(metrics *seriesFileMetrics, defaultLabels prometheus.Labels) *seriesPartitionTracker {
 	return &seriesPartitionTracker{
 		metrics: metrics,
 		labels:  defaultLabels,
+		enabled: true,
 	}
 }
 
@@ -581,36 +583,60 @@ func (t *seriesPartitionTracker) Labels() prometheus.Labels {
 
 // AddSeriesCreated increases the number of series created in the partition by n.
 func (t *seriesPartitionTracker) AddSeriesCreated(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.SeriesCreated.With(labels).Add(float64(n))
 }
 
 // SetSeries sets the number of series in the partition.
 func (t *seriesPartitionTracker) SetSeries(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Series.With(labels).Set(float64(n))
 }
 
 // AddSeries increases the number of series in the partition by n.
 func (t *seriesPartitionTracker) AddSeries(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Series.With(labels).Add(float64(n))
 }
 
 // SubSeries decreases the number of series in the partition by n.
 func (t *seriesPartitionTracker) SubSeries(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Series.With(labels).Sub(float64(n))
 }
 
 // SetDiskSize sets the number of bytes used by files for in partition.
 func (t *seriesPartitionTracker) SetDiskSize(sz uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.DiskSize.With(labels).Set(float64(sz))
 }
 
 // SetSegments sets the number of segments files for the partition.
 func (t *seriesPartitionTracker) SetSegments(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Segments.With(labels).Set(float64(n))
 }
@@ -618,6 +644,10 @@ func (t *seriesPartitionTracker) SetSegments(n uint64) {
 // IncCompactionsActive increments the number of active compactions for the
 // components of a partition (index and segments).
 func (t *seriesPartitionTracker) IncCompactionsActive() {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["component"] = "index" // TODO(edd): when we add segment compactions we will add a new label value.
 	t.metrics.CompactionsActive.With(labels).Inc()
@@ -626,6 +656,10 @@ func (t *seriesPartitionTracker) IncCompactionsActive() {
 // DecCompactionsActive decrements the number of active compactions for the
 // components of a partition (index and segments).
 func (t *seriesPartitionTracker) DecCompactionsActive() {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["component"] = "index" // TODO(edd): when we add segment compactions we will add a new label value.
 	t.metrics.CompactionsActive.With(labels).Dec()
@@ -634,6 +668,10 @@ func (t *seriesPartitionTracker) DecCompactionsActive() {
 // incCompactions increments the number of compactions for the partition.
 // Callers should use IncCompactionOK and IncCompactionErr.
 func (t *seriesPartitionTracker) incCompactions(status string, duration time.Duration) {
+	if !t.enabled {
+		return
+	}
+
 	if duration > 0 {
 		labels := t.Labels()
 		labels["component"] = "index"

--- a/tsdb/tsi1/cache.go
+++ b/tsdb/tsi1/cache.go
@@ -216,10 +216,11 @@ type seriesIDCacheElement struct {
 type cacheTracker struct {
 	metrics *cacheMetrics
 	labels  prometheus.Labels
+	enabled bool
 }
 
 func newCacheTracker(metrics *cacheMetrics, defaultLabels prometheus.Labels) *cacheTracker {
-	return &cacheTracker{metrics: metrics, labels: defaultLabels}
+	return &cacheTracker{metrics: metrics, labels: defaultLabels, enabled: true}
 }
 
 // Labels returns a copy of labels for use with index cache metrics.
@@ -232,11 +233,19 @@ func (t *cacheTracker) Labels() prometheus.Labels {
 }
 
 func (t *cacheTracker) SetSize(sz uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Size.With(labels).Set(float64(sz))
 }
 
 func (t *cacheTracker) incGet(status string) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["status"] = status
 	t.metrics.Gets.With(labels).Inc()
@@ -246,6 +255,10 @@ func (t *cacheTracker) IncGetHit()  { t.incGet("hit") }
 func (t *cacheTracker) IncGetMiss() { t.incGet("miss") }
 
 func (t *cacheTracker) incPut(status string) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["status"] = status
 	t.metrics.Puts.With(labels).Inc()
@@ -255,6 +268,10 @@ func (t *cacheTracker) IncPutHit()  { t.incPut("hit") }
 func (t *cacheTracker) IncPutMiss() { t.incPut("miss") }
 
 func (t *cacheTracker) incDeletes(status string) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["status"] = status
 	t.metrics.Deletes.With(labels).Inc()
@@ -264,6 +281,10 @@ func (t *cacheTracker) IncDeletesHit()  { t.incDeletes("hit") }
 func (t *cacheTracker) IncDeletesMiss() { t.incDeletes("miss") }
 
 func (t *cacheTracker) IncEvictions() {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Evictions.With(labels).Inc()
 }

--- a/tsdb/tsi1/partition.go
+++ b/tsdb/tsi1/partition.go
@@ -1294,12 +1294,14 @@ func (p *Partition) MeasurementCardinalityStats() MeasurementCardinalityStats {
 type partitionTracker struct {
 	metrics *partitionMetrics
 	labels  prometheus.Labels
+	enabled bool // Allows tracker to be disabled.
 }
 
 func newPartitionTracker(metrics *partitionMetrics, defaultLabels prometheus.Labels) *partitionTracker {
 	return &partitionTracker{
 		metrics: metrics,
 		labels:  defaultLabels,
+		enabled: true,
 	}
 }
 
@@ -1315,6 +1317,10 @@ func (t *partitionTracker) Labels() prometheus.Labels {
 // AddSeriesCreated increases the number of series created in the partition by n
 // and sets a sample of the time taken to create a series.
 func (t *partitionTracker) AddSeriesCreated(n uint64, d time.Duration) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.SeriesCreated.With(labels).Add(float64(n))
 
@@ -1328,48 +1334,80 @@ func (t *partitionTracker) AddSeriesCreated(n uint64, d time.Duration) {
 
 // AddSeriesDropped increases the number of series dropped in the partition by n.
 func (t *partitionTracker) AddSeriesDropped(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.SeriesDropped.With(labels).Add(float64(n))
 }
 
 // SetSeries sets the number of series in the partition.
 func (t *partitionTracker) SetSeries(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Series.With(labels).Set(float64(n))
 }
 
 // AddSeries increases the number of series in the partition by n.
 func (t *partitionTracker) AddSeries(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Series.With(labels).Add(float64(n))
 }
 
 // SubSeries decreases the number of series in the partition by n.
 func (t *partitionTracker) SubSeries(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Series.With(labels).Sub(float64(n))
 }
 
 // SetMeasurements sets the number of measurements in the partition.
 func (t *partitionTracker) SetMeasurements(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Measurements.With(labels).Set(float64(n))
 }
 
 // AddMeasurements increases the number of measurements in the partition by n.
 func (t *partitionTracker) AddMeasurements(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Measurements.With(labels).Add(float64(n))
 }
 
 // SubMeasurements decreases the number of measurements in the partition by n.
 func (t *partitionTracker) SubMeasurements(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.Measurements.With(labels).Sub(float64(n))
 }
 
 // SetFiles sets the number of files in the partition.
 func (t *partitionTracker) SetFiles(n uint64, typ string) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["type"] = typ
 	t.metrics.FilesTotal.With(labels).Set(float64(n))
@@ -1377,12 +1415,20 @@ func (t *partitionTracker) SetFiles(n uint64, typ string) {
 
 // SetDiskSize sets the size of files in the partition.
 func (t *partitionTracker) SetDiskSize(n uint64) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	t.metrics.DiskSize.With(labels).Set(float64(n))
 }
 
 // IncActiveCompaction increments the number of active compactions for the provided level.
 func (t *partitionTracker) IncActiveCompaction(level int) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["level"] = fmt.Sprint(level)
 
@@ -1391,6 +1437,10 @@ func (t *partitionTracker) IncActiveCompaction(level int) {
 
 // DecActiveCompaction decrements the number of active compactions for the provided level.
 func (t *partitionTracker) DecActiveCompaction(level int) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["level"] = fmt.Sprint(level)
 
@@ -1399,6 +1449,10 @@ func (t *partitionTracker) DecActiveCompaction(level int) {
 
 // CompactionAttempted updates the number of compactions attempted for the provided level.
 func (t *partitionTracker) CompactionAttempted(level int, success bool, d time.Duration) {
+	if !t.enabled {
+		return
+	}
+
 	labels := t.Labels()
 	labels["level"] = fmt.Sprint(level)
 	if success {


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This PR allows metrics to be disabled.

_What was the problem?_

For some tasks, such as running tooling online to build a live index, we don't want to integrate the engine metrics.

_What was the solution?_

Allow the metrics to be disabled before opening the series file or index.