### PR TITLE
fix(ci): add required jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,8 @@ workflows:
               only:
                 - master
     jobs:
+      - gotest
+      - jstest
       - deploy:
           requires:
             - gotest


### PR DESCRIPTION
https://circleci.com/gh/zhulongcheng/platform/137?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
```
#!/bin/sh -eo pipefail
# deploy: requires job \"jstest\" but \"jstest\" is not part of this workflow.
# deploy: requires job \"gotest\" but \"gotest\" is not part of this workflow.
# At least one job in the workflow must have no dependencies.
# The following jobs are unreachable: deploy
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false
Exited with code 1
```