### PR TITLE
fix(platform): fix the pointer alloc for telegraf config

### DIFF
--- a/bolt/telegraf.go
+++ b/bolt/telegraf.go
@@ -190,10 +190,11 @@ func (c *Client) UpdateTelegrafConfig(ctx context.Context, id platform.ID, tc *p
 		tc.LastModBy = userID
 		pErr = c.putTelegrafConfig(ctx, tx, tc)
 		if pErr != nil {
-			pErr.Op = op
-			err = pErr
+			return &platform.Error{
+				Err: pErr,
+			}
 		}
-		return err
+		return nil
 	})
 	return tc, err
 }

--- a/telegraf/plugins/type.go
+++ b/telegraf/plugins/type.go
@@ -10,3 +10,15 @@ const (
 	Processor  Type = "processor"  // Processor is a processor plugin.
 	Aggregator Type = "aggregator" // Aggregator is an aggregator plugin.
 )
+
+// Config interface for all plugins.
+type Config interface {
+	// TOML encodes to toml string
+	TOML() string
+	// UnmarshalTOML decodes the parsed data to the object
+	UnmarshalTOML(data interface{}) error
+	// Type is the plugin type
+	Type() Type
+	// PluginName is the string value of telegraf plugin package name.
+	PluginName() string
+}

--- a/telegraf_test.go
+++ b/telegraf_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -12,8 +13,27 @@ import (
 	"github.com/influxdata/platform/telegraf/plugins/outputs"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/platform/telegraf/plugins/inputs"
 )
