### PR TITLE
Add uptime to ready endpoint

### DIFF
--- a/http/ready.go
+++ b/http/ready.go
@@ -1,12 +1,34 @@
 package http
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/influxdata/platform/toml"
 )
 
-// ReadyHandler is a default readiness handler. The default behavior is always ready.
+var up = time.Now()
+
+// ReadyHandler is a default readiness handler. The default behaviour is always ready.
 func ReadyHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, `{"status": "ready"}`)
+
+	var status = struct {
+		Status string        `json:"status"`
+		Start  time.Time     `json:"started"`
+		Up     toml.Duration `json:"up"`
+	}{
+		Status: "ready",
+		Start:  up,
+		Up:     toml.Duration(time.Since(up)),
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "    ")
+	err := enc.Encode(status)
+	if err != nil {
+		fmt.Fprintf(w, "Error encoding status data: %v\n", err)
+	}
 }


### PR DESCRIPTION
This PR adds some extra detail about how long the process has been up to the `/ready` endpoint.

The contents of the response will now look like:

```json
{
    "status": "ready",
    "started": "2018-12-12T11:43:36.824427Z",
    "up": "5.452864366s"
}
```