### PR TITLE
Fix(ui/dataLoaders): Update config field modifiers

### DIFF
--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -12,7 +12,7 @@ import {Links} from 'src/types/v2/links'
 import {Task, TaskStatus} from 'src/types/v2/tasks'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {ConfigurationState} from 'src/types/v2/dataLoaders'
-import {TelegrafPluginInputCpu} from 'src/api'
+import {TelegrafPluginInputCpu, TelegrafPluginInputRedis} from 'src/api'
 
 export const links: Links = {
   authorizations: '/api/v2/authorizations',
@@ -290,6 +290,15 @@ export const telegrafPlugin = {
   name: TelegrafPluginInputCpu.NameEnum.Cpu,
   configured: ConfigurationState.Unconfigured,
   active: true,
+}
+
+export const redisPlugin = {
+  name: TelegrafPluginInputRedis.NameEnum.Redis,
+  type: TelegrafPluginInputRedis.TypeEnum.Input,
+  config: {
+    servers: [],
+    password: '',
+  },
 }
 
 export const influxDB2Plugin = {

--- a/ui/src/onboarding/reducers/dataLoaders.test.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.test.ts
@@ -8,14 +8,26 @@ import dataLoadersReducer, {
 import {
   setDataLoadersType,
   addTelegrafPlugin,
+  addConfigValue,
+  removeConfigValue,
   removeTelegrafPlugin,
   setActiveTelegrafPlugin,
   setTelegrafConfigID,
+  updateTelegrafPluginConfig,
 } from 'src/onboarding/actions/dataLoaders'
 
 // Types
-import {TelegrafPluginInputCpu, TelegrafPluginInputDisk} from 'src/api'
-import {DataLoaderType, ConfigurationState} from 'src/types/v2/dataLoaders'
+import {
+  TelegrafPluginInputCpu,
+  TelegrafPluginInputDisk,
+  TelegrafPluginInputRedis,
+} from 'src/api'
+import {
+  DataLoaderType,
+  ConfigurationState,
+  TelegrafPlugin,
+} from 'src/types/v2/dataLoaders'
+import {redisPlugin} from 'mocks/dummyData'
 
 describe('dataLoader reducer', () => {
   it('can set a type', () => {
@@ -126,6 +138,114 @@ describe('dataLoader reducer', () => {
     const actual = dataLoadersReducer(INITIAL_STATE, setTelegrafConfigID(id))
 
     const expected = {...INITIAL_STATE, telegrafConfigID: id}
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('can update a plugin config field', () => {
+    const plugin = {
+      ...redisPlugin,
+      config: {servers: [], password: ''},
+    }
+    const tp: TelegrafPlugin = {
+      name: TelegrafPluginInputRedis.NameEnum.Redis,
+      configured: ConfigurationState.Unconfigured,
+      active: true,
+      plugin,
+    }
+    const actual = dataLoadersReducer(
+      {...INITIAL_STATE, telegrafPlugins: [tp]},
+      updateTelegrafPluginConfig(
+        TelegrafPluginInputRedis.NameEnum.Redis,
+        'password',
+        'pa$$w0rd'
+      )
+    )
+
+    const expected = {
+      ...INITIAL_STATE,
+      telegrafPlugins: [
+        {
+          ...tp,
+          plugin: {
+            ...plugin,
+            config: {servers: [], password: 'pa$$w0rd'},
+          },
+        },
+      ],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('can add a plugin config value', () => {
+    const plugin = {
+      ...redisPlugin,
+      config: {servers: ['first'], password: ''},
+    }
+    const tp: TelegrafPlugin = {
+      name: TelegrafPluginInputRedis.NameEnum.Redis,
+      configured: ConfigurationState.Unconfigured,
+      active: true,
+      plugin,
+    }
+    const actual = dataLoadersReducer(
+      {...INITIAL_STATE, telegrafPlugins: [tp]},
+      addConfigValue(
+        TelegrafPluginInputRedis.NameEnum.Redis,
+        'servers',
+        'second'
+      )
+    )
+
+    const expected = {
+      ...INITIAL_STATE,
+      telegrafPlugins: [
+        {
+          ...tp,
+          plugin: {
+            ...plugin,
+            config: {servers: ['first', 'second'], password: ''},
+          },
+        },
+      ],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('can remove a plugin config value', () => {
+    const plugin = {
+      ...redisPlugin,
+      config: {servers: ['first', 'second'], password: ''},
+    }
+    const tp: TelegrafPlugin = {
+      name: TelegrafPluginInputRedis.NameEnum.Redis,
+      configured: ConfigurationState.Unconfigured,
+      active: true,
+      plugin,
+    }
+    const actual = dataLoadersReducer(
+      {...INITIAL_STATE, telegrafPlugins: [tp]},
+      removeConfigValue(
+        TelegrafPluginInputRedis.NameEnum.Redis,
+        'servers',
+        'first'
+      )
+    )
+
+    const expected = {
+      ...INITIAL_STATE,
+      telegrafPlugins: [
+        {
+          ...tp,
+          plugin: {
+            ...plugin,
+            config: {servers: ['second'], password: ''},
+          },
+        },
+      ],
+    }
 
     expect(actual).toEqual(expected)
   })

--- a/ui/src/onboarding/reducers/dataLoaders.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.ts
@@ -2,7 +2,10 @@
 import _ from 'lodash'
 
 // Utils
-import {createNewPlugin} from 'src/onboarding/utils/pluginConfigs'
+import {
+  createNewPlugin,
+  updateConfigFields,
+} from 'src/onboarding/utils/pluginConfigs'
 
 // Types
 import {Action} from 'src/onboarding/actions/dataLoaders'
@@ -67,10 +70,11 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
 
             return {
               ...tp,
-              plugin: {
-                ...plugin,
-                [action.payload.field]: action.payload.value,
-              },
+              plugin: updateConfigFields(
+                plugin,
+                action.payload.field,
+                action.payload.value
+              ),
             }
           }
           return tp
@@ -90,10 +94,11 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
 
             return {
               ...tp,
-              plugin: {
-                ...plugin,
-                [action.payload.fieldName]: updatedConfigFieldValue,
-              },
+              plugin: updateConfigFields(
+                plugin,
+                action.payload.fieldName,
+                updatedConfigFieldValue
+              ),
             }
           }
           return tp
@@ -117,10 +122,11 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
 
             return {
               ...tp,
-              plugin: {
-                ...plugin,
-                [action.payload.fieldName]: filteredConfigFieldValue,
-              },
+              plugin: updateConfigFields(
+                plugin,
+                action.payload.fieldName,
+                filteredConfigFieldValue
+              ),
             }
           }
           return tp

--- a/ui/src/onboarding/utils/pluginConfigs.ts
+++ b/ui/src/onboarding/utils/pluginConfigs.ts
@@ -14,6 +14,16 @@ export const getConfigFields = (
   return telegrafPluginsInfo[pluginName].fields
 }
 
+export const updateConfigFields = <T extends Plugin>(
+  plugin: T,
+  fieldName: string,
+  value: string[] | string
+): T => {
+  return Object.assign({}, plugin, {
+    config: Object.assign({}, plugin.config, {[fieldName]: value}),
+  })
+}
+
 export const createNewPlugin = (name: TelegrafPluginName): Plugin => {
   return telegrafPluginsInfo[name].defaults
 }


### PR DESCRIPTION
Closes #1829

_What was the problem?_
the wrong values were getting overwritten so nothing was actually changing in the stored configs when updating

  - [x] Rebased/mergeable
  - [x] Tests pass
