### PR TITLE
Display red x in sidebar when plugin config is invalid

### DIFF
--- a/ui/src/onboarding/components/OnboardingSideBar.tsx
+++ b/ui/src/onboarding/components/OnboardingSideBar.tsx
@@ -34,6 +34,8 @@ const configStateToTabStatus = (cs: ConfigurationState): TabStatus => {
   switch (cs) {
     case ConfigurationState.Unconfigured:
       return TabStatus.Default
+    case ConfigurationState.InvalidConfiguration:
+      return TabStatus.Error
     case ConfigurationState.Configured:
       return TabStatus.Success
   }

--- a/ui/src/onboarding/reducers/dataLoaders.test.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.test.ts
@@ -148,7 +148,7 @@ describe('dataLoader reducer', () => {
         },
         {
           name: TelegrafPluginInputFile.NameEnum.File,
-          configured: ConfigurationState.Unconfigured,
+          configured: ConfigurationState.InvalidConfiguration,
           active: false,
           plugin: {
             name: TelegrafPluginInputFile.NameEnum.File,

--- a/ui/src/onboarding/reducers/dataLoaders.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.ts
@@ -248,7 +248,10 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
             )
 
             if (!isValidConfig || _.isEmpty(config)) {
-              return {...tp, configured: ConfigurationState.Unconfigured}
+              return {
+                ...tp,
+                configured: ConfigurationState.InvalidConfiguration,
+              }
             } else {
               return {...tp, configured: ConfigurationState.Configured}
             }

--- a/ui/src/types/v2/dataLoaders.ts
+++ b/ui/src/types/v2/dataLoaders.ts
@@ -50,6 +50,7 @@ export interface DataLoadersState {
 
 export enum ConfigurationState {
   Unconfigured = 'unconfigured',
+  InvalidConfiguration = 'invalid',
   Configured = 'configured',
 }
 


### PR DESCRIPTION
Closes #1971

_What was the problem?_
Previously, the symbol for a plugin config was an open circle whether the user had not yet set any fields on it or if the fields were invalid.

_What was the solution?_
The circle will now be the default symbol when a user has not yet modified a plugin configuration. If the plugin configuration is modified and is invalid, a red x will be shown instead.

  - [x] Rebased/mergeable
  - [x] Tests pass
