### PR TITLE
Add support for prefix tombstone entries

### DIFF
--- a/tsdb/tsm1/tombstone.go
+++ b/tsdb/tsm1/tombstone.go
@@ -38,6 +38,9 @@ Tombstone file format:
 ║ │      ││               ││            ││                        ││               ││               │ ║
 ║ └──────┘└───────────────┘└────────────┘└────────────────────────┘└───────────────┘└───────────────┘ ║
 ╚═════════════════════════════════════════════════════════════════════════════════════════════════════╝
+
+NOTE: v1, v2 and v3 tombstone supports have been dropped from 2.x. Only v4 is now
+supported.
 */
 
 import (
@@ -133,12 +136,12 @@ func (t *Tombstoner) WithObserver(obs FileStoreObserver) {
 	t.obs = obs
 }
 
-// AddPrefix adds a prefix-based tomstone key.
+// AddPrefix adds a prefix-based tombstone key.
 func (t *Tombstoner) AddPrefix(key []byte) error {
 	return t.AddPrefixRange(key, math.MinInt64, math.MaxInt64)
 }
 
-// AddPrefixRange adds a prefix-based tomstone key with an explicit range.
+// AddPrefixRange adds a prefix-based tombstone key with an explicit range.
 func (t *Tombstoner) AddPrefixRange(key []byte, min, max int64) error {
 	if t.FilterFn != nil && !t.FilterFn(key) {
 		return nil

--- a/tsdb/tsm1/tombstone_test.go
+++ b/tsdb/tsm1/tombstone_test.go
@@ -2,7 +2,6 @@ package tsm1_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -280,67 +279,16 @@ func TestTombstoner_Delete(t *testing.T) {
 	}
 }
 
-func TestTombstoner_ReadV1(t *testing.T) {
+func TestTombstoner_ReadV4(t *testing.T) {
 	dir := MustTempDir()
 	defer func() { os.RemoveAll(dir) }()
-
-	f := MustTempFile(dir)
-	if err := ioutil.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
-		t.Fatalf("write v1 file: %v", err)
-	}
-	f.Close()
-
-	if err := os.Rename(f.Name(), f.Name()+".tombstone"); err != nil {
-		t.Fatalf("rename tombstone failed: %v", err)
-	}
-
-	ts := tsm1.NewTombstoner(f.Name(), nil)
-
-	// Read once
-	_ = mustReadAll(ts)
-
-	// Read again
-	entries := mustReadAll(ts)
-
-	if got, exp := len(entries), 1; got != exp {
-		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
-	}
-
-	if got, exp := string(entries[0].Key), "foo"; got != exp {
-		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
-	}
-
-	// Use a new Tombstoner to verify values are persisted
-	ts = tsm1.NewTombstoner(f.Name(), nil)
-	entries = mustReadAll(ts)
-	if got, exp := len(entries), 1; got != exp {
-		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
-	}
-
-	if got, exp := string(entries[0].Key), "foo"; got != exp {
-		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
-	}
+	t.Skip("TODO")
 }
 
-func TestTombstoner_ReadEmptyV1(t *testing.T) {
+func TestTombstoner_ReadV5(t *testing.T) {
 	dir := MustTempDir()
 	defer func() { os.RemoveAll(dir) }()
-
-	f := MustTempFile(dir)
-	f.Close()
-
-	if err := os.Rename(f.Name(), f.Name()+".tombstone"); err != nil {
-		t.Fatalf("rename tombstone failed: %v", err)
-	}
-
-	ts := tsm1.NewTombstoner(f.Name(), nil)
-
-	_ = mustReadAll(ts)
-
-	entries := mustReadAll(ts)
-	if got, exp := len(entries), 0; got != exp {
-		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
-	}
+	t.Skip("TODO")
 }
 
 func mustReadAll(t *tsm1.Tombstoner) []tsm1.Tombstone {


### PR DESCRIPTION
Closes #1833.

_Briefly describe your proposed changes:_

This PR adds support for prefix-based tombstone keys, along with a new API to creating them. Prefix keys are to be used when the intention is to delete all series keys matching a prefix, which commonly might be an organisation or an oganisaton+bucket combination.

In these cases we can use a single prefix key rather than adding a tombstone entry for each and every matching key.

_What was the problem?_

The existing `tsm1` engine does not provide support for prefix base tombstone keys.

_What was the solution?_

For the `v4` tombstone version we use a `32 bit` value to represent the length of a tombstone entry's key. We don't need that many bits, so we reduce it to 24 bits. This leaves us with 8 spare bits when encoding a tombstone entry.

We use the first of these 8 bits to indicate if the encoded entry contains a normal key or a prefix key.
