### PR TITLE
Write a write service to support influxdb1

### DIFF
--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -141,11 +141,13 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 			Addr:      flags.host,
 			Token:     flags.token,
 			Precision: writeFlags.Precision,
+			OrgID:     orgID,
+			BucketID:  bucketID,
 		},
 	}
 
 	ctx = signals.WithStandardSignals(ctx)
-	if err := s.Write(ctx, orgID, bucketID, r); err != context.Canceled {
+	if err := s.Write(ctx, r); err != context.Canceled {
 		return err
 	}
 	return nil

--- a/http/write_handler_test.go
+++ b/http/write_handler_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/influxdata/platform"
 )
 
+func TestConvertPrecisionToInfluxDB1(t *testing.T) {
+	precision := "ns"
+	precision = convertPrecisionToInfluxDB1(precision)
+	if precision != "n" {
+		t.Errorf("expected n got %s", precision)
+	}
+}
+
 func TestWriteService_Write(t *testing.T) {
 	type args struct {
 		org    platform.ID
@@ -50,9 +58,11 @@ func TestWriteService_Write(t *testing.T) {
 				w.WriteHeader(tt.status)
 			}))
 			s := &WriteService{
-				Addr: ts.URL,
+				Addr:     ts.URL,
+				OrgID:    tt.args.org,
+				BucketID: tt.args.bucket,
 			}
-			if err := s.Write(context.Background(), tt.args.org, tt.args.bucket, tt.args.r); (err != nil) != tt.wantErr {
+			if err := s.Write(context.Background(), tt.args.r); (err != nil) != tt.wantErr {
 				t.Errorf("WriteService.Write() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if got, want := *org, tt.args.org; got != want {

--- a/mock/write_service.go
+++ b/mock/write_service.go
@@ -3,16 +3,14 @@ package mock
 import (
 	"context"
 	"io"
-
-	"github.com/influxdata/platform"
 )
 
 // WriteService writes data read from the reader.
 type WriteService struct {
-	WriteF func(context.Context, platform.ID, platform.ID, io.Reader) error
+	WriteF func(context.Context, io.Reader) error
 }
 
 // Write calls the mocked WriteF function with arguments.
-func (s *WriteService) Write(ctx context.Context, org, bucket platform.ID, r io.Reader) error {
-	return s.WriteF(ctx, org, bucket, r)
+func (s *WriteService) Write(ctx context.Context, r io.Reader) error {
+	return s.WriteF(ctx, r)
 }

--- a/write.go
+++ b/write.go
@@ -7,5 +7,5 @@ import (
 
 // WriteService writes data read from the reader.
 type WriteService interface {
-	Write(ctx context.Context, org, bucket ID, r io.Reader) error
+	Write(ctx context.Context, r io.Reader) error
 }

--- a/write/batcher_test.go
+++ b/write/batcher_test.go
@@ -256,7 +256,7 @@ func TestBatcher_write(t *testing.T) {
 			// or get back all the bytes from the reader.
 			var got string
 			svc := &mock.WriteService{
-				WriteF: func(ctx context.Context, org, bucket platform.ID, r io.Reader) error {
+				WriteF: func(ctx context.Context, r io.Reader) error {
 					if tt.args.writeError {
 						return fmt.Errorf("error")
 					}
@@ -272,7 +272,7 @@ func TestBatcher_write(t *testing.T) {
 				Service:          svc,
 			}
 
-			go b.write(ctx, tt.args.org, tt.args.bucket, tt.args.lines, tt.args.errC)
+			go b.write(ctx, tt.args.lines, tt.args.errC)
 
 			if cancel != nil {
 				cancel()
@@ -365,7 +365,7 @@ func TestBatcher_Write(t *testing.T) {
 				gotFlushes int
 			)
 			svc := &mock.WriteService{
-				WriteF: func(ctx context.Context, org, bucket platform.ID, r io.Reader) error {
+				WriteF: func(ctx context.Context, r io.Reader) error {
 					if tt.args.writeError {
 						return fmt.Errorf("error")
 					}
@@ -383,7 +383,7 @@ func TestBatcher_Write(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			if err := b.Write(ctx, tt.args.org, tt.args.bucket, tt.args.r); (err != nil) != tt.wantErr {
+			if err := b.Write(ctx, tt.args.r); (err != nil) != tt.wantErr {
 				t.Errorf("Batcher.Write() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -402,7 +402,7 @@ func TestBatcher_WriteTimeout(t *testing.T) {
 	// or get back all the bytes from the reader.
 	var got string
 	svc := &mock.WriteService{
-		WriteF: func(ctx context.Context, org, bucket platform.ID, r io.Reader) error {
+		WriteF: func(ctx context.Context, r io.Reader) error {
 			b, err := ioutil.ReadAll(r)
 			got = string(b)
 			return err
@@ -419,7 +419,7 @@ func TestBatcher_WriteTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
-	if err := b.Write(ctx, platform.ID(1), platform.ID(2), r); err != context.DeadlineExceeded {
+	if err := b.Write(ctx, r); err != context.DeadlineExceeded {
 		t.Errorf("Batcher.Write() with timeout error = %v", err)
 	}
 


### PR DESCRIPTION
Currently we don't have a client that supports influxdb v1.
This code changes the interface for the HTTP.WriteService in order to be
a bit more general, and I wrote a WriteService that target InfluxDB v1

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>
