### PR TITLE
ci: use -p=4 on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - image: circleci/golang:1.11
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: "-mod=readonly -p=8" # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=4" # Go on Circle thinks 32 CPUs are available, but there aren't.
     working_directory: /go/src/github.com/influxdata/platform
     steps:
       - checkout
@@ -53,9 +53,7 @@ jobs:
       # TODO add these checks to the Makefile
       # - run: go get -v -t -d ./...
 
-      # TODO(#544): fix the remaining static check in the generated promql file, and enable exit-non-zero.
-      # Not yet sure if that's a bug in staticcheck or if we need to submit a patch to pigeon to fix the generator.
-      - run: GO111MODULE=on go mod vendor # megacheck isn't module-aware yet, so install module dependencies to vendor.
+      - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
       - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
       - run: staticcheck ./...
 
@@ -77,7 +75,7 @@ jobs:
       - image: circleci/golang:1.11-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: "-mod=readonly -p=8" # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=4" # Go on Circle thinks 32 CPUs are available, but there aren't.
     working_directory: /go/src/github.com/influxdata/platform
     steps:
       - checkout


### PR DESCRIPTION
The docker container we're using has 2 vCPUs. -p=8 was working fine for
a while, but diagnosing #1832 looks like the tsi1.test process was
likely getting OOM-killed. Reducing from -p=8 to -p=4 ought to reduce
memory pressure enough to avoid OOM kills, hopefully.

Also remove a stale TODO.