### PR TITLE
feat(api/health): Add a standardized health and ready check system

### DIFF
--- a/kit/check/check.go
+++ b/kit/check/check.go
@@ -1,0 +1,208 @@
+// Package check standardizes /health and /ready endpoints.
+// This allows you to easily know when your server is ready and healthy.
+package check
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync/atomic"
+)
+
+// Status string to indicate the overall status of the check.
+type Status string
+
+const (
+	// StatusFail indicates a specific check has failed.
+	StatusFail Status = "fail"
+	// StatusPass indicates a specific check has passed.
+	StatusPass Status = "pass"
+
+	// DefaultCheckName is the name of the default checker.
+	DefaultCheckName = "internal"
+)
+
+// Check wraps a map of service names to status checkers.
+type Check struct {
+	healthChecks []Checker
+	readyChecks  []Checker
+
+	manualOverride atomic.Value
+	manualReady    atomic.Value
+	manualHealthy  atomic.Value
+
+	passthroughHandler http.Handler
+}
+
+// Checker indicates a service whose health can be checked.
+type Checker interface {
+	Check(ctx context.Context) Response
+}
+
+// NewCheck returns a Health with a default checker.
+func NewCheck() *Check {
+	h := &Check{
+		manualOverride: atomic.Value{},
+		manualReady:    atomic.Value{},
+		manualHealthy:  atomic.Value{},
+	}
+	h.manualOverride.Store(false)
+	h.manualReady.Store(false)
+	h.manualHealthy.Store(false)
+	return h
+}
+
+// AddHealthCheck adds the check to the list of ready checks.
+// If c is a NamedChecker, the name will be added.
+func (c *Check) AddHealthCheck(check Checker) {
+	if nc, ok := check.(NamedChecker); ok {
+		c.healthChecks = append(c.healthChecks, Named(nc.CheckName(), nc))
+	} else {
+		c.healthChecks = append(c.healthChecks, check)
+	}
+}
+
+// AddReadyCheck adds the check to the list of ready checks.
+// If c is a NamedChecker, the name will be added.
+func (c *Check) AddReadyCheck(check Checker) {
+	if nc, ok := check.(NamedChecker); ok {
+		c.readyChecks = append(c.readyChecks, Named(nc.CheckName(), nc))
+	} else {
+		c.readyChecks = append(c.readyChecks, check)
+	}
+}
+
+// CheckHealth evaluates c's set of health checks and returns a populated Response.
+func (c *Check) CheckHealth(ctx context.Context) Response {
+	response := Response{
+		Name:   "Health",
+		Status: StatusPass,
+		Checks: make(Responses, len(c.healthChecks)),
+	}
+	for i, ch := range c.healthChecks {
+		resp := ch.Check(ctx)
+		if resp.Status != StatusPass {
+			response.Status = resp.Status
+		}
+		response.Checks[i] = resp
+	}
+	sort.Sort(response.Checks)
+	return response
+}
+
+// CheckReady evaluates c's set of ready checks and returns a populated Response.
+func (c *Check) CheckReady(ctx context.Context) Response {
+	response := Response{
+		Name:   "Ready",
+		Status: StatusPass,
+		Checks: make(Responses, len(c.readyChecks)),
+	}
+	for i, c := range c.readyChecks {
+		resp := c.Check(ctx)
+		if resp.Status != StatusPass {
+			response.Status = resp.Status
+		}
+		response.Checks[i] = resp
+	}
+	sort.Sort(response.Checks)
+	return response
+}
+
+// SetPassthrough allows you to set a handler to use if the request is not a ready or health check.
+// This can be usefull if you intend to use this as a middleware.
+func (c *Check) SetPassthrough(h http.Handler) {
+	c.passthroughHandler = h
+}
+
+// ServeHTTP serves /ready and /health requests with the respective checks.
+func (c *Check) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	// allow requests not intended for checks to pass through.
+	if r.URL.Path != "/ready" && r.URL.Path != "/health" {
+		if c.passthroughHandler != nil {
+			c.passthroughHandler.ServeHTTP(w, r)
+			return
+		}
+
+		// We cant handle this request.
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	msg := ""
+	status := http.StatusOK
+
+	var resp Response
+	switch r.URL.Path {
+	case "/ready":
+		resp = c.CheckReady(r.Context())
+	case "/health":
+		resp = c.CheckHealth(r.Context())
+	}
+
+	// Check for a manual override state change.
+	query := r.URL.Query()
+	switch query.Get("force") {
+	case "true":
+		c.manualOverride.Store(true)
+		switch r.URL.Path {
+		case "/ready":
+			switch query.Get("ready") {
+			case "true":
+				c.manualReady.Store(true)
+			case "false":
+				c.manualReady.Store(false)
+			}
+		case "/health":
+			switch query.Get("healthy") {
+			case "true":
+				c.manualHealthy.Store(true)
+			case "false":
+				c.manualHealthy.Store(false)
+			}
+		}
+	case "false":
+		c.manualOverride.Store(false)
+	}
+
+	// Check for a manual override currently in effect.
+	if c.manualOverride.Load().(bool) {
+		// A human has requested a manual override, so we need to add a health response
+		// and set the HTTP response status
+		manualResp := Response{
+			Name:    "manual-override",
+			Message: "A human has requested a manual override",
+		}
+		var pass bool
+		switch r.URL.Path {
+		case "/ready":
+			pass = c.manualReady.Load().(bool)
+		case "/health":
+			pass = c.manualHealthy.Load().(bool)
+		}
+		if pass {
+			manualResp.Status = StatusPass
+		} else {
+			manualResp.Status = StatusFail
+		}
+		resp.Status = manualResp.Status
+		resp.Checks = append(resp.Checks, manualResp)
+	}
+
+	// Set the HTTP status if the check failed
+	if resp.Status == StatusFail {
+		// Normal state, the HTTP response status reflects the status-reported health.
+		status = http.StatusServiceUnavailable
+	}
+
+	b, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		msg = `{"message": "error marshaling response", "status": "fail"}`
+		status = http.StatusInternalServerError
+	}
+	msg = string(b)
+	w.WriteHeader(status)
+	fmt.Fprintln(w, msg)
+}

