### PR TITLE
Update swagger doc for /api/v2/ response

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -142,21 +142,17 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 }
 
 var apiLinks = map[string]interface{}{
-	"signin":         "/api/v2/signin",
-	"signout":        "/api/v2/signout",
-	"setup":          "/api/v2/setup",
-	"sources":        "/api/v2/sources",
-	"dashboards":     "/api/v2/dashboards",
-	"views":          "/api/v2/views",
-	"write":          "/api/v2/write",
-	"orgs":           "/api/v2/orgs",
+	// when adding new links, please take care to keep this list alphabetical
+	// as this makes it easier to verify values against the swagger document.
 	"authorizations": "/api/v2/authorizations",
 	"buckets":        "/api/v2/buckets",
-	"users":          "/api/v2/users",
-	"me":             "/api/v2/me",
-	"tasks":          "/api/v2/tasks",
-	"macros":         "/api/v2/macros",
-	"telegrafs":      "/api/v2/telegrafs",
+	"dashboards":     "/api/v2/dashboards",
+	"external": map[string]string{
+		"statusFeed": "https://www.influxdata.com/feed/json",
+	},
+	"macros": "/api/v2/macros",
+	"me":     "/api/v2/me",
+	"orgs":   "/api/v2/orgs",
 	"query": map[string]string{
 		"self":        "/api/v2/query",
 		"ast":         "/api/v2/query/ast",
@@ -164,14 +160,20 @@ var apiLinks = map[string]interface{}{
 		"spec":        "/api/v2/query/spec",
 		"suggestions": "/api/v2/query/suggestions",
 	},
-	"external": map[string]string{
-		"statusFeed": "https://www.influxdata.com/feed/json",
-	},
+	"setup":   "/api/v2/setup",
+	"signin":  "/api/v2/signin",
+	"signout": "/api/v2/signout",
+	"sources": "/api/v2/sources",
 	"system": map[string]string{
 		"metrics": "/metrics",
 		"debug":   "/debug/pprof",
 		"health":  "/health",
 	},
+	"tasks":     "/api/v2/tasks",
+	"telegrafs": "/api/v2/telegrafs",
+	"users":     "/api/v2/users",
+	"views":     "/api/v2/views",
+	"write":     "/api/v2/write",
 }
 
 func (h *APIHandler) serveLinks(w http.ResponseWriter, r *http.Request) {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4910,31 +4910,58 @@ components:
           format: uri
     Routes:
       properties:
-        sources:
-          type: string
-          format: uri
-        dashboards:
-          type: string
-          format: uri
-        query:
-          type: string
-          format: uri
-        write:
-          type: string
-          format: uri
-        orgs:
-          type: string
-          format: uri
         authorizations:
           type: string
           format: uri
         buckets:
           type: string
           format: uri
-        users:
+        dashboards:
           type: string
           format: uri
-        tasks:
+        external:
+          type: object
+          properties:
+            statusFeed:
+              type: string
+              format: uri
+        macros:
+          type: string
+          format: uri
+        me:
+          type: string
+          format: uri
+        orgs:
+          type: string
+          format: uri
+        query:
+          type: object
+          properties:
+            self:
+              type: string
+              format: uri
+            ast:
+              type: string
+              format: uri
+            analyze:
+              type: string
+              format: uri
+            spec:
+              type: string
+              format: uri
+            suggestions:
+              type: string
+              format: uri
+        setup:
+          type: string
+          format: uri
+        signin:
+          type: string
+          format: uri
+        signout:
+          type: string
+          format: uri
+        sources:
           type: string
           format: uri
         system:
@@ -4949,14 +4976,21 @@ components:
             health:
               type: string
               format: uri
-        external:
-          type: object
-          properties:
-            statusFeed:
-              type: string
-              format: uri
-        flux:
-          $ref: "#/components/schemas/FluxLinks"
+        tasks:
+          type: string
+          format: uri
+        telegrafs:
+          type: string
+          format: uri
+        users:
+          type: string
+          format: uri
+        write:
+          type: string
+          format: uri
+        views:
+          type: string
+          format: uri
     Error:
       properties:
         code:


### PR DESCRIPTION
Closes #1873 

_Briefly describe your proposed changes:_
The swagger for the top level links had become out of sync with what the api handler returned.

I alphabetized both the links in the code and in the swagger doc so that future additions are easier to make and verify.

  - [x] Rebased/mergeable
  - [x] Tests pass
