### PR TITLE
fix(http): health endpoint now returns pass

### DIFF
--- a/http/health.go
+++ b/http/health.go
@@ -7,6 +7,8 @@ import (
 
 // HealthHandler returns the status of the process.
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	msg := `{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[]}`
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, `{"message": "howdy y'all", "status": "healthy"}`)
+	fmt.Fprintln(w, msg)
 }

--- a/http/health_test.go
+++ b/http/health_test.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+	tests := []struct {
+		name  string
+		w     *httptest.ResponseRecorder
+		r     *http.Request
+		wants wants
+	}{
+		{
+			name: "health endpoint returns pass",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest(http.MethodGet, "/health", nil),
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json; charset=utf-8",
+				body:        `{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[]}`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			HealthHandler(tt.w, tt.r)
+			res := tt.w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. HealthHandler() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. HealthHandler() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. HealthHandler() = \n***%v***\n,\nwant\n***%v***", tt.name, string(body), tt.wants.body)
+			}
+		})
+	}
+}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6707,7 +6707,7 @@ components:
           type: string
           enum:
             - pass
-            - failo
+            - fail
     Labels:
       type: array
       items:


### PR DESCRIPTION
Closes #2021 

_Briefly describe your proposed changes:_
Update /health endpoint to give the most basic answer possible.

_What was the problem?_
Health endpoint was sending back "healthy" whereas swagger check is now "pass" and "fail."

_What was the solution?_

Update and add the test.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)