--- a/kit/check/check_test.go
+++ b/kit/check/check_test.go
@@ -1,0 +1,314 @@
+package check
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestEmptyCheck(t *testing.T) {
+	c := NewCheck()
+	resp := c.CheckReady(context.Background())
+	if len(resp.Checks) > 0 {
+		t.Errorf("no checks added but %d returned", len(resp.Checks))
+	}
+
+	if resp.Name != "Ready" {
+		t.Errorf("expected: \"Ready\", got: %q", resp.Name)
+	}
+
+	if resp.Status != StatusPass {
+		t.Errorf("expected: %q, got: %q", StatusPass, resp.Status)
+	}
+}
+
+func TestAddHealthyCheck(t *testing.T) {
+	h := NewCheck()
+	h.AddHealthCheck(Named("awesome", ErrCheck(func() error {
+		return nil
+	})))
+	r := h.CheckHealth(context.Background())
+	if r.Status != StatusPass {
+		t.Error("Health should fail because one of the check is unhealthy")
+	}
+
+	if len(r.Checks) != 1 {
+		t.Fatal("check not in results")
+	}
+
+	v := r.Checks[0]
+	if v.Status != StatusPass {
+		t.Errorf("the added check should be pass not %q.", v.Status)
+	}
+}
+
+func TestAddUnHealthyCheck(t *testing.T) {
+	h := NewCheck()
+	h.AddHealthCheck(Named("failure", ErrCheck(func() error {
+		return errors.New("Oops! I am sorry")
+	})))
+	r := h.CheckHealth(context.Background())
+	if r.Status != StatusFail {
+		t.Error("Health should fail because one of the check is unhealthy")
+	}
+
+	if len(r.Checks) != 1 {
+		t.Fatal("check not in results")
+	}
+
+	v := r.Checks[0]
+	if v.Status != StatusFail {
+		t.Errorf("the added check should be fail not %s.", v.Status)
+	}
+	if v.Message != "Oops! I am sorry" {
+		t.Errorf(
+			"the error should be 'Oops! I am sorry' not  %s.",
+			v.Message,
+		)
+	}
+}
+
+func buildCheckWithServer() (*Check, *httptest.Server) {
+	c := NewCheck()
+	return c, httptest.NewServer(c)
+}
+
+type mockCheck struct {
+	status Status
+	name   string
+}
+
+func (m mockCheck) Check(_ context.Context) Response {
+	return Response{
+		Name:   m.name,
+		Status: m.status,
+	}
+}
+
+func mockPass(name string) Checker {
+	return mockCheck{status: StatusPass, name: name}
+}
+
+func mockFail(name string) Checker {
+	return mockCheck{status: StatusFail, name: name}
+}
+
+func respBuilder(body io.ReadCloser) (*Response, error) {
+	defer body.Close()
+	d := json.NewDecoder(body)
+	r := &Response{}
+	return r, d.Decode(r)
+}
+
+func TestBasicHTTPHandler(t *testing.T) {
+	_, ts := buildCheckWithServer()
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := respBuilder(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := &Response{
+		Name:   "Ready",
+		Status: StatusPass,
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("unexpected response. expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestHealthSorting(t *testing.T) {
+	c, ts := buildCheckWithServer()
+	defer ts.Close()
+
+	c.AddHealthCheck(mockPass("a"))
+	c.AddHealthCheck(mockPass("c"))
+	c.AddHealthCheck(mockPass("b"))
+	c.AddHealthCheck(mockFail("k"))
+	c.AddHealthCheck(mockFail("b"))
+
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := respBuilder(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &Response{
+		Name:   "Health",
+		Status: "fail",
+		Checks: Responses{
+			Response{Name: "b", Status: "fail"},
+			Response{Name: "k", Status: "fail"},
+			Response{Name: "a", Status: "pass"},
+			Response{Name: "b", Status: "pass"},
+			Response{Name: "c", Status: "pass"},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("unexpected response. expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestNoCrossOver(t *testing.T) {
+	c, ts := buildCheckWithServer()
+	defer ts.Close()
+
+	c.AddHealthCheck(mockPass("a"))
+	c.AddHealthCheck(mockPass("c"))
+	c.AddReadyCheck(mockPass("b"))
+	c.AddReadyCheck(mockFail("k"))
+	c.AddHealthCheck(mockFail("b"))
+
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := respBuilder(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &Response{
+		Name:   "Health",
+		Status: "fail",
+		Checks: Responses{
+			Response{Name: "b", Status: "fail"},
+			Response{Name: "a", Status: "pass"},
+			Response{Name: "c", Status: "pass"},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("unexpected response. expected %v, actual %v", expected, actual)
+	}
+
+	resp, err = http.Get(ts.URL + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err = respBuilder(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected = &Response{
+		Name:   "Ready",
+		Status: "fail",
+		Checks: Responses{
+			Response{Name: "k", Status: "fail"},
+			Response{Name: "b", Status: "pass"},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("unexpected response. expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestOverride(t *testing.T) {
+	c, ts := buildCheckWithServer()
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/health?force=true&healthy=false")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 503 {
+		t.Fatal("override not being accepted")
+	}
+
+	if !c.manualOverride.Load().(bool) {
+		t.Fatal("override not set for next request")
+	}
+}
+
+func TestPassthrough(t *testing.T) {
+	c, ts := buildCheckWithServer()
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 404 {
+		t.Fatal("failed to error when no passthrough is present")
+	}
+
+	used := false
+	s := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		used = true
+		w.Write([]byte("hi"))
+	})
+
+	c.SetPassthrough(s)
+
+	resp, err = http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatal("bad response code from passthrough")
+	}
+
+	if !used {
+		t.Fatal("passthrough server not used")
+	}
+
+}
+
+func ExampleNewCheck() {
+	// Run the default healthcheck. it always return 200. It is good if you
+	// have a service without any dependency
+	h := NewCheck()
+	h.CheckHealth(context.Background())
+}
+
+func ExampleCheck_CheckHealth() {
+	h := NewCheck()
+	h.AddHealthCheck(Named("google", CheckerFunc(func(ctx context.Context) Response {
+		var r net.Resolver
+		_, err := r.LookupHost(ctx, "google.com")
+		if err != nil {
+			return Error(err)
+		}
+		return Pass()
+	})))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	h.CheckHealth(ctx)
+}
+
+func ExampleCheck_ServeHTTP() {
+	c := NewCheck()
+	http.ListenAndServe(":6060", c)
+}
+
+func ExampleCheck_SetPassthrough() {
+	c := NewCheck()
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello friends!"))
+	})
+
+	c.SetPassthrough(http.DefaultServeMux)
+	http.ListenAndServe(":6060", c)
+}

--- a/kit/check/helpers.go
+++ b/kit/check/helpers.go
@@ -1,0 +1,73 @@
+package check
+
+import (
+	"context"
+	"fmt"
+)
+
+// NamedChecker is a superset of Checker that also indicates the name of the service.
+// Prefer to implement NamedChecker if your service has a fixed name,
+// as opposed to calling *Health.AddNamed.
+type NamedChecker interface {
+	Checker
+	CheckName() string
+}
+
+// CheckerFunc is an adapter of a plain func() error to the Checker interface.
+type CheckerFunc func(ctx context.Context) Response
+
+// Check implements Checker.
+func (f CheckerFunc) Check(ctx context.Context) Response {
+	return f(ctx)
+}
+
+// Named returns a Checker that will attach a name to the Response from the check.
+// This way, it is possible to augment a Response with a human-readable name, but not have to encode
+// that logic in the actual check itself.
+func Named(name string, checker Checker) Checker {
+	return CheckerFunc(func(ctx context.Context) Response {
+		resp := checker.Check(ctx)
+		resp.Name = name
+		return resp
+	})
+}
+
+// NamedFunc is the same as Named except it takes a CheckerFunc.
+func NamedFunc(name string, fn CheckerFunc) Checker {
+	return Named(name, fn)
+}
+
+// ErrCheck will create a health checker that executes a function. If the function returns an error,
+// it will return an unhealthy response. Otherwise, it will be as if the Ok function was called.
+// Note: it is better to use CheckFunc, because with Check, the context is ignored.
+func ErrCheck(fn func() error) Checker {
+	return CheckerFunc(func(_ context.Context) Response {
+		if err := fn(); err != nil {
+			return Error(err)
+		}
+		return Pass()
+	})
+}
+
+// Pass is a utility function to generate a passing status response with the default parameters.
+func Pass() Response {
+	return Response{
+		Status: StatusPass,
+	}
+}
+
+// Info is a utility function to generate a healthy status with a printf message.
+func Info(msg string, args ...interface{}) Response {
+	return Response{
+		Status:  StatusPass,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
+// Error is a utility function for creating a response from an error message.
+func Error(err error) Response {
+	return Response{
+		Status:  StatusFail,
+		Message: err.Error(),
+	}
+}

--- a/kit/check/response.go
+++ b/kit/check/response.go
@@ -1,0 +1,39 @@
+package check
+
+// Response is a result of a collection of health checks.
+type Response struct {
+	Name    string    `json:"name"`
+	Status  Status    `json:"status"`
+	Message string    `json:"message,omitempty"`
+	Checks  Responses `json:"checks,omitempty"`
+}
+
+// HasCheck verifies whether the receiving Response has a check with the given name or not.
+func (r *Response) HasCheck(name string) bool {
+	found := false
+	for _, check := range r.Checks {
+		if check.Name == name {
+			found = true
+			break
+		}
+	}
+	return found
+}
+
+// Responses is a sortable collection of Response objects.
+type Responses []Response
+
+func (r Responses) Len() int { return len(r) }
+
+// Less defines the order in which responses are sorted.
+//
+// Failing responses are always sorted before passing responses. Responses with
+// the same status are then sorted according to the name of the check.
+func (r Responses) Less(i, j int) bool {
+	if r[i].Status == r[j].Status {
+		return r[i].Name < r[j].Name
+	}
+	return r[i].Status < r[j].Status
+}
+
+func (r Responses) Swap(i, j int) { r[i], r[j] = r[j], r[i] }


### PR DESCRIPTION
Build a system that can be used for both ready and health checking.
It can be used directly as a http.Handler and can be given a passthrough handler,
allowing it to operate as middleware.
