### PR TITLE
chore(ci): Setup nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,4 +113,19 @@ workflows:
           filters:
             branches:
               only: master
-
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - deploy:
+          requires:
+            - gotest
+            - jstest
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This change configures CircleCI to perform a nightly build,  `make nightly`.