### PR TITLE
tsm1: tombstone performance

### DIFF
--- a/tsdb/tsm1/reader.go
+++ b/tsdb/tsm1/reader.go
@@ -1033,7 +1033,7 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) {
 	tombstones := map[string][]TimeRange{}
 	var ie []IndexEntry
 
-	for i := 0; len(keys) > 0 && i < d.KeyCount(); i++ {
+	for i := d.searchOffset(keys[0]); len(keys) > 0 && i < d.KeyCount(); i++ {
 		k, entries := d.readEntriesAt(d.offset(i), &ie)
 
 		// Skip any keys that don't exist.  These are less than the current key.

--- a/tsdb/tsm1/writer.go
+++ b/tsdb/tsm1/writer.go
@@ -390,7 +390,7 @@ func copyBuffer(f syncer, dst io.Writer, src io.Reader, buf []byte) (written int
 				written += int64(nw)
 			}
 
-			if written-lastSync > fsyncEvery {
+			if f != nil && written-lastSync > fsyncEvery {
 				if err := f.Sync(); err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
# Summary

`DeleteRange` would start at the first key in the index and do a linear walk until it reached the first key to be deleted. This is obviously bad when attempting to delete a large key. Instead, do a seek to the first key to be deleted.

## Performance changes

I did very short benchmarks, so lots of noise, but:

```
BenchmarkIndirectIndex_DeleteRangeLast-8     310663434       1550          -100.00%
BenchmarkIndirectIndex_DeleteRangeFull-8     18776033480     773649708     -95.88%
```

`DeleteRangeFull` is the closest thing to what retention does right now.