### PR TITLE
Telegraf plugins alphabetized in the sidebar

### DIFF
--- a/ui/src/onboarding/reducers/dataLoaders.test.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.test.ts
@@ -361,9 +361,9 @@ describe('dataLoader reducer', () => {
     const expected = {
       ...INITIAL_STATE,
       telegrafPlugins: [
-        redisTelegrafPlugin,
-        diskTelegrafPlugin,
         cpuTelegrafPlugin,
+        diskTelegrafPlugin,
+        redisTelegrafPlugin,
       ],
     }
 

--- a/ui/src/onboarding/reducers/dataLoaders.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.ts
@@ -78,9 +78,12 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
     case 'ADD_TELEGRAF_PLUGINS':
       return {
         ...state,
-        telegrafPlugins: _.uniqBy(
-          [...state.telegrafPlugins, ...action.payload.telegrafPlugins],
-          'name'
+        telegrafPlugins: _.sortBy(
+          _.uniqBy(
+            [...state.telegrafPlugins, ...action.payload.telegrafPlugins],
+            'name'
+          ),
+          ['name']
         ),
       }
     case 'UPDATE_TELEGRAF_PLUGIN':


### PR DESCRIPTION
Closes #1974

Update addTelegrafPlugin action to sort TelegrafPlugins with asc name when plugin bundles are added.