### PR TITLE
remove multiple calls to w.WriteHeader in http handlers

### DIFF
--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -92,8 +92,7 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newAuthResponse(req.Authorization)); err != nil {
-		h.Logger.Info("failed to encode response", zap.String("handler", "postAuthorization"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -133,8 +132,7 @@ func (h *AuthorizationHandler) handleGetAuthorizations(w http.ResponseWriter, r 
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newAuthsResponse(opts, req.filter, as)); err != nil {
-		h.Logger.Info("failed to encode response", zap.String("handler", "getAuthorizations"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -193,8 +191,7 @@ func (h *AuthorizationHandler) handleGetAuthorization(w http.ResponseWriter, r *
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newAuthResponse(a)); err != nil {
-		h.Logger.Info("failed to encode response", zap.String("handler", "getAuthorization"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -246,8 +243,7 @@ func (h *AuthorizationHandler) handleSetAuthorizationStatus(w http.ResponseWrite
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newAuthResponse(a)); err != nil {
-		h.Logger.Info("failed to encode response", zap.String("handler", "updateAuthorization"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -72,11 +72,6 @@ func (h *AuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	scheme, err := ProbeAuthScheme(r)
 	if err != nil {
 		ForbiddenError(ctx, err, w)
-		// THIS IS TEMPORARY, remove after all errors endpoints converted.
-		EncodeError(ctx, &platform.Error{
-			Code: platform.EForbidden,
-			Err:  err,
-		}, w)
 		return
 	}
 
@@ -100,12 +95,6 @@ func (h *AuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	ForbiddenError(ctx, fmt.Errorf("unauthorized"), w)
-	// THIS IS TEMPORARY, remove after all errors endpoints converted.
-	EncodeError(ctx, &platform.Error{
-		Code: platform.EForbidden,
-		Msg:  "unauthorized",
-	}, w)
-
 }
 
 func (h *AuthenticationHandler) extractAuthorization(ctx context.Context, r *http.Request) (context.Context, error) {

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -13,11 +13,14 @@ import (
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/kit/errors"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // BucketHandler represents an HTTP API handler for buckets.
 type BucketHandler struct {
 	*httprouter.Router
+
+	Logger *zap.Logger
 
 	BucketService              platform.BucketService
 	BucketOperationLogService  platform.BucketOperationLogService
@@ -42,6 +45,7 @@ const (
 func NewBucketHandler(mappingService platform.UserResourceMappingService, labelService platform.LabelService) *BucketHandler {
 	h := &BucketHandler{
 		Router:                     NewRouter(),
+		Logger:                     zap.NewNop(),
 		UserResourceMappingService: mappingService,
 		LabelService:               labelService,
 	}
@@ -228,7 +232,7 @@ func (h *BucketHandler) handlePostBucket(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newBucketResponse(req.Bucket)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -279,7 +283,7 @@ func (h *BucketHandler) handleGetBucket(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newBucketResponse(b)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -363,7 +367,7 @@ func (h *BucketHandler) handleGetBuckets(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newBucketsResponse(req.opts, req.filter, bs)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -420,7 +424,7 @@ func (h *BucketHandler) handlePatchBucket(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newBucketResponse(b)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -709,7 +713,7 @@ func (h *BucketHandler) handleGetBucketLog(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newBucketLogResponse(req.BucketID, log)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -13,11 +13,14 @@ import (
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/kit/errors"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // DashboardHandler is the handler for the dashboard service
 type DashboardHandler struct {
 	*httprouter.Router
+
+	Logger *zap.Logger
 
 	DashboardService             platform.DashboardService
 	DashboardOperationLogService platform.DashboardOperationLogService
@@ -44,6 +47,7 @@ const (
 func NewDashboardHandler(mappingService platform.UserResourceMappingService, labelService platform.LabelService) *DashboardHandler {
 	h := &DashboardHandler{
 		Router:                     NewRouter(),
+		Logger:                     zap.NewNop(),
 		UserResourceMappingService: mappingService,
 		LabelService:               labelService,
 	}
@@ -231,7 +235,7 @@ func (h *DashboardHandler) handleGetDashboards(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newGetDashboardsResponse(dashboards)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -320,7 +324,7 @@ func (h *DashboardHandler) handlePostDashboard(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newDashboardResponse(req.Dashboard)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -356,7 +360,7 @@ func (h *DashboardHandler) handleGetDashboard(w http.ResponseWriter, r *http.Req
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newDashboardResponse(dashboard)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -399,7 +403,7 @@ func (h *DashboardHandler) handleGetDashboardLog(w http.ResponseWriter, r *http.
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newDashboardLogResponse(req.DashboardID, log)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -502,7 +506,7 @@ func (h *DashboardHandler) handlePatchDashboard(w http.ResponseWriter, r *http.R
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newDashboardResponse(dashboard)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -600,7 +604,7 @@ func (h *DashboardHandler) handlePostDashboardCell(w http.ResponseWriter, r *htt
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newDashboardCellResponse(req.dashboardID, req.cell)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -646,7 +650,7 @@ func (h *DashboardHandler) handlePutDashboardCells(w http.ResponseWriter, r *htt
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newDashboardCellsResponse(req.dashboardID, req.cells)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -758,7 +762,7 @@ func (h *DashboardHandler) handlePatchDashboardCell(w http.ResponseWriter, r *ht
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newDashboardCellResponse(req.dashboardID, cell)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/errors.go
+++ b/http/errors.go
@@ -158,7 +158,10 @@ func encodeKError(e kerrors.Error, w http.ResponseWriter) {
 
 // ForbiddenError encodes error with a forbidden status code.
 func ForbiddenError(ctx context.Context, err error, w http.ResponseWriter) {
-	EncodeError(ctx, kerrors.Forbiddenf(err.Error()), w)
+	EncodeError(ctx, &platform.Error{
+		Code: platform.EForbidden,
+		Err:  err,
+	}, w)
 }
 
 // statusCode returns the http status code for an error.

--- a/http/handler.go
+++ b/http/handler.go
@@ -203,6 +203,16 @@ func (h *Handler) initMetrics() {
 	}, []string{"handler", "method", "path", "status"})
 }
 
+func logEncodingError(logger *zap.Logger, r *http.Request, err error) {
+	// If we encounter an error while encoding the response to an http request
+	// the best thing we can do is log that error, as we may have already written
+	// the headers for the http request in question.
+	logger.Info("error encoding response",
+		zap.String("path", r.URL.Path),
+		zap.String("method", r.Method),
+		zap.Error(err))
+}
+
 // InjectTrace writes any span from the request's context into the request headers.
 func InjectTrace(r *http.Request) {
 	if span := opentracing.SpanFromContext(r.Context()); span != nil {

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -69,6 +69,9 @@ func newGetLabelsHandler(s plat.LabelService) http.HandlerFunc {
 		}
 
 		if err := encodeResponse(ctx, w, http.StatusOK, newLabelsResponse(opts, req.filter, labels)); err != nil {
+			// TODO: this can potentially result in calling w.WriteHeader multiple times, we need to pass a logger in here
+			// some how. This isn't as simple as simply passing in a logger to this function since the time that this function
+			// is called is distinct from the time that a potential logger is set.
 			EncodeError(ctx, err, w)
 			return
 		}
@@ -129,6 +132,9 @@ func newPostLabelHandler(s plat.LabelService) http.HandlerFunc {
 		}
 
 		if err := encodeResponse(ctx, w, http.StatusCreated, newLabelResponse(label)); err != nil {
+			// TODO: this can potentially result in calling w.WriteHeader multiple times, we need to pass a logger in here
+			// some how. This isn't as simple as simply passing in a logger to this function since the time that this function
+			// is called is distinct from the time that a potential logger is set.
 			EncodeError(ctx, err, w)
 			return
 		}
@@ -222,6 +228,9 @@ func newPatchLabelHandler(s plat.LabelService) http.HandlerFunc {
 		}
 
 		if err := encodeResponse(ctx, w, http.StatusOK, newLabelResponse(label)); err != nil {
+			// TODO: this can potentially result in calling w.WriteHeader multiple times, we need to pass a logger in here
+			// some how. This isn't as simple as simply passing in a logger to this function since the time that this function
+			// is called is distinct from the time that a potential logger is set.
 			EncodeError(ctx, err, w)
 			return
 		}

--- a/http/macro_service.go
+++ b/http/macro_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/platform"
 	kerrors "github.com/influxdata/platform/kit/errors"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 const (
@@ -21,6 +22,8 @@ const (
 type MacroHandler struct {
 	*httprouter.Router
 
+	Logger *zap.Logger
+
 	MacroService platform.MacroService
 }
 
@@ -28,6 +31,7 @@ type MacroHandler struct {
 func NewMacroHandler() *MacroHandler {
 	h := &MacroHandler{
 		Router: NewRouter(),
+		Logger: zap.NewNop(),
 	}
 
 	h.HandlerFunc("GET", "/api/v2/macros", h.handleGetMacros)
@@ -83,7 +87,7 @@ func (h *MacroHandler) handleGetMacros(w http.ResponseWriter, r *http.Request) {
 
 	err = encodeResponse(ctx, w, http.StatusOK, newGetMacrosResponse(macros))
 	if err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -123,7 +127,7 @@ func (h *MacroHandler) handleGetMacro(w http.ResponseWriter, r *http.Request) {
 
 	err = encodeResponse(ctx, w, http.StatusOK, newMacroResponse(macro))
 	if err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -163,7 +167,7 @@ func (h *MacroHandler) handlePostMacro(w http.ResponseWriter, r *http.Request) {
 
 	err = encodeResponse(ctx, w, http.StatusCreated, newMacroResponse(req.macro))
 	if err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -212,7 +216,7 @@ func (h *MacroHandler) handlePatchMacro(w http.ResponseWriter, r *http.Request) 
 
 	err = encodeResponse(ctx, w, http.StatusOK, newMacroResponse(macro))
 	if err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -268,7 +272,7 @@ func (h *MacroHandler) handlePutMacro(w http.ResponseWriter, r *http.Request) {
 
 	err = encodeResponse(ctx, w, http.StatusOK, newMacroResponse(req.macro))
 	if err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/onboarding.go
+++ b/http/onboarding.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/influxdata/platform"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // SetupHandler represents an HTTP API handler for onboarding setup.
 type SetupHandler struct {
 	*httprouter.Router
+
+	Logger *zap.Logger
 
 	OnboardingService platform.OnboardingService
 }
@@ -25,6 +28,7 @@ const (
 func NewSetupHandler() *SetupHandler {
 	h := &SetupHandler{
 		Router: NewRouter(),
+		Logger: zap.NewNop(),
 	}
 	h.HandlerFunc("POST", setupPath, h.handlePostSetup)
 	h.HandlerFunc("GET", setupPath, h.isOnboarding)
@@ -44,7 +48,7 @@ func (h *SetupHandler) isOnboarding(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusOK, isOnboardingResponse{result}); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -64,7 +68,7 @@ func (h *SetupHandler) handlePostSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusCreated, newOnboardingResponse(results)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -12,11 +12,14 @@ import (
 	"github.com/influxdata/platform"
 	kerrors "github.com/influxdata/platform/kit/errors"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // OrgHandler represents an HTTP API handler for orgs.
 type OrgHandler struct {
 	*httprouter.Router
+
+	Logger *zap.Logger
 
 	OrganizationService             platform.OrganizationService
 	OrganizationOperationLogService platform.OrganizationOperationLogService
@@ -47,6 +50,7 @@ func NewOrgHandler(mappingService platform.UserResourceMappingService,
 	labelService platform.LabelService) *OrgHandler {
 	h := &OrgHandler{
 		Router:                     NewRouter(),
+		Logger:                     zap.NewNop(),
 		UserResourceMappingService: mappingService,
 		LabelService:               labelService,
 	}
@@ -155,7 +159,7 @@ func (h *OrgHandler) handlePostOrg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newOrgResponse(req.Org)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -192,7 +196,7 @@ func (h *OrgHandler) handleGetOrg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newOrgResponse(b)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -237,7 +241,7 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newOrgsResponse(orgs)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -322,7 +326,7 @@ func (h *OrgHandler) handlePatchOrg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newOrgResponse(o)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -372,7 +376,7 @@ func (h *OrgHandler) handleGetSecrets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newSecretsResponse(req.orgID, ks)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -704,7 +708,7 @@ func (h *OrgHandler) handleGetOrgLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newOrganizationLogResponse(req.OrganizationID, log)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -122,7 +122,7 @@ func (h *FluxHandler) postFluxAST(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -143,7 +143,7 @@ func (h *FluxHandler) postQueryAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusOK, a); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -174,7 +174,7 @@ func (h *FluxHandler) postFluxSpec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -223,7 +223,7 @@ func (h *FluxHandler) getFluxSuggestions(w http.ResponseWriter, r *http.Request)
 	res := suggestionsResponse{Functions: functions}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -242,7 +242,7 @@ func (h *FluxHandler) getFluxSuggestion(w http.ResponseWriter, r *http.Request) 
 
 	res := suggestionResponse{Name: name, Params: suggestion.Params}
 	if err := encodeResponse(ctx, w, http.StatusOK, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -10,11 +10,13 @@ import (
 	"github.com/influxdata/platform"
 	kerrors "github.com/influxdata/platform/kit/errors"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // ScraperHandler represents an HTTP API handler for scraper targets.
 type ScraperHandler struct {
 	*httprouter.Router
+	Logger                *zap.Logger
 	ScraperStorageService platform.ScraperTargetStoreService
 }
 
@@ -26,6 +28,7 @@ const (
 func NewScraperHandler() *ScraperHandler {
 	h := &ScraperHandler{
 		Router: NewRouter(),
+		Logger: zap.NewNop(),
 	}
 	h.HandlerFunc("POST", targetPath, h.handlePostScraperTarget)
 	h.HandlerFunc("GET", targetPath, h.handleGetScraperTargets)
@@ -50,7 +53,7 @@ func (h *ScraperHandler) handlePostScraperTarget(w http.ResponseWriter, r *http.
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusCreated, newTargetResponse(*req)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -90,7 +93,7 @@ func (h *ScraperHandler) handlePatchScraperTarget(w http.ResponseWriter, r *http
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTargetResponse(*target)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -110,7 +113,7 @@ func (h *ScraperHandler) handleGetScraperTarget(w http.ResponseWriter, r *http.R
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTargetResponse(*target)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -126,7 +129,7 @@ func (h *ScraperHandler) handleGetScraperTargets(w http.ResponseWriter, r *http.
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newListTargetsResponse(targets)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/server.go
+++ b/http/server.go
@@ -39,7 +39,8 @@ func NewServer(handler http.Handler, logger *zap.Logger) *Server {
 	return &Server{
 		ShutdownTimeout: DefaultShutdownTimeout,
 		srv: &http.Server{
-			Handler: handler,
+			Handler:  handler,
+			ErrorLog: zap.NewStdLog(logger),
 		},
 		logger: logger,
 	}

--- a/http/source_service.go
+++ b/http/source_service.go
@@ -222,9 +222,8 @@ func (h *SourceHandler) handleGetSourcesBuckets(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// TODO(desa): enrich returned data structure.
 	if err := encodeResponse(ctx, w, http.StatusOK, bs); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -267,7 +266,7 @@ func (h *SourceHandler) handlePostSource(w http.ResponseWriter, r *http.Request)
 	res := newSourceResponse(req.Source)
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -306,7 +305,7 @@ func (h *SourceHandler) handleGetSource(w http.ResponseWriter, r *http.Request) 
 	res := newSourceResponse(s)
 
 	if err := encodeResponse(ctx, w, http.StatusOK, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -398,7 +397,7 @@ func (h *SourceHandler) handleGetSources(w http.ResponseWriter, r *http.Request)
 	res := newSourcesResponse(srcs)
 
 	if err := encodeResponse(ctx, w, http.StatusOK, res); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -429,7 +428,7 @@ func (h *SourceHandler) handlePatchSource(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, b); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -204,7 +204,7 @@ func (h *TaskHandler) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTasksResponse(tasks)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -294,7 +294,7 @@ func (h *TaskHandler) handlePostTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newTaskResponse(*req.Task)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -330,7 +330,7 @@ func (h *TaskHandler) handleGetTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTaskResponse(*task)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -374,7 +374,7 @@ func (h *TaskHandler) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTaskResponse(*task)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -461,7 +461,7 @@ func (h *TaskHandler) handleGetLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, logs); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -528,7 +528,7 @@ func (h *TaskHandler) handleGetRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newRunsResponse(runs, *req.filter.Task)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -630,7 +630,7 @@ func (h *TaskHandler) handleGetRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newRunResponse(*run)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }
@@ -727,7 +727,7 @@ func (h *TaskHandler) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusOK, newRunResponse(*run)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.logger, r, err)
 		return
 	}
 }

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -136,7 +136,7 @@ func (h *TelegrafHandler) handleGetTelegrafs(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusOK, newTelegrafResponses(tcs)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -166,7 +166,7 @@ func (h *TelegrafHandler) handleGetTelegraf(w http.ResponseWriter, r *http.Reque
 		w.Write([]byte(tc.TOML()))
 	case "application/json":
 		if err := encodeResponse(ctx, w, http.StatusOK, newTelegrafResponse(tc)); err != nil {
-			EncodeError(ctx, err, w)
+			logEncodingError(h.Logger, r, err)
 			return
 		}
 	default:
@@ -245,7 +245,7 @@ func (h *TelegrafHandler) handlePostTelegraf(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newTelegrafResponse(tc)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -273,7 +273,7 @@ func (h *TelegrafHandler) handlePutTelegraf(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTelegrafResponse(tc)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -292,7 +292,7 @@ func (h *TelegrafHandler) handleDeleteTelegraf(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusNoContent, nil); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/usage_service.go
+++ b/http/usage_service.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/influxdata/platform"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // UsageHandler represents an HTTP API handler for usages.
 type UsageHandler struct {
 	*httprouter.Router
+
+	Logger *zap.Logger
 
 	UsageService platform.UsageService
 }
@@ -21,6 +24,7 @@ type UsageHandler struct {
 func NewUsageHandler() *UsageHandler {
 	h := &UsageHandler{
 		Router: NewRouter(),
+		Logger: zap.NewNop(),
 	}
 
 	h.HandlerFunc("GET", "/api/v2/usage", h.handleGetUsage)
@@ -44,7 +48,7 @@ func (h *UsageHandler) handleGetUsage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, b); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/view_service.go
+++ b/http/view_service.go
@@ -9,11 +9,14 @@ import (
 	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/kit/errors"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // ViewHandler is the handler for the view service
 type ViewHandler struct {
 	*httprouter.Router
+
+	Logger *zap.Logger
 
 	ViewService                platform.ViewService
 	UserResourceMappingService platform.UserResourceMappingService
@@ -36,6 +39,7 @@ const (
 func NewViewHandler(mappingService platform.UserResourceMappingService, labelService platform.LabelService) *ViewHandler {
 	h := &ViewHandler{
 		Router:                     NewRouter(),
+		Logger:                     zap.NewNop(),
 		UserResourceMappingService: mappingService,
 		LabelService:               labelService,
 	}
@@ -111,7 +115,7 @@ func (h *ViewHandler) handleGetViews(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newGetViewsResponse(views)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -169,7 +173,7 @@ func (h *ViewHandler) handlePostViews(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newViewResponse(req.View)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -208,7 +212,7 @@ func (h *ViewHandler) handleGetView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newViewResponse(view)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
@@ -295,7 +299,7 @@ func (h *ViewHandler) handlePatchView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newViewResponse(view)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }


### PR DESCRIPTION
Closes #1904 
Closes #1602

_Briefly describe your proposed changes:_

This PR removes potential second calls to `w.WriteHeader` and replaces it with a log that there was an error during encoding.

_What was the problem?_

1. There were places where explicit multiple calls to w.WriteHeader. Those were removed.
2. Loggers were added to each handler that encoded responses and log lines were added instead.
3. Notes where other potential calls to w.WriteHeader were added.

  - [ ] Rebased/mergeable
  - [ ] Tests pass