### PR TITLE
Fix nil tracker for full compactions

### DIFF
--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -1554,6 +1554,7 @@ func (e *Engine) fullCompactionStrategy(group CompactionGroup, optimize bool) *c
 		fast:      optimize,
 		engine:    e,
 		level:     5,
+		tracker:   e.compactionTracker,
 	}
 
 	if optimize {


### PR DESCRIPTION
Ensures there is a tracker available when a full compaction kicks in.