### PR TITLE
chore(ci): Run make generate

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,8 @@ builds:
       - GO111MODULE=on
     ldflags: -s -w -X main.commit={{.Commit}}
     binary: influxd
+    hooks:
+      pre: make generate
 
 archive:
   format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ bench:
 
 build: all
 
-nightly: build
+nightly:
 	$(GO_RUN) github.com/goreleaser/goreleaser --snapshot --rm-dist --publish-snapshots
 
 clean:


### PR DESCRIPTION
goreleaser must run make generate before compiling influxd. This will generate the required files for chronograf to be included.

Closes #2050