### PR TITLE
Line protocol precision polish

### DIFF
--- a/ui/src/onboarding/components/configureStep/lineProtocol/PrecisionDropdown.tsx
+++ b/ui/src/onboarding/components/configureStep/lineProtocol/PrecisionDropdown.tsx
@@ -14,17 +14,15 @@ interface Props {
 }
 
 const writePrecisions: WritePrecision[] = [
+  WritePrecision.Ns,
+  WritePrecision.Us,
   WritePrecision.Ms,
   WritePrecision.S,
-  WritePrecision.U,
-  WritePrecision.Us,
-  WritePrecision.Ns,
 ]
 
-const transformPrecision = {
+const makePrecisionReadable = {
   [WritePrecision.Ns]: Precision.Nanoseconds,
   [WritePrecision.Us]: Precision.Microseconds,
-  [WritePrecision.U]: Precision.U,
   [WritePrecision.S]: Precision.Seconds,
   [WritePrecision.Ms]: Precision.Milliseconds,
 }
@@ -42,7 +40,7 @@ class PrecisionDropdown extends PureComponent<Props> {
         >
           {writePrecisions.map(value => (
             <Dropdown.Item key={value} value={value} id={value}>
-              {transformPrecision[value]}
+              {makePrecisionReadable[value]}
             </Dropdown.Item>
           ))}
         </Dropdown>

--- a/ui/src/onboarding/reducers/dataLoaders.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.ts
@@ -31,7 +31,7 @@ export const INITIAL_STATE: DataLoadersState = {
   lineProtocolBody: '',
   activeLPTab: LineProtocolTab.UploadFile,
   lpStatus: RemoteDataState.NotStarted,
-  precision: WritePrecision.Ms,
+  precision: WritePrecision.Ns,
   telegrafConfigID: null,
   pluginBundles: [],
 }

--- a/ui/src/types/v2/dataLoaders.ts
+++ b/ui/src/types/v2/dataLoaders.ts
@@ -162,7 +162,6 @@ export enum Precision {
   Milliseconds = 'Milliseconds',
   Seconds = 'Seconds',
   Microseconds = 'Microseconds',
-  U = 'U',
   Nanoseconds = 'Nanoseconds',
 }
 


### PR DESCRIPTION
Closes #1962 

Remove U as precision option, 
Make nanosecond the default selection, 
Put precisions in order of magnitude.