### PR TITLE
Fix full compaction panic.

### DIFF
--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -1554,6 +1554,7 @@ func (e *Engine) fullCompactionStrategy(group CompactionGroup, optimize bool) *c
 		fast:      optimize,
 		engine:    e,
 		level:     5,
+		tracker:   e.compactionTracker,
 	}
 
 	if optimize {


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Added a compaction tracker to the full compaction strategy.

_What was the problem?_

The tracker was only attached to leveled compaction strategies and caused a panic when the tracker was later invoked.

_What was the solution?_

Add the tracker to the full compaction strategy as well.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)