### PR TITLE
fix(cmd/influxd): Refactor test cancellation out of main path.

### DIFF
--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -115,7 +115,6 @@ func (m *Main) URL() string {
 
 // Shutdown shuts down the HTTP server and waits for all services to clean up.
 func (m *Main) Shutdown(ctx context.Context) {
-	m.cancel()
 	m.httpServer.Shutdown(ctx)
 
 	m.logger.Info("Stopping", zap.String("service", "task"))
@@ -143,6 +142,9 @@ func (m *Main) Shutdown(ctx context.Context) {
 
 	m.logger.Sync()
 }
+
+// Cancel executes the context cancel on the program. Used for testing.
+func (m *Main) Cancel() { m.cancel() }
 
 // Run executes the program with the given CLI arguments.
 func (m *Main) Run(ctx context.Context, args ...string) error {

--- a/cmd/influxd/main_test.go
+++ b/cmd/influxd/main_test.go
@@ -137,6 +137,7 @@ func (m *Main) Run(ctx context.Context, args ...string) error {
 
 // Shutdown stops the program and cleans up temporary paths.
 func (m *Main) Shutdown(ctx context.Context) error {
+	m.Cancel()
 	m.Main.Shutdown(ctx)
 	return os.RemoveAll(m.Path)
 }


### PR DESCRIPTION
Closes #1414

_Briefly describe your proposed changes:_

This commit moves the `Main.cancel()` execution to the `main_test.go` file so it's only executed for tests. This was interfering with the shutdown process on the regular `influxd` binary. Related: https://github.com/influxdata/flux/pull/478

_What was the problem?_

The `flux.Controller` shutdown too quickly and didn't wait for queries to finish. This caused a `SIGSEGV` because the storage would close immediately after and not wait for the queries.

_What was the solution?_

Move the cancellation required by the integration test.

  - [x] Rebased/mergeable
  - [x] Tests pass
