### PR TITLE
Revert "chore(ci): Setup nightly build"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,19 +113,4 @@ workflows:
           filters:
             branches:
               only: master
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - deploy:
-          requires:
-            - gotest
-            - jstest
-          filters:
-            branches:
-              only: master
+


### PR DESCRIPTION
Reverts influxdata/platform#1937
This PR broke ci for some reason.