### PR TITLE
refactor(inputs): moving fromOp from flux

### DIFF
--- a/query/functions/inputs/from.go
+++ b/query/functions/inputs/from.go
@@ -3,9 +3,15 @@ package inputs
 import (
 	"fmt"
 
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/functions"
 	"github.com/influxdata/flux/functions/inputs"
+	"github.com/influxdata/flux/functions/transformations"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/query"
 	"github.com/influxdata/platform/query/functions/inputs/storage"
@@ -13,14 +19,598 @@ import (
 )
 
 func init() {
-	execute.RegisterSource(inputs.FromKind, createFromSource)
+	fromSignature := semantic.FunctionPolySignature{
+		Parameters: map[string]semantic.PolyType{
+			"bucket":   semantic.String,
+			"bucketID": semantic.String,
+		},
+		Required: nil,
+		Return:   flux.TableObjectType,
+	}
+
+	// FromOpSpec is registered in Flux. Do not register it here.
+	execute.RegisterSource(physicalFromKind, createFromSource)
+	flux.RegisterFunction(inputs.FromKind, createFromOpSpec, fromSignature)
+	plan.RegisterProcedureSpec(inputs.FromKind, newFromProcedure, inputs.FromKind)
+	plan.RegisterPhysicalRules(
+		FromConversionRule{},
+		MergeFromRangeRule{},
+		MergeFromFilterRule{},
+		FromDistinctRule{},
+		MergeFromGroupRule{},
+	)
 }
 
-// TODO(adam): implement a BucketsAccessed that doesn't depend on flux.
-// https://github.com/influxdata/flux/issues/114
+type bucketAwareFromOpSpec struct {
+	Bucket   string
+	BucketID platform.ID
+}
+
+func (*bucketAwareFromOpSpec) Kind() flux.OperationKind {
+	return inputs.FromKind
+}
+
+func (s *bucketAwareFromOpSpec) BucketsAccessed() (readBuckets, writeBuckets []platform.BucketFilter) {
+	bf := platform.BucketFilter{}
+	if s.Bucket != "" {
+		bf.Name = &s.Bucket
+	}
+
+	if s.BucketID.Valid() {
+		bf.ID = &s.BucketID
+	}
+
+	if bf.ID != nil || bf.Name != nil {
+		readBuckets = append(readBuckets, bf)
+	}
+	return readBuckets, writeBuckets
+}
+
+func createFromOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	spec := new(bucketAwareFromOpSpec)
+
+	if bucket, ok, err := args.GetString("bucket"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Bucket = bucket
+	}
+
+	if bucketID, ok, err := args.GetString("bucketID"); err != nil {
+		return nil, err
+	} else if ok {
+		err := spec.BucketID.DecodeFromString(bucketID)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid bucket ID")
+		}
+	}
+
+	if spec.Bucket == "" && !spec.BucketID.Valid() {
+		return nil, errors.New("must specify one of bucket or bucketID")
+	}
+	if spec.Bucket != "" && spec.BucketID.Valid() {
+		return nil, errors.New("must specify only one of bucket or bucketID")
+	}
+	return spec, nil
+}
+
+type FromProcedureSpec struct {
+	Bucket   string
+	BucketID string
+}
+
+func newFromProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*inputs.FromOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+
+	return &FromProcedureSpec{
+		Bucket:   spec.Bucket,
+		BucketID: spec.BucketID,
+	}, nil
+}
+
+func (s *FromProcedureSpec) Kind() plan.ProcedureKind {
+	return inputs.FromKind
+}
+
+func (s *FromProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(FromProcedureSpec)
+
+	ns.Bucket = s.Bucket
+	ns.BucketID = s.BucketID
+
+	return ns
+}
+
+func (s FromProcedureSpec) PostPhysicalValidate(id plan.NodeID) error {
+	// FromProcedureSpec has no bounds, so must be invalid.
+	var bucket string
+	if len(s.Bucket) > 0 {
+		bucket = s.Bucket
+	} else {
+		bucket = s.BucketID
+	}
+	return fmt.Errorf(`%s: results from "%s" must be bounded`, id, bucket)
+}
+
+const physicalFromKind = "physFrom"
+
+type PhysicalFromProcedureSpec struct {
+	*FromProcedureSpec
+
+	plan.DefaultCost
+
+	BoundsSet bool
+	Bounds    flux.Bounds
+
+	FilterSet bool
+	Filter    *semantic.FunctionExpression
+
+	DescendingSet bool
+	Descending    bool
+
+	LimitSet     bool
+	PointsLimit  int64
+	SeriesLimit  int64
+	SeriesOffset int64
+
+	WindowSet bool
+	Window    plan.WindowSpec
+
+	GroupingSet bool
+	OrderByTime bool
+	GroupMode   functions.GroupMode
+	GroupKeys   []string
+
+	AggregateSet    bool
+	AggregateMethod string
+}
+
+func (PhysicalFromProcedureSpec) Kind() plan.ProcedureKind {
+	return physicalFromKind
+}
+
+func (s *PhysicalFromProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(PhysicalFromProcedureSpec)
+
+	ns.FromProcedureSpec = s.FromProcedureSpec.Copy().(*FromProcedureSpec)
+
+	ns.BoundsSet = s.BoundsSet
+	ns.Bounds = s.Bounds
+
+	ns.FilterSet = s.FilterSet
+	ns.Filter = s.Filter.Copy().(*semantic.FunctionExpression)
+
+	ns.DescendingSet = s.DescendingSet
+	ns.Descending = s.Descending
+
+	ns.LimitSet = s.LimitSet
+	ns.PointsLimit = s.PointsLimit
+	ns.SeriesLimit = s.SeriesLimit
+	ns.SeriesOffset = s.SeriesOffset
+
+	ns.WindowSet = s.WindowSet
+	ns.Window = s.Window
+
+	ns.GroupingSet = s.GroupingSet
+	ns.OrderByTime = s.OrderByTime
+	ns.GroupMode = s.GroupMode
+	ns.GroupKeys = s.GroupKeys
+
+	ns.AggregateSet = s.AggregateSet
+	ns.AggregateMethod = s.AggregateMethod
+
+	return ns
+}
+
+// TimeBounds implements plan.BoundsAwareProcedureSpec
+func (s *PhysicalFromProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bounds {
+	if s.BoundsSet {
+		bounds := &plan.Bounds{
+			Start: values.ConvertTime(s.Bounds.Start.Time(s.Bounds.Now)),
+			Stop:  values.ConvertTime(s.Bounds.Stop.Time(s.Bounds.Now)),
+		}
+		return bounds
+	}
+	return nil
+}
+
+func (s PhysicalFromProcedureSpec) PostPhysicalValidate(id plan.NodeID) error {
+	if !s.BoundsSet || (s.Bounds.Start.IsZero() && s.Bounds.Stop.IsZero()) {
+		var bucket string
+		if len(s.Bucket) > 0 {
+			bucket = s.Bucket
+		} else {
+			bucket = s.BucketID
+		}
+		return fmt.Errorf(`%s: results from "%s" must be bounded`, id, bucket)
+	}
+	return nil
+}
+
+// FromConversionRule converts a logical `from` node into a physical `from` node.
+// TODO(cwolff): this rule can go away when we require a `range`
+//  to be pushed into a logical `from` to create a physical `from.`
+type FromConversionRule struct {
+}
+
+func (FromConversionRule) Name() string {
+	return "FromConversionRule"
+}
+
+func (FromConversionRule) Pattern() plan.Pattern {
+	return plan.Pat(inputs.FromKind)
+}
+
+func (FromConversionRule) Rewrite(pn plan.PlanNode) (plan.PlanNode, bool, error) {
+	logicalFromSpec := pn.ProcedureSpec().(*FromProcedureSpec)
+	newNode := plan.CreatePhysicalNode(pn.ID(), &PhysicalFromProcedureSpec{
+		FromProcedureSpec: logicalFromSpec.Copy().(*FromProcedureSpec),
+	})
+
+	plan.ReplaceNode(pn, newNode)
+	return newNode, true, nil
+}
+
+// MergeFromRangeRule pushes a `range` into a `from`
+type MergeFromRangeRule struct{}
+
+// Name returns the name of the rule
+func (rule MergeFromRangeRule) Name() string {
+	return "MergeFromRangeRule"
+}
+
+// Pattern returns the pattern that matches `from -> range`
+func (rule MergeFromRangeRule) Pattern() plan.Pattern {
+	return plan.Pat(transformations.RangeKind, plan.Pat(physicalFromKind))
+}
+
+// Rewrite attempts to rewrite a `from -> range` into a `FromRange`
+func (rule MergeFromRangeRule) Rewrite(node plan.PlanNode) (plan.PlanNode, bool, error) {
+	from := node.Predecessors()[0]
+	fromSpec := from.ProcedureSpec().(*PhysicalFromProcedureSpec)
+	rangeSpec := node.ProcedureSpec().(*transformations.RangeProcedureSpec)
+	fromRange := fromSpec.Copy().(*PhysicalFromProcedureSpec)
+
+	// Set new bounds to `range` bounds initially
+	fromRange.Bounds = rangeSpec.Bounds
+
+	var (
+		now   = rangeSpec.Bounds.Now
+		start = rangeSpec.Bounds.Start
+		stop  = rangeSpec.Bounds.Stop
+	)
+
+	bounds := &plan.Bounds{
+		Start: values.ConvertTime(start.Time(now)),
+		Stop:  values.ConvertTime(stop.Time(now)),
+	}
+
+	// Intersect bounds if `from` already bounded
+	if fromSpec.BoundsSet {
+		now = fromSpec.Bounds.Now
+		start = fromSpec.Bounds.Start
+		stop = fromSpec.Bounds.Stop
+
+		fromBounds := &plan.Bounds{
+			Start: values.ConvertTime(start.Time(now)),
+			Stop:  values.ConvertTime(stop.Time(now)),
+		}
+
+		bounds = bounds.Intersect(fromBounds)
+		fromRange.Bounds = flux.Bounds{
+			Start: flux.Time{Absolute: bounds.Start.Time()},
+			Stop:  flux.Time{Absolute: bounds.Stop.Time()},
+		}
+	}
+
+	fromRange.BoundsSet = true
+
+	// Finally merge nodes into single operation
+	merged, err := plan.MergeToPhysicalPlanNode(node, from, fromRange)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return merged, true, nil
+}
+
+// MergeFromFilterRule is a rule that pushes filters into from procedures to be evaluated in the storage layer.
+// TODO: Code that analyzes predicates should be put in platform, or anywhere sources are actually created.
+// This is so we can tailor push down logic to actual capabilities of storage (whether InfluxDB or some other source).
+// Also this rule is likely to be replaced by a more generic rule when we have a better
+// framework for pushing filters, etc into sources.
+type MergeFromFilterRule struct {
+}
+
+func (MergeFromFilterRule) Name() string {
+	return "MergeFromFilterRule"
+}
+
+func (MergeFromFilterRule) Pattern() plan.Pattern {
+	return plan.Pat(transformations.FilterKind, plan.Pat(physicalFromKind))
+}
+
+func (MergeFromFilterRule) Rewrite(filterNode plan.PlanNode) (plan.PlanNode, bool, error) {
+	filterSpec := filterNode.ProcedureSpec().(*transformations.FilterProcedureSpec)
+	fromNode := filterNode.Predecessors()[0]
+	fromSpec := fromNode.ProcedureSpec().(*PhysicalFromProcedureSpec)
+
+	if fromSpec.AggregateSet || fromSpec.GroupingSet {
+		return filterNode, false, nil
+	}
+
+	bodyExpr, ok := filterSpec.Fn.Block.Body.(semantic.Expression)
+	if !ok {
+		return filterNode, false, nil
+	}
+
+	if len(filterSpec.Fn.Block.Parameters.List) != 1 {
+		// I would expect that type checking would catch this, but just to be safe...
+		return filterNode, false, nil
+	}
+
+	paramName := filterSpec.Fn.Block.Parameters.List[0].Key.Name
+
+	pushable, notPushable, err := semantic.PartitionPredicates(bodyExpr, func(e semantic.Expression) (bool, error) {
+		return isPushableExpr(paramName, e)
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	if pushable == nil {
+		// Nothing could be pushed down, no rewrite can happen
+		return filterNode, false, nil
+	}
+
+	newFromSpec := fromSpec.Copy().(*PhysicalFromProcedureSpec)
+	if newFromSpec.FilterSet {
+		newBody := semantic.ExprsToConjunction(newFromSpec.Filter.Block.Body.(semantic.Expression), pushable)
+		newFromSpec.Filter.Block.Body = newBody
+	} else {
+		newFromSpec.FilterSet = true
+		newFromSpec.Filter = filterSpec.Fn.Copy().(*semantic.FunctionExpression)
+		newFromSpec.Filter.Block.Body = pushable
+	}
+
+	if notPushable == nil {
+		// All predicates could be pushed down, so eliminate the filter
+		mergedNode, err := plan.MergeToPhysicalPlanNode(filterNode, fromNode, newFromSpec)
+		if err != nil {
+			return nil, false, err
+		}
+		return mergedNode, true, nil
+	}
+
+	err = fromNode.ReplaceSpec(newFromSpec)
+	if err != nil {
+		return nil, false, err
+	}
+
+	newFilterSpec := filterSpec.Copy().(*transformations.FilterProcedureSpec)
+	newFilterSpec.Fn.Block.Body = notPushable
+	err = filterNode.ReplaceSpec(newFilterSpec)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return filterNode, true, nil
+}
+
+// isPushableExpr determines if a predicate expression can be pushed down into the storage layer.
+func isPushableExpr(paramName string, expr semantic.Expression) (bool, error) {
+	switch e := expr.(type) {
+	case *semantic.LogicalExpression:
+		b, err := isPushableExpr(paramName, e.Left)
+		if err != nil {
+			return false, err
+		}
+
+		if !b {
+			return false, nil
+		}
+
+		return isPushableExpr(paramName, e.Right)
+
+	case *semantic.BinaryExpression:
+		if isPushablePredicate(paramName, e) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func isPushablePredicate(paramName string, be *semantic.BinaryExpression) bool {
+	// Manual testing seems to indicate that (at least right now) we can
+	// only handle predicates of the form <fn param>.<property> <op> <literal>
+	// and the literal must be on the RHS.
+
+	if !isLiteral(be.Right) {
+		return false
+	}
+
+	if isField(paramName, be.Left) && isPushableFieldOperator(be.Operator) {
+		return true
+	}
+
+	if isTag(paramName, be.Left) && isPushableTagOperator(be.Operator) {
+		return true
+	}
+
+	return false
+}
+
+func isLiteral(e semantic.Expression) bool {
+	switch e.(type) {
+	case *semantic.StringLiteral:
+		return true
+	case *semantic.IntegerLiteral:
+		return true
+	case *semantic.BooleanLiteral:
+		return true
+	case *semantic.FloatLiteral:
+		return true
+	case *semantic.RegexpLiteral:
+		return true
+	}
+
+	return false
+}
+
+const fieldValueProperty = "_value"
+
+func isTag(paramName string, e semantic.Expression) bool {
+	memberExpr := validateMemberExpr(paramName, e)
+	return memberExpr != nil && memberExpr.Property != fieldValueProperty
+}
+
+func isField(paramName string, e semantic.Expression) bool {
+	memberExpr := validateMemberExpr(paramName, e)
+	return memberExpr != nil && memberExpr.Property == fieldValueProperty
+}
+
+func validateMemberExpr(paramName string, e semantic.Expression) *semantic.MemberExpression {
+	memberExpr, ok := e.(*semantic.MemberExpression)
+	if !ok {
+		return nil
+	}
+
+	idExpr, ok := memberExpr.Object.(*semantic.IdentifierExpression)
+	if !ok {
+		return nil
+	}
+
+	if idExpr.Name != paramName {
+		return nil
+	}
+
+	return memberExpr
+}
+
+func isPushableTagOperator(kind ast.OperatorKind) bool {
+	pushableOperators := []ast.OperatorKind{
+		ast.EqualOperator,
+		ast.NotEqualOperator,
+		ast.RegexpMatchOperator,
+		ast.NotRegexpMatchOperator,
+	}
+
+	for _, op := range pushableOperators {
+		if op == kind {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isPushableFieldOperator(kind ast.OperatorKind) bool {
+	if isPushableTagOperator(kind) {
+		return true
+	}
+
+	// Fields can be filtered by anything that tags can be filtered by,
+	// plus range operators.
+
+	moreOperators := []ast.OperatorKind{
+		ast.LessThanEqualOperator,
+		ast.LessThanOperator,
+		ast.GreaterThanEqualOperator,
+		ast.GreaterThanOperator,
+	}
+
+	for _, op := range moreOperators {
+		if op == kind {
+			return true
+		}
+	}
+
+	return false
+}
+
+type FromDistinctRule struct {
+}
+
+func (FromDistinctRule) Name() string {
+	return "FromDistinctRule"
+}
+
+func (FromDistinctRule) Pattern() plan.Pattern {
+	return plan.Pat(transformations.DistinctKind, plan.Pat(physicalFromKind))
+}
+
+func (FromDistinctRule) Rewrite(distinctNode plan.PlanNode) (plan.PlanNode, bool, error) {
+	fromNode := distinctNode.Predecessors()[0]
+	distinctSpec := distinctNode.ProcedureSpec().(*transformations.DistinctProcedureSpec)
+	fromSpec := fromNode.ProcedureSpec().(*PhysicalFromProcedureSpec)
+
+	if fromSpec.LimitSet && fromSpec.PointsLimit == -1 {
+		return distinctNode, false, nil
+	}
+
+	groupStar := !fromSpec.GroupingSet && distinctSpec.Column != execute.DefaultValueColLabel && distinctSpec.Column != execute.DefaultTimeColLabel
+	groupByColumn := fromSpec.GroupingSet && len(fromSpec.GroupKeys) > 0 &&
+		((fromSpec.GroupMode == functions.GroupModeBy && execute.ContainsStr(fromSpec.GroupKeys, distinctSpec.Column)) ||
+			(fromSpec.GroupMode == functions.GroupModeExcept && !execute.ContainsStr(fromSpec.GroupKeys, distinctSpec.Column)))
+	if groupStar || groupByColumn {
+		newFromSpec := fromSpec.Copy().(*PhysicalFromProcedureSpec)
+		newFromSpec.LimitSet = true
+		newFromSpec.PointsLimit = -1
+		if err := fromNode.ReplaceSpec(newFromSpec); err != nil {
+			return nil, false, err
+		}
+		return distinctNode, true, nil
+	}
+
+	return distinctNode, false, nil
+}
+
+type MergeFromGroupRule struct {
+}
+
+func (MergeFromGroupRule) Name() string {
+	return "MergeFromGroupRule"
+}
+
+func (MergeFromGroupRule) Pattern() plan.Pattern {
+	return plan.Pat(transformations.GroupKind, plan.Pat(physicalFromKind))
+}
+
+func (MergeFromGroupRule) Rewrite(groupNode plan.PlanNode) (plan.PlanNode, bool, error) {
+	fromNode := groupNode.Predecessors()[0]
+	groupSpec := groupNode.ProcedureSpec().(*transformations.GroupProcedureSpec)
+	fromSpec := fromNode.ProcedureSpec().(*PhysicalFromProcedureSpec)
+
+	if fromSpec.GroupingSet ||
+		fromSpec.LimitSet ||
+		groupSpec.GroupMode != functions.GroupModeBy {
+		return groupNode, false, nil
+	}
+
+	for _, c := range groupSpec.GroupKeys {
+		// Storage can only do grouping over tag keys.
+		// Note: _start and _stop are okay, since storage is always implicitly grouping by them anyway.
+		if c == execute.DefaultTimeColLabel || c == execute.DefaultValueColLabel {
+			return groupNode, false, nil
+		}
+	}
+
+	newFromSpec := fromSpec.Copy().(*PhysicalFromProcedureSpec)
+	newFromSpec.GroupingSet = true
+	newFromSpec.GroupMode = groupSpec.GroupMode
+	newFromSpec.GroupKeys = groupSpec.GroupKeys
+	merged, err := plan.MergeToPhysicalPlanNode(groupNode, fromNode, newFromSpec)
+	if err != nil {
+		return nil, false, err
+	}
+	return merged, true, nil
+}
 
 func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
-	spec := prSpec.(*inputs.FromProcedureSpec)
+	spec := prSpec.(*PhysicalFromProcedureSpec)
 	var w execute.Window
 	bounds := a.StreamContext().Bounds()
 	if bounds == nil {

--- a/query/functions/inputs/from_test.go
+++ b/query/functions/inputs/from_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/functions"
-	fluxInputs "github.com/influxdata/flux/functions/inputs"
 	"github.com/influxdata/flux/functions/transformations"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
@@ -21,6 +20,11 @@ import (
 )
 
 func TestFrom_NewQuery(t *testing.T) {
+	bid, err := platform.IDFromString( "aaaabbbbccccdddd")
+	if err != nil {
+		panic(err)
+	}
+
 	t.Skip()
 	tests := []querytest.NewQueryTestCase{
 		{
@@ -55,8 +59,8 @@ func TestFrom_NewQuery(t *testing.T) {
 				Operations: []*flux.Operation{
 					{
 						ID: "from0",
-						Spec: &fluxInputs.FromOpSpec{
-							BucketID: "aaaabbbbccccdddd",
+						Spec: &inputs.FromOpSpec{
+							BucketID: *bid,
 						},
 					},
 				},
@@ -69,7 +73,7 @@ func TestFrom_NewQuery(t *testing.T) {
 				Operations: []*flux.Operation{
 					{
 						ID: "from0",
-						Spec: &fluxInputs.FromOpSpec{
+						Spec: &inputs.FromOpSpec{
 							Bucket: "mybucket",
 						},
 					},
@@ -117,7 +121,7 @@ func TestFromOperation_Marshaling(t *testing.T) {
 	data := []byte(`{"id":"from","kind":"from","spec":{"bucket":"mybucket"}}`)
 	op := &flux.Operation{
 		ID: "from",
-		Spec: &fluxInputs.FromOpSpec{
+		Spec: &inputs.FromOpSpec{
 			Bucket: "mybucket",
 		},
 	}

--- a/query/functions/inputs/from_test.go
+++ b/query/functions/inputs/from_test.go
@@ -4,13 +4,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/flux/functions/inputs"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/functions"
+	fluxInputs "github.com/influxdata/flux/functions/inputs"
 	"github.com/influxdata/flux/functions/transformations"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/semantic"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/query/functions/inputs"
 	pquerytest "github.com/influxdata/platform/query/querytest"
 )
 
@@ -49,7 +55,7 @@ func TestFrom_NewQuery(t *testing.T) {
 				Operations: []*flux.Operation{
 					{
 						ID: "from0",
-						Spec: &inputs.FromOpSpec{
+						Spec: &fluxInputs.FromOpSpec{
 							BucketID: "aaaabbbbccccdddd",
 						},
 					},
@@ -63,7 +69,7 @@ func TestFrom_NewQuery(t *testing.T) {
 				Operations: []*flux.Operation{
 					{
 						ID: "from0",
-						Spec: &inputs.FromOpSpec{
+						Spec: &fluxInputs.FromOpSpec{
 							Bucket: "mybucket",
 						},
 					},
@@ -111,7 +117,7 @@ func TestFromOperation_Marshaling(t *testing.T) {
 	data := []byte(`{"id":"from","kind":"from","spec":{"bucket":"mybucket"}}`)
 	op := &flux.Operation{
 		ID: "from",
-		Spec: &inputs.FromOpSpec{
+		Spec: &fluxInputs.FromOpSpec{
 			Bucket: "mybucket",
 		},
 	}
@@ -119,11 +125,8 @@ func TestFromOperation_Marshaling(t *testing.T) {
 }
 
 func TestFromOpSpec_BucketsAccessed(t *testing.T) {
-	// TODO(adam) add this test back when BucketsAccessed is restored for the from function
-	// https://github.com/influxdata/flux/issues/114
-	t.Skip("https://github.com/influxdata/flux/issues/114")
 	bucketName := "my_bucket"
-	bucketID, _ := platform.IDFromString("deadbeef")
+	bucketID, _ := platform.IDFromString("aaaabbbbccccdddd")
 	tests := []pquerytest.BucketAwareQueryTestCase{
 		{
 			Name:             "From with bucket",
@@ -133,7 +136,7 @@ func TestFromOpSpec_BucketsAccessed(t *testing.T) {
 		},
 		{
 			Name:             "From with bucketID",
-			Raw:              `from(bucketID:"deadbeef")`,
+			Raw:              `from(bucketID:"aaaabbbbccccdddd")`,
 			WantReadBuckets:  &[]platform.BucketFilter{{ID: bucketID}},
 			WantWriteBuckets: &[]platform.BucketFilter{},
 		},
@@ -144,5 +147,706 @@ func TestFromOpSpec_BucketsAccessed(t *testing.T) {
 			t.Parallel()
 			pquerytest.BucketAwareQueryTestHelper(t, tc)
 		})
+	}
+}
+
+func yield(name string) *transformations.YieldProcedureSpec {
+	return &transformations.YieldProcedureSpec{Name: name}
+}
+
+func fluxTime(t int64) flux.Time {
+	return flux.Time{
+		Absolute: time.Unix(0, t).UTC(),
+	}
+}
+
+func makeFilterFn(exprs ...semantic.Expression) *semantic.FunctionExpression {
+	body := semantic.ExprsToConjunction(exprs...)
+	return &semantic.FunctionExpression{
+		Block: &semantic.FunctionBlock{
+			Parameters: &semantic.FunctionParameters{
+				List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+			},
+			Body: body,
+		},
+	}
+}
+
+func TestFromRangeRule(t *testing.T) {
+	var (
+		from           = &inputs.FromProcedureSpec{}
+		fromWithBounds = &inputs.PhysicalFromProcedureSpec{
+			FromProcedureSpec: from,
+			BoundsSet:         true,
+			Bounds: flux.Bounds{
+				Start: fluxTime(5),
+				Stop:  fluxTime(10),
+			},
+		}
+		fromWithIntersectedBounds = &inputs.PhysicalFromProcedureSpec{
+			FromProcedureSpec: from,
+			BoundsSet:         true,
+			Bounds: flux.Bounds{
+				Start: fluxTime(9),
+				Stop:  fluxTime(10),
+			},
+		}
+		rangeWithBounds = &transformations.RangeProcedureSpec{
+			Bounds: flux.Bounds{
+				Start: fluxTime(5),
+				Stop:  fluxTime(10),
+			},
+		}
+		rangeWithDifferentBounds = &transformations.RangeProcedureSpec{
+			Bounds: flux.Bounds{
+				Start: fluxTime(9),
+				Stop:  fluxTime(14),
+			},
+		}
+		mean  = &transformations.MeanProcedureSpec{}
+		count = &transformations.CountProcedureSpec{}
+	)
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name: "from range",
+			// from -> range  =>  from
+			Rules: []plan.Rule{&inputs.FromConversionRule{}, &inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", from),
+					plan.CreatePhysicalNode("range", rangeWithBounds),
+				},
+				Edges: [][2]int{{0, 1}},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_range", fromWithBounds),
+				},
+			},
+		},
+		{
+			Name: "from range with successor node",
+			// from -> range -> count  =>  from -> count
+			Rules: []plan.Rule{&inputs.FromConversionRule{}, &inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", from),
+					plan.CreatePhysicalNode("range", rangeWithBounds),
+					plan.CreatePhysicalNode("count", count),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_range", fromWithBounds),
+					plan.CreatePhysicalNode("count", count),
+				},
+				Edges: [][2]int{{0, 1}},
+			},
+		},
+		{
+			Name: "from with multiple ranges",
+			// from -> range -> range  =>  from
+			Rules: []plan.Rule{&inputs.FromConversionRule{}, &inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", from),
+					plan.CreatePhysicalNode("range0", rangeWithBounds),
+					plan.CreatePhysicalNode("range1", rangeWithDifferentBounds),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_range0_range1", fromWithIntersectedBounds),
+				},
+			},
+		},
+		{
+			Name: "from range with multiple successor node",
+			// count      mean
+			//     \     /          count     mean
+			//      range       =>      \    /
+			//        |                  from
+			//       from
+			Rules: []plan.Rule{&inputs.FromConversionRule{}, &inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", from),
+					plan.CreatePhysicalNode("range", rangeWithBounds),
+					plan.CreatePhysicalNode("count", count),
+					plan.CreatePhysicalNode("yield0", yield("count")),
+					plan.CreatePhysicalNode("mean", mean),
+					plan.CreatePhysicalNode("yield1", yield("mean")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{1, 4},
+					{4, 5},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_range", fromWithBounds),
+					plan.CreatePhysicalNode("count", count),
+					plan.CreatePhysicalNode("yield0", yield("count")),
+					plan.CreatePhysicalNode("mean", mean),
+					plan.CreatePhysicalNode("yield1", yield("mean")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{0, 3},
+					{3, 4},
+				},
+			},
+		},
+		{
+			Name: "cannot push range into from",
+			// range    count                                      range    count
+			//     \    /       =>   cannot push range into a   =>     \    /
+			//      from           from with multiple successors        from
+			Rules: []plan.Rule{&inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+					}),
+					plan.CreatePhysicalNode("range", rangeWithBounds),
+					plan.CreatePhysicalNode("yield0", yield("range")),
+					plan.CreatePhysicalNode("count", count),
+					plan.CreatePhysicalNode("yield1", yield("count")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{0, 3},
+					{3, 4},
+				},
+			},
+			NoChange: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestFromFilterRule(t *testing.T) {
+	var (
+		bounds = flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		}
+
+		from = &inputs.FromProcedureSpec{}
+
+		physFrom = &inputs.PhysicalFromProcedureSpec{
+			FromProcedureSpec: from,
+			BoundsSet:         true,
+			Bounds:            bounds,
+		}
+
+		rangeWithBounds = &transformations.RangeProcedureSpec{
+			Bounds: bounds,
+		}
+
+		pushableExpr1 = &semantic.BinaryExpression{Operator: ast.EqualOperator,
+			Left:  &semantic.MemberExpression{Object: &semantic.IdentifierExpression{Name: "r"}, Property: "_measurement"},
+			Right: &semantic.StringLiteral{Value: "cpu"}}
+
+		pushableExpr2 = &semantic.BinaryExpression{Operator: ast.EqualOperator,
+			Left:  &semantic.MemberExpression{Object: &semantic.IdentifierExpression{Name: "r"}, Property: "_field"},
+			Right: &semantic.StringLiteral{Value: "cpu"}}
+
+		unpushableExpr = &semantic.BinaryExpression{Operator: ast.LessThanOperator,
+			Left:  &semantic.FloatLiteral{Value: 0.5},
+			Right: &semantic.MemberExpression{Object: &semantic.IdentifierExpression{Name: "r"}, Property: "_value"}}
+
+		statementFn = &semantic.FunctionExpression{
+			Block: &semantic.FunctionBlock{
+				Parameters: &semantic.FunctionParameters{
+					List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+				},
+				Body: &semantic.ReturnStatement{Argument: &semantic.BooleanLiteral{Value: true}},
+			},
+		}
+	)
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name: "from filter",
+			// from -> filter  =>  from
+			Rules: []plan.Rule{inputs.MergeFromFilterRule{}, inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr1)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_filter", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						BoundsSet:         true,
+						Bounds:            bounds,
+						FilterSet:         true,
+						Filter:            makeFilterFn(pushableExpr1),
+					}),
+				},
+			},
+		},
+		{
+			Name: "from filter filter",
+			// from -> filter -> filter  =>  from    (rule applied twice)
+			Rules: []plan.Rule{inputs.MergeFromFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("filter1", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr1)}),
+					plan.CreatePhysicalNode("filter2", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr2)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_filter1_filter2",
+						&inputs.PhysicalFromProcedureSpec{
+							FromProcedureSpec: from,
+							BoundsSet:         true,
+							Bounds:            bounds,
+							FilterSet:         true,
+							Filter:            makeFilterFn(pushableExpr1, pushableExpr2),
+						}),
+				},
+			},
+		},
+		{
+			Name: "from partially-pushable-filter",
+			// from -> partially-pushable-filter  =>  from-with-filter -> unpushable-filter
+			Rules: []plan.Rule{inputs.MergeFromFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr1, unpushableExpr)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from",
+						&inputs.PhysicalFromProcedureSpec{
+							FromProcedureSpec: from,
+							BoundsSet:         true,
+							Bounds:            bounds,
+							FilterSet:         true,
+							Filter:            makeFilterFn(pushableExpr1),
+						}),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(unpushableExpr)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+		},
+		{
+			Name: "from range filter",
+			// from -> range -> filter  =>  from
+			Rules: []plan.Rule{inputs.FromConversionRule{}, inputs.MergeFromFilterRule{}, inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", from),
+					plan.CreatePhysicalNode("range", rangeWithBounds),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr1)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_range_filter", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						BoundsSet:         true,
+						Bounds: flux.Bounds{
+							Start: fluxTime(5),
+							Stop:  fluxTime(10),
+						},
+						FilterSet: true,
+						Filter:    makeFilterFn(pushableExpr1),
+					}),
+				},
+			},
+		},
+		{
+			Name: "from unpushable filter",
+			// from -> filter  =>  from -> filter   (no change)
+			Rules: []plan.Rule{inputs.MergeFromFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", physFrom),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(unpushableExpr)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+		{
+			Name: "from with statement filter",
+			// from -> filter(with statement function)  =>  from -> filter(with statement function)  (no change)
+			Rules: []plan.Rule{inputs.MergeFromFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", physFrom),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: statementFn}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestFromDistinctRule(t *testing.T) {
+
+	var (
+		from     = &inputs.FromProcedureSpec{}
+		physFrom = &inputs.PhysicalFromProcedureSpec{
+			FromProcedureSpec: from,
+		}
+	)
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name:  "from distinct",
+			Rules: []plan.Rule{inputs.FromDistinctRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_measurement"}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						LimitSet:          true,
+						PointsLimit:       -1,
+					}),
+					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_measurement"}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+		},
+		{
+			Name: "from incompatible-group distinct",
+			// If there is an incompatible grouping, don't do the no points optimization.
+			Rules: []plan.Rule{inputs.FromDistinctRule{}, inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeBy,
+						GroupKeys: []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_field"}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_group", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						GroupingSet:       true,
+						GroupMode:         functions.GroupModeBy,
+						GroupKeys:         []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_field"}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestFromGroupRule(t *testing.T) {
+	var (
+		rangeWithBounds = &transformations.RangeProcedureSpec{
+			Bounds: flux.Bounds{
+				Start: fluxTime(5),
+				Stop:  fluxTime(10),
+			},
+		}
+		from     = &inputs.FromProcedureSpec{}
+		physFrom = &inputs.PhysicalFromProcedureSpec{
+			FromProcedureSpec: from,
+		}
+
+		pushableExpr1 = &semantic.BinaryExpression{Operator: ast.EqualOperator,
+			Left:  &semantic.MemberExpression{Object: &semantic.IdentifierExpression{Name: "r"}, Property: "_measurement"},
+			Right: &semantic.StringLiteral{Value: "cpu"}}
+	)
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name:  "from group",
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeBy,
+						GroupKeys: []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr1)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_group", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						GroupingSet:       true,
+						GroupMode:         functions.GroupModeBy,
+						GroupKeys:         []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("filter", &transformations.FilterProcedureSpec{Fn: makeFilterFn(pushableExpr1)}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+		},
+		{
+			Name: "from group group",
+			// Only push down one call to group()
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeBy,
+						GroupKeys: []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeBy,
+						GroupKeys: []string{"_field"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_group", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						GroupingSet:       true,
+						GroupMode:         functions.GroupModeBy,
+						GroupKeys:         []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeBy,
+						GroupKeys: []string{"_field"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+		},
+		{
+			Name: "from range group distinct group",
+			Rules: []plan.Rule{inputs.FromConversionRule{}, inputs.MergeFromGroupRule{},
+				inputs.FromDistinctRule{}, inputs.MergeFromRangeRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", from),
+					plan.CreatePhysicalNode("range", rangeWithBounds),
+					plan.CreatePhysicalNode("group1", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeBy,
+						GroupKeys: []string{"_measurement"},
+					}),
+					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_measurement"}),
+					plan.CreatePhysicalNode("group2", &transformations.GroupProcedureSpec{GroupMode: functions.GroupModeNone}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("merged_from_range_group1", &inputs.PhysicalFromProcedureSpec{
+						FromProcedureSpec: from,
+						BoundsSet:         true,
+						Bounds:            flux.Bounds{Start: fluxTime(5), Stop: fluxTime(10)},
+						GroupingSet:       true,
+						GroupMode:         functions.GroupModeBy,
+						GroupKeys:         []string{"_measurement"},
+						LimitSet:          true,
+						PointsLimit:       -1,
+					}),
+					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_measurement"}),
+					plan.CreatePhysicalNode("group2", &transformations.GroupProcedureSpec{GroupMode: functions.GroupModeNone}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+		},
+		{
+			Name: "from group except",
+			// We should not push down group() with GroupModeExcept, storage does not yet support it.
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreateLogicalNode("from", physFrom),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeExcept,
+						GroupKeys: []string{"_time", "_value"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+		{
+			Name: "from group _time",
+			// We should not push down group(columns: ["_time"])
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeExcept,
+						GroupKeys: []string{"_time"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+		{
+			Name: "from group _value",
+			// We should not push down group(columns: ["_value"])
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", physFrom),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeExcept,
+						GroupKeys: []string{"_value"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestFromRangeValidation(t *testing.T) {
+	testSpec := plantest.PlanSpec{
+		//       3
+		//     /  \
+		//    /    \
+		//   1      2
+		//    \    /
+		//     from
+		Nodes: []plan.PlanNode{
+			plan.CreateLogicalNode("from", &inputs.FromProcedureSpec{}),
+			plantest.CreatePhysicalMockNode("1"),
+			plantest.CreatePhysicalMockNode("2"),
+			plantest.CreatePhysicalMockNode("3"),
+		},
+		Edges: [][2]int{
+			{0, 1},
+			{0, 2},
+			{1, 3},
+			{2, 3},
+		},
+	}
+
+	ps := plantest.CreatePlanSpec(&testSpec)
+	pp := plan.NewPhysicalPlanner(plan.OnlyPhysicalRules())
+	_, err := pp.Plan(ps)
+
+	if err == nil {
+		t.Error("Expected from with no range to fail physical planning")
 	}
 }


### PR DESCRIPTION
Tests fail until https://github.com/influxdata/flux/pull/541 has been merged to master in Flux and the change is propagated to `flux-staging`.

_Briefly describe your proposed changes:_
Move `from` to platform.

_What was the problem?_
Flux erroneously contained the storage-dependent code for the `from` operation.  
`FromOpSpec` couldn't implement `BucketAwareOperationSpec` defined in `platform` due to a cyclic dependency.

_What was the solution?_
Now Flux contains only `FromOpSpec` and registers it. It does not register the function, nor the procedure spec (it does in testing packages). Platform registers the function and creates an operation spec that implements `BucketAwareOperationSpec`.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)