### PR TITLE
Make onboarding token description "<users name>'s token"

### DIFF
--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
@@ -10,8 +11,6 @@ import (
 
 var onboardingBucket = []byte("onboardingv1")
 var onboardingKey = []byte("onboarding_key")
-
-const onboardingTokenDesc = "Deftok"
 
 var _ platform.OnboardingService = (*Client)(nil)
 
@@ -121,7 +120,7 @@ func (c *Client) Generate(ctx context.Context, req *platform.OnboardingRequest) 
 	auth := &platform.Authorization{
 		User:        u.Name,
 		UserID:      u.ID,
-		Description: onboardingTokenDesc,
+		Description: fmt.Sprintf("%s's Token", u.Name),
 		Permissions: []platform.Permission{
 			platform.CreateUserPermission,
 			platform.DeleteUserPermission,

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4502,6 +4502,9 @@ components:
         user:
           type: string
           description: name of user.
+        description:
+          type: string
+          description: a description of the token.
         permissions:
           type: array
           items:

--- a/inmem/onboarding.go
+++ b/inmem/onboarding.go
@@ -2,13 +2,13 @@ package inmem
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/influxdata/platform"
 )
 
 const onboardingKey = "onboarding_key"
-const onboardingTokenDesc = "Deftok"
 
 var _ platform.OnboardingService = (*Service)(nil)
 
@@ -95,7 +95,7 @@ func (s *Service) Generate(ctx context.Context, req *platform.OnboardingRequest)
 	auth := &platform.Authorization{
 		User:        u.Name,
 		UserID:      u.ID,
-		Description: onboardingTokenDesc,
+		Description: fmt.Sprintf("%s's Token", u.Name),
 		Permissions: []platform.Permission{
 			platform.CreateUserPermission,
 			platform.DeleteUserPermission,

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -169,7 +169,7 @@ func Generate(
 						Status:      platform.Active,
 						User:        "admin",
 						UserID:      MustIDBase16(oneID),
-						Description: "Deftok",
+						Description: "admin's Token",
 						Permissions: []platform.Permission{
 							platform.CreateUserPermission,
 							platform.DeleteUserPermission,


### PR DESCRIPTION
Closes #1861 

_Briefly describe your proposed changes:_
This PR renames the onboarding token description to be `<user name>'s` and adds the token description to swagger.

  - [x] Rebased/mergeable
  - [x] Tests pass
