### PR TITLE
fix(http): change /query to use org/orgID

### DIFF
--- a/http/requests.go
+++ b/http/requests.go
@@ -9,9 +9,9 @@ import (
 
 const (
 	// OrgName is the http query parameter to specify an organization by name.
-	OrgName = "organization"
+	OrgName = "org"
 	// OrgID is the http query parameter to specify an organization by ID.
-	OrgID = "organizationID"
+	OrgID = "orgID"
 )
 
 // queryOrganization returns the organization for any http request.

--- a/http/requests_test.go
+++ b/http/requests_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -39,7 +38,10 @@ func Test_queryOrganization(t *testing.T) {
 								ID: platform.ID(1),
 							}, nil
 						}
-						return nil, fmt.Errorf("unknown ID")
+						return nil, &platform.Error{
+							Code: platform.EInvalid,
+							Msg:  "unknown org name",
+						}
 					},
 				},
 			},
@@ -69,7 +71,10 @@ func Test_queryOrganization(t *testing.T) {
 								Name: "org1",
 							}, nil
 						}
-						return nil, fmt.Errorf("unknown org name")
+						return nil, &platform.Error{
+							Code: platform.EInvalid,
+							Msg:  "unknown org name",
+						}
 					},
 				},
 			},

--- a/http/requests_test.go
+++ b/http/requests_test.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/mock"
+)
+
+func Test_queryOrganization(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		r   *http.Request
+		svc platform.OrganizationService
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *platform.Organization
+		wantErr bool
+	}{
+		{
+			name: "org id finds organization",
+			want: &platform.Organization{
+				ID: platform.ID(1),
+			},
+			args: args{
+				ctx: context.Background(),
+				r:   httptest.NewRequest(http.MethodPost, "/api/v2/query?orgID=0000000000000001", nil),
+				svc: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+						if *filter.ID == platform.ID(1) {
+							return &platform.Organization{
+								ID: platform.ID(1),
+							}, nil
+						}
+						return nil, fmt.Errorf("unknown ID")
+					},
+				},
+			},
+		},
+		{
+			name:    "bad id returns errorn",
+			wantErr: true,
+			args: args{
+				ctx: context.Background(),
+				r:   httptest.NewRequest(http.MethodPost, "/api/v2/query?orgID=howdy", nil),
+			},
+		},
+		{
+			name: "org name finds organization",
+			want: &platform.Organization{
+				ID:   platform.ID(1),
+				Name: "org1",
+			},
+			args: args{
+				ctx: context.Background(),
+				r:   httptest.NewRequest(http.MethodPost, "/api/v2/query?org=org1", nil),
+				svc: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+						if *filter.Name == "org1" {
+							return &platform.Organization{
+								ID:   platform.ID(1),
+								Name: "org1",
+							}, nil
+						}
+						return nil, fmt.Errorf("unknown org name")
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := queryOrganization(tt.args.ctx, tt.args.r, tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("queryOrganization() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("queryOrganization() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/http/requests_test.go
+++ b/http/requests_test.go
@@ -45,7 +45,7 @@ func Test_queryOrganization(t *testing.T) {
 			},
 		},
 		{
-			name:    "bad id returns errorn",
+			name:    "bad id returns error",
 			wantErr: true,
 			args: args{
 				ctx: context.Background(),

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2491,6 +2491,11 @@ paths:
         description: specifies the name of the organization executing the query.
         schema:
           type: string
+      - in: query
+        name: orgID
+        description: specifies the ID of the organization executing the query.
+        schema:
+          type: string
     requestBody:
         description: flux query or specification to execute
         content:


### PR DESCRIPTION
Closes #2106 

_Briefly describe your proposed changes:_
We should use `org` and `orgID` rather than `organization` and `organizationID` as HTTP query parameters to `/api/v2/query`

_What was the problem?_
Documentation in swagger had `org`.

_What was the solution?_
Update docs and add tests to show org/organizationID,

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)