### PR TITLE
test(tsdb/tsi1): test series id cache delete concurrently

### DIFF
--- a/tsdb/tsi1/log_file_test.go
+++ b/tsdb/tsi1/log_file_test.go
@@ -23,6 +23,8 @@ import (
 
 // Ensure log file can append series.
 func TestLogFile_AddSeriesList(t *testing.T) {
+	t.Parallel()
+
 	sfile := MustOpenSeriesFile()
 	defer sfile.Close()
 
@@ -127,6 +129,8 @@ func TestLogFile_AddSeriesList(t *testing.T) {
 }
 
 func TestLogFile_SeriesStoredInOrder(t *testing.T) {
+	t.Parallel()
+
 	sfile := MustOpenSeriesFile()
 	defer sfile.Close()
 
@@ -189,6 +193,8 @@ func TestLogFile_SeriesStoredInOrder(t *testing.T) {
 
 // Ensure log file can delete an existing measurement.
 func TestLogFile_DeleteMeasurement(t *testing.T) {
+	t.Parallel()
+
 	sfile := MustOpenSeriesFile()
 	defer sfile.Close()
 
@@ -232,6 +238,8 @@ func TestLogFile_DeleteMeasurement(t *testing.T) {
 
 // Ensure log file can recover correctly.
 func TestLogFile_Open(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Truncate", func(t *testing.T) {
 		sfile := MustOpenSeriesFile()
 		defer sfile.Close()

--- a/tsdb/tsi1/partition_test.go
+++ b/tsdb/tsi1/partition_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPartition_Open(t *testing.T) {
+	t.Parallel() // There's a bit of IO in this test.
+
 	sfile := MustOpenSeriesFile()
 	defer sfile.Close()
 


### PR DESCRIPTION
Report the total number of gets, puts, and deletes at the end of the
test. I've found this kind of output to be a useful sanity check in
similar tests that exercise concurrency involving tasks.

Use a local random source in each goroutine. I unscientifically
eyeballed that to increase total operations by 5-10%.

Also call t.Parallel in a few more tests that involve disk access. This
shaves 1-2 seconds off the full tsi1 test suite on my machine.