### PR TITLE
fix(storage): Extend lock during stats fetch to prevent race

### DIFF
--- a/storage/reads/table.gen.go
+++ b/storage/reads/table.gen.go
@@ -57,8 +57,8 @@ func (t *floatTable) Close() {
 
 func (t *floatTable) Statistics() flux.Statistics {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	cur := t.cur
-	t.mu.Unlock()
 	if cur == nil {
 		return flux.Statistics{}
 	}
@@ -289,8 +289,8 @@ func (t *integerTable) Close() {
 
 func (t *integerTable) Statistics() flux.Statistics {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	cur := t.cur
-	t.mu.Unlock()
 	if cur == nil {
 		return flux.Statistics{}
 	}
@@ -521,8 +521,8 @@ func (t *unsignedTable) Close() {
 
 func (t *unsignedTable) Statistics() flux.Statistics {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	cur := t.cur
-	t.mu.Unlock()
 	if cur == nil {
 		return flux.Statistics{}
 	}
@@ -753,8 +753,8 @@ func (t *stringTable) Close() {
 
 func (t *stringTable) Statistics() flux.Statistics {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	cur := t.cur
-	t.mu.Unlock()
 	if cur == nil {
 		return flux.Statistics{}
 	}
@@ -985,8 +985,8 @@ func (t *booleanTable) Close() {
 
 func (t *booleanTable) Statistics() flux.Statistics {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	cur := t.cur
-	t.mu.Unlock()
 	if cur == nil {
 		return flux.Statistics{}
 	}

--- a/storage/reads/table.gen.go.tmpl
+++ b/storage/reads/table.gen.go.tmpl
@@ -51,8 +51,8 @@ func (t *{{.name}}Table) Close() {
 
 func (t *{{.name}}Table) Statistics() flux.Statistics {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	cur := t.cur
-	t.mu.Unlock()
 	if cur == nil {
 		return flux.Statistics{}
 	}


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Expand the lock period for tables to protect against a changing underlying cursor. See included data race report for details.

<details>
<summary>Data race report</summary>

```
WARNING: DATA RACE
Write at 0x00c0002665d8 by goroutine 156:
  github.com/influxdata/platform/storage/reads.(*floatMultiShardArrayCursor).reset()
      /Users/benbjohnson/src/platform/storage/reads/array_cursor.gen.go:103 +0x83
  github.com/influxdata/platform/storage/reads.(*multiShardArrayCursors).createCursor()
      /Users/benbjohnson/src/platform/storage/reads/array_cursor.go:145 +0x63c
  github.com/influxdata/platform/storage/reads.(*resultSet).Cursor()
      /Users/benbjohnson/src/platform/storage/reads/resultset.go:61 +0x11a
  github.com/influxdata/platform/storage/reads.(*tableIterator).handleRead()
      /Users/benbjohnson/src/platform/storage/reads/reader.go:150 +0xf3
  github.com/influxdata/platform/storage/reads.(*tableIterator).Do()
      /Users/benbjohnson/src/platform/storage/reads/reader.go:127 +0xa03
  github.com/influxdata/platform/query/functions/inputs/storage.(*source).run()
      /Users/benbjohnson/src/platform/query/functions/inputs/storage/storage.go:109 +0x15e
  github.com/influxdata/platform/query/functions/inputs/storage.(*source).Run()
      /Users/benbjohnson/src/platform/query/functions/inputs/storage/storage.go:100 +0x59
  github.com/influxdata/flux/execute.(*executionState).do.func1()
      /Users/benbjohnson/src/flux/execute/executor.go:265 +0x7c

Previous read at 0x00c0002665d8 by goroutine 22:
  github.com/influxdata/platform/storage/reads.(*floatMultiShardArrayCursor).Stats()
      /Users/benbjohnson/src/platform/storage/reads/array_cursor.gen.go:112 +0x3a
  github.com/influxdata/platform/storage/reads.(*floatTable).Statistics()
      /Users/benbjohnson/src/platform/storage/reads/table.gen.go:65 +0xc2
  github.com/influxdata/flux/execute.(*result).Do()
      /Users/benbjohnson/src/flux/execute/result.go:77 +0xa7
  github.com/influxdata/flux/csv.(*ResultEncoder).Encode()
      /Users/benbjohnson/src/flux/csv/result.go:771 +0x676
  github.com/influxdata/flux.(*DelimitedMultiResultEncoder).Encode()
      /Users/benbjohnson/src/flux/result.go:217 +0x1a9
  github.com/influxdata/platform/query.ProxyQueryServiceBridge.Query()
      /Users/benbjohnson/src/platform/query/bridges.go:47 +0x1ad
  github.com/influxdata/platform/query.(*ProxyQueryServiceBridge).Query()
      <autogenerated>:1 +0xb5
  github.com/influxdata/platform/http.(*FluxHandler).handlePostQuery()
      /Users/benbjohnson/src/platform/http/query_handler.go:82 +0x281
  github.com/influxdata/platform/http.(*FluxHandler).handlePostQuery-fm()
      /Users/benbjohnson/src/platform/http/query_handler.go:51 +0x5f
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.11.2/libexec/src/net/http/server.go:1964 +0x51
  github.com/julienschmidt/httprouter.(*Router).Handler.func1()
      /Users/benbjohnson/go/pkg/mod/github.com/julienschmidt/httprouter@v1.2.0/params_go17.go:26 +0x29c
  github.com/julienschmidt/httprouter.(*Router).ServeHTTP()
      /Users/benbjohnson/go/pkg/mod/github.com/julienschmidt/httprouter@v1.2.0/router.go:334 +0xe60
  github.com/influxdata/platform/http.(*APIHandler).ServeHTTP()
      /Users/benbjohnson/src/platform/http/api_handler.go:208 +0x10b0
  github.com/influxdata/platform/http.(*AuthenticationHandler).ServeHTTP()
      /Users/benbjohnson/src/platform/http/authentication_middleware.go:90 +0x8c4
  github.com/influxdata/platform/http.(*PlatformHandler).ServeHTTP()
      /Users/benbjohnson/src/platform/http/platform_handler.go:59 +0x120
  github.com/influxdata/platform/http.(*Handler).ServeHTTP()
      /Users/benbjohnson/src/platform/http/handler.go:166 +0x4cd
  net/http.serverHandler.ServeHTTP()
      /usr/local/Cellar/go/1.11.2/libexec/src/net/http/server.go:2741 +0xc4
  net/http.(*conn).serve()
      /usr/local/Cellar/go/1.11.2/libexec/src/net/http/server.go:1847 +0x80a

Goroutine 156 (running) created at:
  github.com/influxdata/flux/execute.(*executionState).do()
      /Users/benbjohnson/src/flux/execute/executor.go:246 +0xce
  github.com/influxdata/flux/execute.(*executor).Execute()
      /Users/benbjohnson/src/flux/execute/executor.go:69 +0x10b
  github.com/influxdata/flux/control.(*Controller).processQuery()
      /Users/benbjohnson/src/flux/control/controller.go:392 +0x336
  github.com/influxdata/flux/control.(*Controller).run()
      /Users/benbjohnson/src/flux/control/controller.go:310 +0x401

Goroutine 22 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/Cellar/go/1.11.2/libexec/src/net/http/server.go:2851 +0x4c5
  main.(*Main).run.func2()
      /Users/benbjohnson/src/platform/cmd/influxd/main.go:424 +0x439
```

</details>


_What was the problem?_

A data race was reported when executing a query.

_What was the solution?_

Expand the lock period to protect the cursor from multiple accesses.


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)