+
+var telegrafCmpOptions = cmp.Options{
+	cmpopts.IgnoreUnexported(
+		inputs.CPUStats{},
+		inputs.Kubernetes{},
+		inputs.File{},
+		outputs.File{},
+		outputs.InfluxDBV2{},
+		unsupportedPlugin{},
+	),
+	cmp.Transformer("Sort", func(in []*TelegrafConfig) []*TelegrafConfig {
+		out := append([]*TelegrafConfig(nil), in...)
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID > out[j].ID
+		})
+		return out
+	}),
+}
 
 type unsupportedPluginType struct {
 	Field string `json:"field"`
@@ -53,6 +73,79 @@ func (u *unsupportedPlugin) Type() plugins.Type {
 
 func (u *unsupportedPlugin) UnmarshalTOML(data interface{}) error {
 	return nil
+}
+
+func TestTelegrafConfigJSONDecodeWithoutID(t *testing.T) {
+	s := `{
+		"name":"config 2",
+		"agent": {
+			"collectionInterval": 120000
+		},
+		"plugins": [
+			{
+				"name":"cpu",
+				"type":"input",
+				"comment": "cpu collect cpu metrics",
+				"config":{}
+			},
+			{
+				"name":"kubernetes",
+				"type":"input",
+				"config":{
+					"url":"http://1.1.1.1:12"
+				}
+			},
+			{
+				"name": "influxdb_v2",
+				"type": "output",
+				"comment": "3",
+				"config": {
+					"urls": [
+						"http://127.0.0.1:9999"
+					],
+					"token": "token1",
+					"organization": "org",
+					"bucket": "bucket"
+				}
+			}
+		]
+	}`
+	want := &TelegrafConfig{
+		Name: "config 2",
+		Agent: TelegrafAgentConfig{
+			Interval: 120000,
+		},
+		Plugins: []TelegrafPlugin{
+			{
+				Comment: "cpu collect cpu metrics",
+				Config:  &inputs.CPUStats{},
+			},
+			{
+				Config: &inputs.Kubernetes{
+					URL: "http://1.1.1.1:12",
+				},
+			},
+			{
+				Comment: "3",
+				Config: &outputs.InfluxDBV2{
+					URLs: []string{
+						"http://127.0.0.1:9999",
+					},
+					Token:        "token1",
+					Organization: "org",
+					Bucket:       "bucket",
+				},
+			},
+		},
+	}
+	got := new(TelegrafConfig)
+	err := json.Unmarshal([]byte(s), got)
+	if err != nil {
+		t.Fatal("json decode error", err.Error())
+	}
+	if diff := cmp.Diff(got, want, telegrafCmpOptions...); diff != "" {
+		t.Errorf("telegraf configs are different -got/+want\ndiff %s", diff)
+	}
 }
 
 func TestTelegrafConfigJSON(t *testing.T) {
@@ -153,9 +246,8 @@ func TestTelegrafConfigJSON(t *testing.T) {
 			t.Fatalf("%s decode failed, got err: %v, should be %v", c.name, err, c.err)
 		}
 
-		// use DeepEqual to ignore unexported field panic
-		if c.err == nil && !reflect.DeepEqual(got, c.cfg) {
-			t.Fatalf("%s decode failed, want: %v, got: %v", c.name, c.cfg, got)
+		if diff := cmp.Diff(got, c.cfg, telegrafCmpOptions...); c.err == nil && diff != "" {
+			t.Errorf("failed %s, telegraf configs are different -got/+want\ndiff %s", c.name, diff)
 		}
 	}
 }

--- a/testing/telegraf.go
+++ b/testing/telegraf.go
@@ -3,13 +3,13 @@ package testing
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/mock"
 	"github.com/influxdata/platform/telegraf/plugins/inputs"
@@ -24,11 +24,14 @@ type TelegrafConfigFields struct {
 }
 
 var telegrafCmpOptions = cmp.Options{
-	cmp.Comparer(func(a, b *platform.TelegrafConfig) bool {
-		x, _ := json.Marshal(a)
-		y, _ := json.Marshal(b)
-		return bytes.Equal(x, y)
-	}),
+	cmpopts.IgnoreUnexported(
+		inputs.CPUStats{},
+		inputs.MemStats{},
+		inputs.Kubernetes{},
+		inputs.File{},
+		outputs.File{},
+		outputs.InfluxDBV2{},
+	),
 	cmp.Transformer("Sort", func(in []*platform.TelegrafConfig) []*platform.TelegrafConfig {
 		out := append([]*platform.TelegrafConfig(nil), in...)
 		sort.Slice(out, func(i, j int) bool {
@@ -1133,6 +1136,102 @@ func UpdateTelegrafConfig(
 						{
 							Comment: "comment2",
 							Config:  &inputs.MemStats{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "config update",
+			fields: TelegrafConfigFields{
+				TelegrafConfigs: []*platform.TelegrafConfig{
+					{
+						ID:        MustIDBase16(oneID),
+						Name:      "tc1",
+						LastModBy: MustIDBase16(threeID),
+						Plugins: []platform.TelegrafPlugin{
+							{
+								Config: &inputs.CPUStats{},
+							},
+						},
+					},
+					{
+						ID:        MustIDBase16(twoID),
+						Name:      "tc2",
+						LastModBy: MustIDBase16(threeID),
+						Plugins: []platform.TelegrafPlugin{
+							{
+								Comment: "comment1",
+								Config: &inputs.File{
+									Files: []string{"f1", "f2"},
+								},
+							},
+							{
+								Comment: "comment2",
+								Config: &inputs.Kubernetes{
+									URL: "http://1.2.3.4",
+								},
+							},
+							{
+								Config: &inputs.Kubernetes{
+									URL: "123",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				userID: MustIDBase16(fourID),
+				now:    now,
+				id:     MustIDBase16(twoID),
+				telegrafConfig: &platform.TelegrafConfig{
+					Name:      "tc2",
+					LastModBy: MustIDBase16(threeID),
+					Plugins: []platform.TelegrafPlugin{
+						{
+							Comment: "comment1",
+							Config: &inputs.File{
+								Files: []string{"f1", "f2", "f3"},
+							},
+						},
+						{
+							Comment: "comment2",
+							Config: &inputs.Kubernetes{
+								URL: "http://1.2.3.5",
+							},
+						},
+						{
+							Config: &inputs.Kubernetes{
+								URL: "1234",
+							},
+						},
+					},
+				},
+			},
+			wants: wants{
+				telegrafConfig: &platform.TelegrafConfig{
+					ID:        MustIDBase16(twoID),
+					Name:      "tc2",
+					LastModBy: MustIDBase16(fourID),
+					LastMod:   now,
+					Plugins: []platform.TelegrafPlugin{
+						{
+							Comment: "comment1",
+							Config: &inputs.File{
+								Files: []string{"f1", "f2", "f3"},
+							},
+						},
+						{
+							Comment: "comment2",
+							Config: &inputs.Kubernetes{
+								URL: "http://1.2.3.5",
+							},
+						},
+						{
+							Config: &inputs.Kubernetes{
+								URL: "1234",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Closes https://github.com/influxdata/platform/issues/1903

_Briefly describe your proposed changes:_
_What was the problem?
  previous implementation a map of pointer, won't allocate a new pointer.
_What was the solution?_
  use reflect.New to always allocate a new pointer when doing interface Unmarshalling.
  added more testing
  fixed bugs in old testing
  