### PR TITLE
Fix panic when read request results in empty an group

### DIFF
--- a/storage/reads/group_resultset_test.go
+++ b/storage/reads/group_resultset_test.go
@@ -193,6 +193,36 @@ group:
 	}
 }
 
+func TestNewGroupResultSet_GroupNone_NoDataReturnsNil(t *testing.T) {
+	newCursor := func() (reads.SeriesCursor, error) {
+		return &sliceSeriesCursor{
+			rows: newSeriesRows(
+				"aaa,tag0=val00",
+				"aaa,tag0=val01",
+			)}, nil
+	}
+
+	rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadRequest{Group: datatypes.GroupNone}, newCursor)
+	if rs != nil {
+		t.Errorf("expected nil cursor")
+	}
+}
+
+func TestNewGroupResultSet_GroupBy_NoDataReturnsNil(t *testing.T) {
+	newCursor := func() (reads.SeriesCursor, error) {
+		return &sliceSeriesCursor{
+			rows: newSeriesRows(
+				"aaa,tag0=val00",
+				"aaa,tag0=val01",
+			)}, nil
+	}
+
+	rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadRequest{Group: datatypes.GroupBy, GroupKeys: []string{"tag0"}}, newCursor)
+	if rs != nil {
+		t.Errorf("expected nil cursor")
+	}
+}
+
 func TestNewGroupResultSet_Sorting(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
If there is no data for the given time range, the group cursor should return `nil`. For the `groupNoneSort` function, move the `n` counter inside the if condition, so that it returns `0` if no series have data.

Moves the check to determine if a series has data for the current time range into the `groupBySort` function, which is consistent with the `groupNoneSort` function and correctly returns `len(rows) == 0` when there are no group rows.

Closes influxdata/flux#319