### PR TITLE
Fix(ui/dataLoaders): Update streaming button to send you to the streaming step

### DIFF
--- a/ui/src/onboarding/components/OnboardingSideBar.tsx
+++ b/ui/src/onboarding/components/OnboardingSideBar.tsx
@@ -27,7 +27,7 @@ interface Props {
   notify: NotificationAction
   onTabClick: (tabID: string) => void
   currentStepIndex: number
-  handleNewSourceClick: () => void
+  onNewSourceClick: () => void
 }
 
 const configStateToTabStatus = (cs: ConfigurationState): TabStatus => {
@@ -71,7 +71,7 @@ class OnboardingSideBar extends Component<Props> {
   }
 
   private get buttons(): JSX.Element[] {
-    const {handleNewSourceClick} = this.props
+    const {onNewSourceClick} = this.props
     return [
       <SideBar.Button
         key="Download Config File"
@@ -87,7 +87,7 @@ class OnboardingSideBar extends Component<Props> {
         titleText="Add New Source"
         color={ComponentColor.Default}
         icon={IconFont.Plus}
-        onClick={handleNewSourceClick}
+        onClick={onNewSourceClick}
       />,
     ]
   }

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -63,7 +63,10 @@ interface OwnProps {
   onIncrementCurrentStepIndex: () => void
   onDecrementCurrentStepIndex: () => void
   onSetCurrentStepIndex: (stepNumber: number) => void
-  onSetCurrentSubStepIndex: (stepNumber: number, substepNumber: number) => void
+  onSetCurrentSubStepIndex: (
+    stepNumber: number,
+    substep: number | 'streaming'
+  ) => void
 }
 
 interface DispatchProps {
@@ -121,7 +124,6 @@ class OnboardingWizard extends PureComponent<Props> {
       onRemovePluginBundle,
       setupParams,
       notify,
-      onDecrementCurrentStepIndex,
     } = this.props
 
     return (
@@ -136,7 +138,7 @@ class OnboardingWizard extends PureComponent<Props> {
             title="Plugins to Configure"
             visible={this.sideBarVisible}
             currentStepIndex={currentStepIndex}
-            handleNewSourceClick={onDecrementCurrentStepIndex}
+            onNewSourceClick={this.handleNewSourceClick}
           />
           <div className="wizard-step--container">
             <OnboardingStepSwitcher
@@ -199,6 +201,11 @@ class OnboardingWizard extends PureComponent<Props> {
       currentStepIndex === 4
 
     return isStreaming && isSideBarStep
+  }
+
+  private handleNewSourceClick = () => {
+    const {onSetCurrentSubStepIndex} = this.props
+    onSetCurrentSubStepIndex(2, 'streaming')
   }
 
   private handleClickSideBarTab = (telegrafPluginID: string) => {

--- a/ui/src/onboarding/containers/OnboardingWizardPage.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizardPage.tsx
@@ -93,10 +93,10 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
     router.push(`/onboarding/${index}`)
   }
 
-  private setSubstepIndex = (index: number, subIndex: number) => {
+  private setSubstepIndex = (index: number, subStep: number | 'streaming') => {
     const {router} = this.props
 
-    router.push(`/onboarding/${index}/${subIndex}`)
+    router.push(`/onboarding/${index}/${subStep}`)
   }
 }
 


### PR DESCRIPTION
Closes #1916 

_What was the problem?_
Clicking add new source would use the "go back" functionality rather than taking you to the streaming sources step
_What was the solution?_
clicking go back takes you to the streaming sources step


  - [x] Rebased/mergeable
  - [ ] Tests pass