### PR TITLE
fix(platform): use json struct instead of string for embed error

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -172,12 +172,14 @@ func TestErrorCode(t *testing.T) {
 
 func TestJSON(t *testing.T) {
 	cases := []struct {
-		name string
-		err  *platform.Error
+		name    string
+		err     *platform.Error
+		encoded string
 	}{
 		{
-			name: "simple error",
-			err:  &platform.Error{Code: platform.ENotFound},
+			name:    "simple error",
+			err:     &platform.Error{Code: platform.ENotFound},
+			encoded: `{"code":"not found"}`,
 		},
 		{
 			name: "with op",
@@ -185,14 +187,16 @@ func TestJSON(t *testing.T) {
 				Code: platform.ENotFound,
 				Op:   "bolt.FindAuthorizationByID",
 			},
+			encoded: `{"code":"not found","op":"bolt.FindAuthorizationByID"}`,
 		},
 		{
 			name: "with op and value",
 			err: &platform.Error{
 				Code: platform.ENotFound,
-				Op:   "bolt.FindAuthorizationByID",
+				Op:   "bolt/FindAuthorizationByID",
 				Msg:  fmt.Sprintf("with ID %d", 323),
 			},
+			encoded: `{"code":"not found","msg":"with ID 323","op":"bolt/FindAuthorizationByID"}`,
 		},
 		{
 			name: "with a third party error",
@@ -201,6 +205,7 @@ func TestJSON(t *testing.T) {
 				Op:   "cmd/fluxd.injectDeps",
 				Err:  errors.New("empty value"),
 			},
+			encoded: `{"code":"failed to get the storage host","op":"cmd/fluxd.injectDeps","err":"empty value"}`,
 		},
 		{
 			name: "with a internal error",
@@ -209,6 +214,23 @@ func TestJSON(t *testing.T) {
 				Op:   "cmd/fluxd.injectDeps",
 				Err:  &platform.Error{Code: platform.EEmptyValue, Op: "cmd/fluxd.getStrList"},
 			},
+			encoded: `{"code":"failed to get the storage host","op":"cmd/fluxd.injectDeps","err":{"code":"empty value","op":"cmd/fluxd.getStrList"}}`,
+		},
+		{
+			name: "with a deep internal error",
+			err: &platform.Error{
+				Code: EFailedToGetStorageHost,
+				Op:   "cmd/fluxd.injectDeps",
+				Err: &platform.Error{
+					Code: platform.EInvalid,
+					Op:   "cmd/fluxd.getStrList",
+					Err: &platform.Error{
+						Code: platform.EEmptyValue,
+						Err:  errors.New("an err"),
+					},
+				},
+			},
+			encoded: `{"code":"failed to get the storage host","op":"cmd/fluxd.injectDeps","err":{"code":"invalid","op":"cmd/fluxd.getStrList","err":{"code":"empty value","err":"an err"}}}`,
 		},
 	}
 	for _, c := range cases {
@@ -217,9 +239,13 @@ func TestJSON(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s encode failed, want err: %v, should be nil", c.name, err)
 		}
+
+		if string(result) != c.encoded {
+			t.Fatalf("%s encode failed, want result: %s, got %s", c.name, c.encoded, string(result))
+		}
 		// decode testing
 		got := new(platform.Error)
-		err = json.Unmarshal([]byte(result), got)
+		err = json.Unmarshal(result, got)
 		if err != nil {
 			t.Fatalf("%s decode failed, want err: %v, should be nil", c.name, err)
 		}


### PR DESCRIPTION
Closes https://github.com/influxdata/platform/issues/1863

after this pr. 
previous json with embedded error will be changed from
```
{"code":"not found","msg":"organization not found","op":"inmem/FindBuckets","err":"{\"code\":\"\",\"err\":\"{\\\"code\\\":\\\"\\\",\\\"op\\\":\\\"inmem/FindOrganization\\\",\\\"err\\\":\\\"{\\\\\\\"code\\\\\\\":\\\\\\\"not found\\\\\\\",\\\\\\\"msg\\\\\\\":\\\\\\\"organization not found\\\\\\\",\\\\\\\"op\\\\\\\":\\\\\\\"inmem/FindOrganizations\\\\\\\"}\\\"}\"}"
``` 
to
```
{"code":"not found","msg":"organization not found","op":"inmem/FindBuckets","err":{"code":"","err":{"code":"","op":"inmem/FindOrganization","err":{"code":"not found","msg":"organization not found","op":"inmem/FindOrganizations"}}}
```