### PR TITLE
Match shape of get/authorizations to backend response

### DIFF
--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -3592,7 +3592,7 @@ components:
         links:
           readOnly: true
           $ref: "#/components/schemas/Links"
-        auths:
+        authorizations:
           type: array
           items:
             $ref: "#/components/schemas/Authorization"

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -417,7 +417,7 @@ export const createTelegrafConfigResponse = {
 export const authResponse = {
   data: {
     links: {self: '/api/v2/authorizations'},
-    auths: [
+    authorizations: [
       {
         links: {
           self: '/api/v2/authorizations/030358b6aa718000',

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -171,7 +171,7 @@ export interface Authorizations {
      * @type {Array<Authorization>}
      * @memberof Authorizations
      */
-    auths?: Array<Authorization>;
+    authorizations?: Array<Authorization>;
     /**
      * 
      * @type {Links}

--- a/ui/src/authorizations/apis/index.ts
+++ b/ui/src/authorizations/apis/index.ts
@@ -4,7 +4,7 @@ import {AxiosResponse} from 'axios'
 
 export const getAuthorizations = async (): Promise<Authorization[]> => {
   const {data} = await authorizationsAPI.authorizationsGet()
-  return data.auths
+  return data.authorizations
 }
 
 export const deleteAuthorization = async (

--- a/ui/src/onboarding/apis/index.ts
+++ b/ui/src/onboarding/apis/index.ts
@@ -105,7 +105,7 @@ export const getAuthorizationToken = async (
 ): Promise<string> => {
   try {
     const data = await authorizationsAPI.authorizationsGet(undefined, username)
-    return getDeep<string>(data, 'data.auths.0.token', '')
+    return getDeep<string>(data, 'data.authorizations.0.token', '')
   } catch (error) {
     console.error(error)
   }


### PR DESCRIPTION
The response from the get/authorizations endpoint was recently changed from having an array called `auths` to one called `authorizations`. This PR changes the generated client as well as the parsing of the response from this endpoint. 

  - [x] Rebased/mergeable
  - [x] Tests pass
