### PR TITLE
tsm1 index fixes and improvements

### DIFF
--- a/tsdb/tsm1/compact_test.go
+++ b/tsdb/tsm1/compact_test.go
@@ -126,7 +126,10 @@ func TestCompactor_CompactFullLastTimestamp(t *testing.T) {
 	}
 
 	r := MustOpenTSMReader(files[0])
-	entries := r.Entries([]byte("cpu,host=A#!~#value"))
+	entries, err := r.ReadEntries([]byte("cpu,host=A#!~#value"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	_, b, err := r.ReadBytes(&entries[0], nil)
 	if err != nil {
 		t.Fatalf("ReadBytes: unexpected error %v", err)
@@ -661,7 +664,11 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 2; got != exp {
+	entries, err := r.ReadEntries([]byte("cpu,host=A#!~#value"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := len(entries), 2; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -774,7 +781,11 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 1; got != exp {
+	entries, err := r.ReadEntries([]byte("cpu,host=A#!~#value"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -888,7 +899,11 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 2; got != exp {
+	entries, err := r.ReadEntries([]byte("cpu,host=A#!~#value"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := len(entries), 2; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -996,7 +1011,11 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 2; got != exp {
+	entries, err := r.ReadEntries([]byte("cpu,host=A#!~#value"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := len(entries), 2; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -586,7 +586,9 @@ func (f *FileStore) Open() error {
 			defer f.openLimiter.Release()
 
 			start := time.Now()
-			df, err := NewTSMReader(file, WithMadviseWillNeed(f.tsmMMAPWillNeed))
+			df, err := NewTSMReader(file,
+				WithMadviseWillNeed(f.tsmMMAPWillNeed),
+				WithTSMReaderLogger(f.logger))
 			f.logger.Info("Opened file",
 				zap.String("path", file.Name()),
 				zap.Int("id", idx),
@@ -812,7 +814,9 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 			}
 		}
 
-		tsm, err := NewTSMReader(fd, WithMadviseWillNeed(f.tsmMMAPWillNeed))
+		tsm, err := NewTSMReader(fd,
+			WithMadviseWillNeed(f.tsmMMAPWillNeed),
+			WithTSMReaderLogger(f.logger))
 		if err != nil {
 			return err
 		}

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -411,7 +411,7 @@ func (f *FileStore) WalkKeys(seek []byte, fn func(key []byte, typ byte) error) e
 		}
 	}
 
-	return nil
+	return ki.Err()
 }
 
 // Keys returns all keys and types for all files in the file store.

--- a/tsdb/tsm1/reader_block_iterator.go
+++ b/tsdb/tsm1/reader_block_iterator.go
@@ -1,0 +1,52 @@
+package tsm1
+
+// BlockIterator allows iterating over each block in a TSM file in order.  It provides
+// raw access to the block bytes without decoding them.
+type BlockIterator struct {
+	r       *TSMReader
+	iter    *TSMIndexIterator
+	entries []IndexEntry
+}
+
+// PeekNext returns the next key to be iterated or an empty string.
+func (b *BlockIterator) PeekNext() []byte {
+	return b.iter.Peek()
+}
+
+// Next returns true if there are more blocks to iterate through.
+func (b *BlockIterator) Next() bool {
+	if b.iter.Err() != nil {
+		return false
+	}
+
+	if len(b.entries) > 0 {
+		b.entries = b.entries[1:]
+		if len(b.entries) > 0 {
+			return true
+		}
+	}
+
+	if !b.iter.Next() {
+		return false
+	}
+	b.entries = b.iter.Entries()
+
+	return len(b.entries) > 0
+}
+
+// Read reads information about the next block to be iterated.
+func (b *BlockIterator) Read() (key []byte, minTime int64, maxTime int64, typ byte, checksum uint32, buf []byte, err error) {
+	if err := b.iter.Err(); err != nil {
+		return nil, 0, 0, 0, 0, nil, err
+	}
+	checksum, buf, err = b.r.ReadBytes(&b.entries[0], nil)
+	if err != nil {
+		return nil, 0, 0, 0, 0, nil, err
+	}
+	return b.iter.Key(), b.entries[0].MinTime, b.entries[0].MaxTime, b.iter.Type(), checksum, buf, err
+}
+
+// Err returns any errors encounter during iteration.
+func (b *BlockIterator) Err() error {
+	return b.iter.Err()
+}

--- a/tsdb/tsm1/reader_index_iterator.go
+++ b/tsdb/tsm1/reader_index_iterator.go
@@ -1,0 +1,106 @@
+package tsm1
+
+import (
+	"fmt"
+)
+
+// TSMIndexIterator allows one to iterate over the TSM index.
+type TSMIndexIterator struct {
+	b    *faultBuffer
+	n    int
+	d    *indirectIndex
+	iter *readerOffsetsIterator
+
+	// if true, don't need to advance iter on the call to Next
+	first  bool
+	peeked bool
+
+	ok  bool
+	err error
+
+	offset  uint32
+	eoffset uint32
+	key     []byte
+	typ     byte
+	entries []IndexEntry
+}
+
+// Next advances the iterator and reports if it is still valid.
+func (t *TSMIndexIterator) Next() bool {
+	if t.n != t.d.KeyCount() {
+		t.err, t.ok = fmt.Errorf("Key count changed during iteration"), false
+	}
+	if !t.ok || t.err != nil {
+		return false
+	}
+	if !t.peeked && !t.first {
+		t.ok = t.iter.Next()
+	}
+	if !t.ok {
+		return false
+	}
+
+	t.peeked = false
+	t.first = false
+
+	t.offset = t.iter.Offset()
+	t.eoffset = t.iter.EntryOffset(t.b)
+	t.key = nil
+	t.typ = 0
+	t.entries = t.entries[:0]
+	return true
+}
+
+// Peek reports the next key or nil if there is not one or an error happened.
+func (t *TSMIndexIterator) Peek() []byte {
+	if !t.ok || t.err != nil {
+		return nil
+	}
+	if !t.peeked {
+		t.ok = t.iter.Next()
+		t.peeked = true
+	}
+
+	if !t.ok {
+		return nil
+	}
+
+	return t.iter.Key(t.b)
+}
+
+// Key reports the current key.
+func (t *TSMIndexIterator) Key() []byte {
+	if t.key == nil {
+		buf := t.b.access(t.offset, 0)
+		t.key = readKey(buf)
+		t.typ = buf[2+len(t.key)]
+	}
+	return t.key
+}
+
+// Type reports the current type.
+func (t *TSMIndexIterator) Type() byte {
+	if t.key == nil {
+		buf := t.b.access(t.offset, 0)
+		t.key = readKey(buf)
+		t.typ = buf[2+len(t.key)]
+	}
+	return t.typ
+}
+
+// Entries reports the current list of entries.
+func (t *TSMIndexIterator) Entries() []IndexEntry {
+	if len(t.entries) == 0 {
+		buf := t.b.access(t.eoffset, 0)
+		t.entries, t.err = readEntries(buf, t.entries)
+	}
+	if t.err != nil {
+		return nil
+	}
+	return t.entries
+}
+
+// Err reports if an error stopped the iteration.
+func (t *TSMIndexIterator) Err() error {
+	return t.err
+}

--- a/tsdb/tsm1/reader_offsets.go
+++ b/tsdb/tsm1/reader_offsets.go
@@ -3,6 +3,7 @@ package tsm1
 import (
 	"bytes"
 	"encoding/binary"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -58,7 +59,7 @@ func (r *readerOffsets) searchPrefix(n int) int {
 	return i
 }
 
-// addKey tracks the key in the readerOffsets at the given offset.
+// AddKey tracks the key in the readerOffsets at the given offset.
 func (r *readerOffsets) AddKey(offset uint32, key []byte) {
 	r.offsets = append(r.offsets, offset)
 	pre := keyPrefix(key)
@@ -79,44 +80,41 @@ func (r *readerOffsets) Iterator() readerOffsetsIterator {
 	return readerOffsetsIterator{r: r, first: true}
 }
 
+//
+// iterator stuff
+//
+
 // readerOffsetsIterator iterates over the keys in readerOffsets.
 type readerOffsetsIterator struct {
 	r     *readerOffsets
 	first bool        // is this the first call to next?
-	del   bool        // should the next call delete?
-	oi    int         // index into offsets
-	od    int         // undeleted index into offsets
+	del   bool        // has delete been called?
+	i     int         // index into offsets
 	pi    int         // index into prefixes
-	psub  int         // number of deleted entries
 	ks    rOIKeyState // current key state
 }
 
 // rOIKeyState keeps track of cached information for the current key.
 type rOIKeyState struct {
-	length uint32 // high bit means set
+	length uint16
 	key    []byte
 }
 
-// newROIKeyState constructs a rOIKeyState for the given key, precaching it.
-func newROIKeyState(key []byte) (ks rOIKeyState) {
-	if key != nil {
-		ks.length = uint32(len(key)) | 1<<31
-		ks.key = key
-	}
-	return ks
-}
+// Index returns the current pointed at index.
+func (ri *readerOffsetsIterator) Index() int { return ri.i }
 
 // setIndex sets the reader to the given index and clears any cached state.
-func (ri *readerOffsetsIterator) setIndex(i, pi int, key []byte) {
-	ri.oi, ri.od, ri.pi, ri.ks = i, i, pi, newROIKeyState(key)
+func (ri *readerOffsetsIterator) setIndex(i, pi int) {
+	ri.i, ri.pi, ri.ks = i, pi, rOIKeyState{}
 }
 
 // Length returns the length of the current pointed at key.
 func (ri *readerOffsetsIterator) Length(b *faultBuffer) uint16 {
-	if ri.ks.length&1<<31 == 0 {
-		ri.ks.length = uint32(binary.BigEndian.Uint16(b.access(ri.Offset(), 2))) | 1<<31
+	if ri.ks.length == 0 {
+		buf := b.access(ri.Offset(), 2)
+		ri.ks.length = uint16(buf[0])<<8 | uint16(buf[1])
 	}
-	return uint16(ri.ks.length)
+	return ri.ks.length
 }
 
 // Key returns the current pointed at key.
@@ -137,68 +135,79 @@ func (ri *readerOffsetsIterator) EntryOffset(b *faultBuffer) uint32 {
 	return ri.Offset() + 2 + uint32(ri.Length(b))
 }
 
-// prefix returns the current pointed at prefix.
-func (ri *readerOffsetsIterator) Prefix() prefix { return ri.r.prefixes[ri.pi].pre }
+// Prefix returns the current pointed at prefix.
+func (ri *readerOffsetsIterator) Prefix() prefix {
+	return ri.r.prefixes[ri.pi].pre
+}
 
-// offset returns the current pointed at offset.
-func (ri *readerOffsetsIterator) Offset() uint32 { return ri.r.offsets[ri.oi] }
+// Offset returns the current pointed at offset.
+func (ri *readerOffsetsIterator) Offset() uint32 {
+	return atomic.LoadUint32(&ri.r.offsets[ri.i]) &^ (1 << 31)
+}
 
 // Next advances the iterator and returns true if it points at a value.
 func (ri *readerOffsetsIterator) Next() bool {
-	if ri.oi >= len(ri.r.offsets) {
+	if ri.i >= len(ri.r.offsets) {
 		return false
 	} else if ri.first {
 		ri.first = false
 		return true
 	}
 
-	if ri.del {
-		ri.psub++
-		ri.del = false
-	} else {
-		if ri.oi != ri.od {
-			ri.r.offsets[ri.od] = ri.r.offsets[ri.oi]
-		}
-		ri.od++
-	}
-
-	ri.oi++
+	ri.i++
 	ri.ks = rOIKeyState{}
 
-	for ri.pi < len(ri.r.prefixes) && ri.oi >= ri.r.prefixes[ri.pi].total {
-		ri.r.prefixes[ri.pi].total -= ri.psub
+	for ri.pi < len(ri.r.prefixes) && ri.i >= ri.r.prefixes[ri.pi].total {
 		ri.pi++
 	}
 
-	return ri.oi < len(ri.r.offsets)
+	return ri.i < len(ri.r.offsets)
 }
 
-// Done should be called to finalize up any deletes.
+// Done should be called to finalize up any deletes. Must be called under a write lock.
 func (ri *readerOffsetsIterator) Done() {
-	if ri.del { // if flagged to delete, pretend next was called
-		ri.psub++
-		ri.oi++
+	if !ri.del {
+		return
 	}
-	if ri.oi != ri.od {
-		for ; ri.pi < len(ri.r.prefixes); ri.pi++ {
-			ri.r.prefixes[ri.pi].total -= ri.psub
+	ri.del = false
+
+	j, psub, pi := 0, 0, 0
+	for i, v := range ri.r.offsets {
+		for pi < len(ri.r.prefixes) && i >= ri.r.prefixes[pi].total {
+			ri.r.prefixes[pi].total -= psub
+			pi++
 		}
-		copy(ri.r.offsets[ri.od:], ri.r.offsets[ri.oi:])
-		ri.r.offsets = ri.r.offsets[:len(ri.r.offsets)-(ri.oi-ri.od)]
+
+		if v&(1<<31) > 0 {
+			psub++
+			continue
+		}
+
+		if i != j {
+			ri.r.offsets[j] = ri.r.offsets[i]
+		}
+		j++
+	}
+
+	ri.r.offsets = ri.r.offsets[:j]
+}
+
+// Delete flags the entry to be deleted on the next call to Done. Is safe for
+// concurrent use under a read lock, but Done must be called under a write lock.
+func (ri *readerOffsetsIterator) Delete() {
+	ri.del = true
+	if offset := ri.Offset(); offset&(1<<31) == 0 {
+		atomic.StoreUint32(&ri.r.offsets[ri.i], offset|(1<<31))
 	}
 }
 
-// Delete flags the entry to be skipped on the next call to Next.
-// Should only be called with the write lock.
-func (ri *readerOffsetsIterator) Delete() { ri.del = true }
+// HasDeletes returns true if the iterator has any Delete calls.
+func (ri *readerOffsetsIterator) HasDeletes() bool { return ri.del }
 
 // Seek points the iterator at the smallest key greater than or equal to the
 // given key, returning true if it was an exact match. It returns false for
-// ok if the key does not exist. Do not call Seek if you have ever called Delete.
+// ok if the key does not exist.
 func (ri *readerOffsetsIterator) Seek(key []byte, b *faultBuffer) (exact, ok bool) {
-	if ri.del || ri.psub > 0 {
-		panic("does not support Seek when we just deleted a key")
-	}
 	ri.first = false
 
 	pre, i, j, pi := keyPrefix(key), 0, len(ri.r.offsets), 0
@@ -206,7 +215,7 @@ func (ri *readerOffsetsIterator) Seek(key []byte, b *faultBuffer) (exact, ok boo
 	for i < j {
 		h := int(uint(i+j) >> 1)
 		pi = ri.r.searchPrefix(h)
-		ri.setIndex(h, pi, nil)
+		ri.setIndex(h, pi)
 
 		switch ri.Compare(key, pre, b) {
 		case -1:
@@ -218,23 +227,24 @@ func (ri *readerOffsetsIterator) Seek(key []byte, b *faultBuffer) (exact, ok boo
 		}
 	}
 
-	ri.setIndex(i, pi, nil)
-	if ri.oi >= len(ri.r.offsets) {
+	ri.setIndex(i, pi)
+	if ri.i >= len(ri.r.offsets) {
 		return false, false
 	}
 
-	for ri.pi < len(ri.r.prefixes) && ri.oi >= ri.r.prefixes[ri.pi].total {
+	for ri.pi < len(ri.r.prefixes) && ri.i >= ri.r.prefixes[ri.pi].total {
 		ri.pi++
 	}
 
 	return bytes.Equal(ri.Key(b), key), true
 }
 
-// SeekTo sets the iterator to point at the nth element.
-func (ri *readerOffsetsIterator) SeekTo(n int) { ri.setIndex(n, ri.r.searchPrefix(n), nil) }
+// SetIndex sets the iterator to point at the nth element.
+func (ri *readerOffsetsIterator) SetIndex(n int) {
+	ri.setIndex(n, ri.r.searchPrefix(n))
+}
 
-// Compare is like bytes.Compare with the pointed at key, but reduces the amount of
-// faults.
+// Compare is like bytes.Compare with the pointed at key, but reduces the amount of faults.
 func (ri *readerOffsetsIterator) Compare(key []byte, pre prefix, b *faultBuffer) int {
 	if cmp := comparePrefix(ri.Prefix(), pre); cmp != 0 {
 		return cmp

--- a/tsdb/tsm1/reader_offsets.go
+++ b/tsdb/tsm1/reader_offsets.go
@@ -1,0 +1,243 @@
+package tsm1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"unsafe"
+)
+
+// readerOffsets keeps track of offsets of keys for an indirectIndex.
+type readerOffsets struct {
+	offsets  []uint32
+	prefixes []prefixEntry
+	entry    prefixEntry
+}
+
+// prefixEntry keeps a prefix along with a prefix sum of the total number of
+// keys with the given prefix.
+type prefixEntry struct {
+	pre   prefix
+	total int // partial sums
+}
+
+// prefix is an 8 byte prefix of a key that sorts the same way the key does.
+type prefix [8]byte
+
+// comparePrefix is like bytes.Compare but for a prefix.
+func comparePrefix(a, b prefix) int {
+	au, bu := binary.BigEndian.Uint64(a[:]), binary.BigEndian.Uint64(b[:])
+	if au == bu {
+		return 0
+	} else if au < bu {
+		return -1
+	}
+	return 1
+}
+
+// keyPrefix returns a prefix that can be used with compare
+// to sort the same way the bytes would.
+func keyPrefix(key []byte) (pre prefix) {
+	if len(key) >= 8 {
+		return *(*[8]byte)(unsafe.Pointer(&key[0]))
+	}
+	copy(pre[:], key)
+	return pre
+}
+
+// searchPrefix returns the index of the prefixEntry for the nth offset.
+func (r *readerOffsets) searchPrefix(n int) int {
+	i, j := 0, len(r.prefixes)
+	for i < j {
+		h := int(uint(i+j) >> 1)
+		if n >= r.prefixes[h].total {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return i
+}
+
+// addKey tracks the key in the readerOffsets at the given offset.
+func (r *readerOffsets) AddKey(offset uint32, key []byte) {
+	r.offsets = append(r.offsets, offset)
+	pre := keyPrefix(key)
+	if r.entry.pre != pre && r.entry.total != 0 {
+		r.prefixes = append(r.prefixes, r.entry)
+	}
+	r.entry.pre = pre
+	r.entry.total++
+}
+
+// done signals that we are done adding keys.
+func (r *readerOffsets) Done() {
+	r.prefixes = append(r.prefixes, r.entry)
+}
+
+// Iterator returns an iterator that can walk and seek around the keys cheaply.
+func (r *readerOffsets) Iterator() readerOffsetsIterator {
+	return readerOffsetsIterator{r: r, first: true}
+}
+
+// readerOffsetsIterator iterates over the keys in readerOffsets.
+type readerOffsetsIterator struct {
+	r     *readerOffsets
+	first bool        // is this the first call to next?
+	del   bool        // should the next call delete?
+	oi    int         // index into offsets
+	od    int         // undeleted index into offsets
+	pi    int         // index into prefixes
+	psub  int         // number of deleted entries
+	ks    rOIKeyState // current key state
+}
+
+// rOIKeyState keeps track of cached information for the current key.
+type rOIKeyState struct {
+	length uint32 // high bit means set
+	key    []byte
+}
+
+// newROIKeyState constructs a rOIKeyState for the given key, precaching it.
+func newROIKeyState(key []byte) (ks rOIKeyState) {
+	if key != nil {
+		ks.length = uint32(len(key)) | 1<<31
+		ks.key = key
+	}
+	return ks
+}
+
+// setIndex sets the reader to the given index and clears any cached state.
+func (ri *readerOffsetsIterator) setIndex(i, pi int, key []byte) {
+	ri.oi, ri.od, ri.pi, ri.ks = i, i, pi, newROIKeyState(key)
+}
+
+// Length returns the length of the current pointed at key.
+func (ri *readerOffsetsIterator) Length(b *faultBuffer) uint16 {
+	if ri.ks.length&1<<31 == 0 {
+		ri.ks.length = uint32(binary.BigEndian.Uint16(b.access(ri.Offset(), 2))) | 1<<31
+	}
+	return uint16(ri.ks.length)
+}
+
+// Key returns the current pointed at key.
+func (ri *readerOffsetsIterator) Key(b *faultBuffer) []byte {
+	if ri.ks.key == nil {
+		ri.ks.key = b.access(ri.KeyOffset(), uint32(ri.Length(b)))
+	}
+	return ri.ks.key
+}
+
+// KeyOffset returns the offset of the current pointed at the key.
+func (ri *readerOffsetsIterator) KeyOffset() uint32 {
+	return ri.Offset() + 2
+}
+
+// EntryOffset returns the offset of the current pointed at entries (including type byte).
+func (ri *readerOffsetsIterator) EntryOffset(b *faultBuffer) uint32 {
+	return ri.Offset() + 2 + uint32(ri.Length(b))
+}
+
+// prefix returns the current pointed at prefix.
+func (ri *readerOffsetsIterator) Prefix() prefix { return ri.r.prefixes[ri.pi].pre }
+
+// offset returns the current pointed at offset.
+func (ri *readerOffsetsIterator) Offset() uint32 { return ri.r.offsets[ri.oi] }
+
+// Next advances the iterator and returns true if it points at a value.
+func (ri *readerOffsetsIterator) Next() bool {
+	if ri.oi >= len(ri.r.offsets) {
+		return false
+	} else if ri.first {
+		ri.first = false
+		return true
+	}
+
+	if ri.del {
+		ri.psub++
+		ri.del = false
+	} else {
+		if ri.oi != ri.od {
+			ri.r.offsets[ri.od] = ri.r.offsets[ri.oi]
+		}
+		ri.od++
+	}
+
+	ri.oi++
+	ri.ks = rOIKeyState{}
+
+	for ri.pi < len(ri.r.prefixes) && ri.oi >= ri.r.prefixes[ri.pi].total {
+		ri.r.prefixes[ri.pi].total -= ri.psub
+		ri.pi++
+	}
+
+	return ri.oi < len(ri.r.offsets)
+}
+
+// Done should be called to finalize up any deletes.
+func (ri *readerOffsetsIterator) Done() {
+	if ri.del { // if flagged to delete, pretend next was called
+		ri.psub++
+		ri.oi++
+	}
+	if ri.oi != ri.od {
+		for ; ri.pi < len(ri.r.prefixes); ri.pi++ {
+			ri.r.prefixes[ri.pi].total -= ri.psub
+		}
+		copy(ri.r.offsets[ri.od:], ri.r.offsets[ri.oi:])
+		ri.r.offsets = ri.r.offsets[:len(ri.r.offsets)-(ri.oi-ri.od)]
+	}
+}
+
+// Delete flags the entry to be skipped on the next call to Next.
+// Should only be called with the write lock.
+func (ri *readerOffsetsIterator) Delete() { ri.del = true }
+
+// Seek points the iterator at the smallest key greater than or equal to the
+// given key, returning true if it was an exact match. It returns false for
+// ok if the key does not exist. Do not call Seek if you have ever called Delete.
+func (ri *readerOffsetsIterator) Seek(key []byte, b *faultBuffer) (exact, ok bool) {
+	if ri.del || ri.psub > 0 {
+		panic("does not support Seek when we just deleted a key")
+	}
+	ri.first = false
+
+	pre, i, j, pi := keyPrefix(key), 0, len(ri.r.offsets), 0
+
+	for i < j {
+		h := int(uint(i+j) >> 1)
+		pi = ri.r.searchPrefix(h)
+		ri.setIndex(h, pi, nil)
+
+		switch ri.Compare(key, pre, b) {
+		case -1:
+			i = h + 1
+		case 1:
+			j = h
+		default:
+			return true, true
+		}
+	}
+
+	ri.setIndex(i, pi, nil)
+	if ri.oi >= len(ri.r.offsets) {
+		return false, false
+	}
+
+	for ri.pi < len(ri.r.prefixes) && ri.oi >= ri.r.prefixes[ri.pi].total {
+		ri.pi++
+	}
+
+	return bytes.Equal(ri.Key(b), key), true
+}
+
+// SeekTo sets the iterator to point at the nth element.
+func (ri *readerOffsetsIterator) SeekTo(n int) { ri.setIndex(n, ri.r.searchPrefix(n), nil) }
+
+// Compare is like bytes.Compare with the pointed at key, but reduces the amount of
+// faults.
+func (ri *readerOffsetsIterator) Compare(key []byte, pre prefix, b *faultBuffer) int {
+	if cmp := comparePrefix(ri.Prefix(), pre); cmp != 0 {
+		return cmp
+	}
+	return bytes.Compare(ri.Key(b), key)
+}

--- a/tsdb/tsm1/reader_offsets_test.go
+++ b/tsdb/tsm1/reader_offsets_test.go
@@ -1,0 +1,167 @@
+package tsm1
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func TestReaderOffsets(t *testing.T) {
+	const numKeys = 100
+
+	check := func(t *testing.T, what string, got, exp interface{}, extra ...interface{}) {
+		t.Helper()
+		if got != exp {
+			args := []interface{}{"incorrect", what, "got:", got, "exp:", exp}
+			args = append(args, extra...)
+			t.Fatal(args...)
+		}
+	}
+
+	makeKey := func(i int) string { return fmt.Sprintf("%09d", i) }
+
+	makeRO := func() (readerOffsets, *faultBuffer) {
+		var buf []byte
+		var ro readerOffsets
+		for i := 0; i < numKeys; i++ {
+			ro.AddKey(addKey(&buf, makeKey(i)))
+		}
+		ro.Done()
+
+		return ro, &faultBuffer{b: buf}
+	}
+
+	t.Run("Create_SingleKey", func(t *testing.T) {
+		var buf []byte
+		var ro readerOffsets
+		ro.AddKey(addKey(&buf, makeKey(0)))
+		ro.Done()
+
+		check(t, "offsets", len(ro.offsets), 1)
+		check(t, "prefixes", len(ro.prefixes), 1)
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		ro, _ := makeRO()
+
+		check(t, "offsets", len(ro.offsets), numKeys)
+		check(t, "prefixes", len(ro.prefixes), numKeys/10)
+	})
+
+	t.Run("Iterate", func(t *testing.T) {
+		ro, fb := makeRO()
+
+		iter := ro.Iterator()
+		for i := 0; iter.Next(); i++ {
+			check(t, "key", string(iter.Key(fb)), makeKey(i))
+		}
+	})
+
+	t.Run("Seek", func(t *testing.T) {
+		ro, fb := makeRO()
+		exact, ok := false, false
+
+		iter := ro.Iterator()
+		for i := 0; i < numKeys-1; i++ {
+			exact, ok = iter.Seek([]byte(makeKey(i)), fb)
+			check(t, "exact", exact, true)
+			check(t, "ok", ok, true)
+			check(t, "key", string(iter.Key(fb)), makeKey(i))
+
+			exact, ok = iter.Seek([]byte(makeKey(i)+"0"), fb)
+			check(t, "exact", exact, false)
+			check(t, "ok", ok, true)
+			check(t, "key", string(iter.Key(fb)), makeKey(i+1))
+		}
+
+		exact, ok = iter.Seek([]byte(makeKey(numKeys-1)), fb)
+		check(t, "exact", exact, true)
+		check(t, "ok", ok, true)
+		check(t, "key", string(iter.Key(fb)), makeKey(numKeys-1))
+
+		exact, ok = iter.Seek([]byte(makeKey(numKeys-1)+"0"), fb)
+		check(t, "exact", exact, false)
+		check(t, "ok", ok, false)
+
+		exact, ok = iter.Seek([]byte("1"), fb)
+		check(t, "exact", exact, false)
+		check(t, "ok", ok, false)
+
+		exact, ok = iter.Seek(nil, fb)
+		check(t, "exact", exact, false)
+		check(t, "ok", ok, true)
+		check(t, "key", string(iter.Key(fb)), makeKey(0))
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		ro, fb := makeRO()
+
+		iter := ro.Iterator()
+		for i := 0; iter.Next(); i++ {
+			if i%2 == 0 {
+				continue
+			}
+			iter.Delete()
+		}
+		iter.Done()
+
+		iter = ro.Iterator()
+		for i := 0; iter.Next(); i++ {
+			check(t, "key", string(iter.Key(fb)), makeKey(2*i))
+		}
+	})
+
+	t.Run("Fuzz", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			ro, fb := makeRO()
+			deleted := make(map[string]struct{})
+
+			for i := 0; i < numKeys; i++ {
+				// delete a random key. if we seek past, delete the first key.
+				{
+					iter := ro.Iterator()
+					_, ok := iter.Seek([]byte(makeKey(rand.Intn(numKeys))), fb)
+					if !ok {
+						iter.Seek(nil, fb)
+					}
+
+					key := string(iter.Key(fb))
+					_, ok = deleted[key]
+					check(t, "key deleted", ok, false)
+					deleted[key] = struct{}{}
+
+					iter.Delete()
+					iter.Next()
+					iter.Done()
+				}
+
+				// seek to every key that isn't deleted.
+				for i := 0; i < numKeys; i++ {
+					key := makeKey(i)
+					if _, ok := deleted[key]; ok {
+						continue
+					}
+
+					iter := ro.Iterator()
+					exact, ok := iter.Seek([]byte(key), fb)
+					check(t, "exact", exact, true)
+					check(t, "ok", ok, true)
+					check(t, "key", string(iter.Key(fb)), key)
+				}
+			}
+
+			check(t, "amount deleted", len(deleted), numKeys)
+			iter := ro.Iterator()
+			check(t, "next", iter.Next(), false)
+		}
+	})
+}
+
+func addKey(buf *[]byte, key string) (uint32, []byte) {
+	offset := len(*buf)
+	*buf = append(*buf, byte(len(key)>>8), byte(len(key)))
+	*buf = append(*buf, key...)
+	*buf = append(*buf, 0)
+	*buf = append(*buf, make([]byte, indexEntrySize)...)
+	return uint32(offset), []byte(key)
+}

--- a/tsdb/tsm1/reader_offsets_test.go
+++ b/tsdb/tsm1/reader_offsets_test.go
@@ -115,25 +115,20 @@ func TestReaderOffsets(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			ro, fb := makeRO()
 			deleted := make(map[string]struct{})
+			iter := ro.Iterator()
 
 			for i := 0; i < numKeys; i++ {
 				// delete a random key. if we seek past, delete the first key.
-				{
-					iter := ro.Iterator()
-					_, ok := iter.Seek([]byte(makeKey(rand.Intn(numKeys))), fb)
-					if !ok {
-						iter.Seek(nil, fb)
-					}
-
-					key := string(iter.Key(fb))
-					_, ok = deleted[key]
-					check(t, "key deleted", ok, false)
-					deleted[key] = struct{}{}
-
-					iter.Delete()
-					iter.Next()
-					iter.Done()
+				_, ok := iter.Seek([]byte(makeKey(rand.Intn(numKeys))), fb)
+				if !ok {
+					iter.Seek(nil, fb)
 				}
+				key := string(iter.Key(fb))
+				_, ok = deleted[key]
+				check(t, "key deleted", ok, false, "for key", key)
+				deleted[key] = struct{}{}
+				iter.Delete()
+				iter.Done()
 
 				// seek to every key that isn't deleted.
 				for i := 0; i < numKeys; i++ {
@@ -142,16 +137,15 @@ func TestReaderOffsets(t *testing.T) {
 						continue
 					}
 
-					iter := ro.Iterator()
 					exact, ok := iter.Seek([]byte(key), fb)
-					check(t, "exact", exact, true)
-					check(t, "ok", ok, true)
+					check(t, "exact", exact, true, "for key", key)
+					check(t, "ok", ok, true, "for key", key)
 					check(t, "key", string(iter.Key(fb)), key)
 				}
 			}
 
 			check(t, "amount deleted", len(deleted), numKeys)
-			iter := ro.Iterator()
+			iter = ro.Iterator()
 			check(t, "next", iter.Next(), false)
 		}
 	})

--- a/tsdb/tsm1/reader_test.go
+++ b/tsdb/tsm1/reader_test.go
@@ -1895,16 +1895,16 @@ func resetFaults(indirect *indirectIndex) {
 
 func getIndex(tb testing.TB) *indirectIndex {
 	if globalIndex != nil {
-		globalIndex.offsets = append([]uint32(nil), indexOffsets...)
-		globalIndex.prefixes = append([]prefixEntry(nil), indexPrefixes...)
+		globalIndex.ro.offsets = append([]uint32(nil), indexOffsets...)
+		globalIndex.ro.prefixes = append([]prefixEntry(nil), indexPrefixes...)
 		globalIndex.tombstones = make(map[uint32][]TimeRange)
 		resetFaults(globalIndex)
 		return globalIndex
 	}
 
 	globalIndex, indexBytes = mustMakeIndex(tb, indexKeyCount, indexBlockCount)
-	indexOffsets = append([]uint32(nil), globalIndex.offsets...)
-	indexPrefixes = append([]prefixEntry(nil), globalIndex.prefixes...)
+	indexOffsets = append([]uint32(nil), globalIndex.ro.offsets...)
+	indexPrefixes = append([]prefixEntry(nil), globalIndex.ro.prefixes...)
 
 	for i := 0; i < indexKeyCount; i++ {
 		indexAllKeys = append(indexAllKeys, []byte(fmt.Sprintf("cpu-%08d", i)))

--- a/tsdb/tsm1/reader_test.go
+++ b/tsdb/tsm1/reader_test.go
@@ -1876,10 +1876,11 @@ const (
 )
 
 var (
-	globalIndex  *indirectIndex
-	indexOffsets []uint32
-	indexAllKeys [][]byte
-	indexBytes   []byte
+	globalIndex   *indirectIndex
+	indexOffsets  []uint32
+	indexPrefixes []prefixEntry
+	indexAllKeys  [][]byte
+	indexBytes    []byte
 )
 
 func getFaults(indirect *indirectIndex) int64 {
@@ -1895,6 +1896,7 @@ func resetFaults(indirect *indirectIndex) {
 func getIndex(tb testing.TB) *indirectIndex {
 	if globalIndex != nil {
 		globalIndex.offsets = append([]uint32(nil), indexOffsets...)
+		globalIndex.prefixes = append([]prefixEntry(nil), indexPrefixes...)
 		globalIndex.tombstones = make(map[uint32][]TimeRange)
 		resetFaults(globalIndex)
 		return globalIndex
@@ -1902,6 +1904,7 @@ func getIndex(tb testing.TB) *indirectIndex {
 
 	globalIndex, indexBytes = mustMakeIndex(tb, indexKeyCount, indexBlockCount)
 	indexOffsets = append([]uint32(nil), globalIndex.offsets...)
+	indexPrefixes = append([]prefixEntry(nil), globalIndex.prefixes...)
 
 	for i := 0; i < indexKeyCount; i++ {
 		indexAllKeys = append(indexAllKeys, []byte(fmt.Sprintf("cpu-%08d", i)))

--- a/tsdb/tsm1/reader_test.go
+++ b/tsdb/tsm1/reader_test.go
@@ -1090,7 +1090,10 @@ func TestIndirectIndex_Entries(t *testing.T) {
 		t.Fatalf("unexpected error unmarshaling index: %v", err)
 	}
 
-	entries := indirect.Entries([]byte("cpu"))
+	entries, err := indirect.ReadEntries([]byte("cpu"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if got, exp := len(entries), len(exp); got != exp {
 		t.Fatalf("entries length mismatch: got %v, exp %v", got, exp)
@@ -1133,7 +1136,10 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 	// mem has not been added to the index so we should get no entries back
 	// for both
 	exp := index.Entries([]byte("mem"))
-	entries := indirect.Entries([]byte("mem"))
+	entries, err := indirect.ReadEntries([]byte("mem"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if got, exp := len(entries), len(exp); got != exp && exp != 0 {
 		t.Fatalf("entries length mismatch: got %v, exp %v", got, exp)
@@ -1953,7 +1959,7 @@ func BenchmarkIndirectIndex_Entries(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		resetFaults(indirect)
-		indirect.Entries([]byte("cpu-00000001"))
+		indirect.ReadEntries([]byte("cpu-00000001"), nil)
 	}
 
 	b.SetBytes(getFaults(globalIndex) * 4096)
@@ -1961,14 +1967,14 @@ func BenchmarkIndirectIndex_Entries(b *testing.B) {
 }
 
 func BenchmarkIndirectIndex_ReadEntries(b *testing.B) {
-	var cache []IndexEntry
+	var entries []IndexEntry
 	indirect, _ := mustMakeIndex(b, 1000, 1000)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		resetFaults(indirect)
-		indirect.ReadEntries([]byte("cpu-00000001"), &cache)
+		entries, _ = indirect.ReadEntries([]byte("cpu-00000001"), entries)
 	}
 
 	b.SetBytes(getFaults(globalIndex) * 4096)

--- a/tsdb/tsm1/reader_test.go
+++ b/tsdb/tsm1/reader_test.go
@@ -1995,6 +1995,25 @@ func BenchmarkIndirectIndex_DeleteRangeFull(b *testing.B) {
 	}
 }
 
+func BenchmarkIndirectIndex_DeleteRangeFull_Covered(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		indirect := getIndex(b)
+		b.StartTimer()
+
+		for i := 0; i < len(indexAllKeys); i += 4096 {
+			n := i + 4096
+			if n > len(indexAllKeys) {
+				n = len(indexAllKeys)
+			}
+			indirect.DeleteRange(indexAllKeys[i:n], 0, math.MaxInt64)
+		}
+	}
+}
+
 func BenchmarkIndirectIndex_Delete(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
# Summary

TL;DR:

- Fixes #1983 
- Improves benchmarks and reduces page faults
- Each commit is self contained for review if desired

---

### Remove offsets from mmap
This uses a `[]uint32` instead of a `[]byte` stored off the Go heap.

### Use a uint32 for offsets globally
Consolidates offsets from `int`, `int32`, `uint32` into just `uint32`.

### Use uint32 key for tombstones
Rather than look up tombstones by `[]byte`, look them up by the `uint32` offset that almost certainly have access to already.

### Fix multiple issues with DeleteRange
DeleteRange wasn't precise about keys being deleted, had incorrect locking, and didn't seek when the next key to delete wasn't the next key in the index.

### Add helper to track page faults in index
Estimates page faults by keeping track of the most recently accessed page, and considers it a fault if the accessed page is not the most recently accessed, or the one after it.

### Keep first 8 bytes of each key in memory
Reduces the amount of page faults by ~30% at very little memory overhead. Since keys tend to share the same first 8 bytes, rather than store the 8 bytes for every key, we do a sort of run length encoding, so we only store 8 bytes for every distinct prefix.

### Introduce readerOffsets to manage the offsets slice
Just an abstraction around the offsets and prefixes slice to keep the delete logic in one spot and well tested.

### Use readerOffsetsIterator for deletes
Cleans up a bunch of code in the Delete paths because of the previous abstraction.

### Change TSMFile to use an iterator style api
Direct indexes become invalidated during deletes. This returns an iterator so that we can add code to make it safe to iterate while deletes are in progress.

# Benchmarks

```
name                           old time/op    new time/op    delta
UnmarshalBinary                  70.0ms ±17%    71.0ms ±12%      ~     (p=1.000 n=8+8)
DeleteRangeLast                  1.48µs ± 1%    0.28µs ± 5%   -81.29%  (p=0.000 n=8+7)
DeleteRangeFull/Large             786ms ± 1%     363ms ± 3%   -53.89%  (p=0.000 n=7+8)
DeleteRangeFull/Small            2.37ms ± 0%    1.14ms ± 3%   -52.02%  (p=0.000 n=7+8)
DeleteRangeFull_Covered/Large     384ms ± 2%     188ms ± 3%   -51.04%  (p=0.000 n=8+8)
DeleteRangeFull_Covered/Small     470µs ± 1%     190µs ± 1%   -59.71%  (p=0.000 n=8+7)
Delete/Large                     74.0ms ± 1%   128.7ms ± 1%   +73.80%  (p=0.001 n=7+7)
Delete/Small                      142µs ± 1%     130µs ± 1%    -8.24%  (p=0.000 n=8+8)

name                           old alloc/op   new alloc/op   delta
UnmarshalBinary                  11.6MB ± 0%    11.7MB ± 0%    +0.02%  (p=0.000 n=8+7)
DeleteRangeLast                  3.26kB ± 0%   0.00kB ±NaN%  -100.00%  (p=0.000 n=8+8)
DeleteRangeFull/Large             233MB ± 0%     161MB ± 0%   -30.75%  (p=0.000 n=8+8)
DeleteRangeFull/Small            2.13MB ± 0%    1.40MB ± 0%   -34.53%  (p=0.000 n=8+8)
DeleteRangeFull_Covered/Large    12.4MB ± 0%     0.4MB ± 0%   -96.82%  (p=0.002 n=7+8)
DeleteRangeFull_Covered/Small     120kB ± 0%       0kB ± 0%   -99.89%  (p=0.000 n=8+8)
Delete/Large                     4.54kB ± 0%    0.21kB ± 0%   -95.26%  (p=0.000 n=8+8)
Delete/Small                      80.0B ± 0%     0.0B ±NaN%  -100.00%  (p=0.000 n=8+8)

name                           old allocs/op  new allocs/op  delta
UnmarshalBinary                    35.0 ± 0%      42.0 ± 0%   +20.00%  (p=0.000 n=8+8)
DeleteRangeLast                    3.00 ± 0%     0.00 ±NaN%  -100.00%  (p=0.000 n=8+8)
DeleteRangeFull/Large             1.53M ± 0%     0.52M ± 0%   -65.98%  (p=0.000 n=8+8)
DeleteRangeFull/Small             15.2k ± 0%      5.2k ± 0%   -65.97%  (p=0.000 n=8+8)
DeleteRangeFull_Covered/Large       620 ± 0%       124 ± 0%   -80.00%  (p=0.002 n=7+8)
DeleteRangeFull_Covered/Small      10.0 ± 0%       2.0 ± 0%   -80.00%  (p=0.000 n=8+8)
Delete/Large                        246 ± 0%         1 ± 0%   -99.59%  (p=0.000 n=8+8)
Delete/Small                       4.00 ± 0%     0.00 ±NaN%  -100.00%  (p=0.000 n=8+8)
```

The below numbers measure an estimate of page faults, so lower speeds are better. It
is considered a fault if the access is not the most recently access page, or the next
page after the most recently accessed page.

```
DeleteRangeFull          24.7MB/s ±10%  17.4MB/s ± 7%   -29.54%          (p=0.000 n=8+8)
DeleteRangeFull_Covered  14.2MB/s ± 1%     0MB/s ± 0%  -100.00%          (p=0.000 n=8+7)
Delete                    171MB/s ± 1%     0MB/s ±14%   -99.97%          (p=0.000 n=7+8)
```

DeleteRangeFull_Covered is the case where it deletes every key but without that being
statically known: it's just a range large enough to cover every entry. While it gets
slower in terms of cpu time, it's deleting 500k series, so it's really about 1.4µs per
series. The wins from being more linear in disk access seem more important.