### PR TITLE
feat(models): only use common SI time units for timestamp precision

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -739,7 +739,6 @@ paths:
             enum:
               - ns
               - us
-              - u
               - ms
               - s
       responses:

--- a/models/points.go
+++ b/models/points.go
@@ -335,7 +335,7 @@ func ParseName(buf []byte) []byte {
 // ValidPrecision checks if the precision is known.
 func ValidPrecision(precision string) bool {
 	switch precision {
-	case "n", "ns", "u", "us", "ms", "s":
+	case "ns", "us", "ms", "s":
 		return true
 	default:
 		return false
@@ -479,16 +479,12 @@ func parsePoint(buf []byte, defaultTime time.Time, precision string) (Point, err
 func GetPrecisionMultiplier(precision string) int64 {
 	d := time.Nanosecond
 	switch precision {
-	case "u":
+	case "us":
 		d = time.Microsecond
 	case "ms":
 		d = time.Millisecond
 	case "s":
 		d = time.Second
-	case "m":
-		d = time.Minute
-	case "h":
-		d = time.Hour
 	}
 	return int64(d)
 }
@@ -1676,17 +1672,12 @@ func (p *point) Fields() (Fields, error) {
 // SetPrecision will round a time to the specified precision.
 func (p *point) SetPrecision(precision string) {
 	switch precision {
-	case "n":
-	case "u":
+	case "us":
 		p.SetTime(p.Time().Truncate(time.Microsecond))
 	case "ms":
 		p.SetTime(p.Time().Truncate(time.Millisecond))
 	case "s":
 		p.SetTime(p.Time().Truncate(time.Second))
-	case "m":
-		p.SetTime(p.Time().Truncate(time.Minute))
-	case "h":
-		p.SetTime(p.Time().Truncate(time.Hour))
 	}
 }
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -266,7 +266,7 @@ func BenchmarkParsePointWithPrecisionN(b *testing.B) {
 	line := `cpu value=1i 1000000000`
 	defaultTime := time.Now().UTC()
 	for i := 0; i < b.N; i++ {
-		models.ParsePointsWithPrecision([]byte(line), defaultTime, "n")
+		models.ParsePointsWithPrecision([]byte(line), defaultTime, "ns")
 		b.SetBytes(int64(len(line)))
 	}
 }
@@ -275,7 +275,7 @@ func BenchmarkParsePointWithPrecisionU(b *testing.B) {
 	line := `cpu value=1i 1000000000`
 	defaultTime := time.Now().UTC()
 	for i := 0; i < b.N; i++ {
-		models.ParsePointsWithPrecision([]byte(line), defaultTime, "u")
+		models.ParsePointsWithPrecision([]byte(line), defaultTime, "us")
 		b.SetBytes(int64(len(line)))
 	}
 }
@@ -365,7 +365,7 @@ func NewTestPoint(name string, tags models.Tags, fields models.Fields, time time
 }
 
 func test(t *testing.T, line string, point TestPoint) {
-	pts, err := models.ParsePointsWithPrecision([]byte(line), time.Unix(0, 0), "n")
+	pts, err := models.ParsePointsWithPrecision([]byte(line), time.Unix(0, 0), "ns")
 	if err != nil {
 		t.Fatalf(`ParsePoints("%s") mismatch. got %v, exp nil`, line, err)
 	}
@@ -1783,13 +1783,13 @@ func TestParsePointsWithPrecision(t *testing.T) {
 		{
 			name:      "nanosecond",
 			line:      `cpu,host=serverA,region=us-east value=1.0 946730096789012345`,
-			precision: "n",
+			precision: "ns",
 			exp:       "cpu,host=serverA,region=us-east value=1.0 946730096789012345",
 		},
 		{
 			name:      "microsecond",
 			line:      `cpu,host=serverA,region=us-east value=1.0 946730096789012`,
-			precision: "u",
+			precision: "us",
 			exp:       "cpu,host=serverA,region=us-east value=1.0 946730096789012000",
 		},
 		{
@@ -1803,18 +1803,6 @@ func TestParsePointsWithPrecision(t *testing.T) {
 			line:      `cpu,host=serverA,region=us-east value=1.0 946730096`,
 			precision: "s",
 			exp:       "cpu,host=serverA,region=us-east value=1.0 946730096000000000",
-		},
-		{
-			name:      "minute",
-			line:      `cpu,host=serverA,region=us-east value=1.0 15778834`,
-			precision: "m",
-			exp:       "cpu,host=serverA,region=us-east value=1.0 946730040000000000",
-		},
-		{
-			name:      "hour",
-			line:      `cpu,host=serverA,region=us-east value=1.0 262980`,
-			precision: "h",
-			exp:       "cpu,host=serverA,region=us-east value=1.0 946728000000000000",
 		},
 	}
 	for _, test := range tests {
@@ -1849,12 +1837,12 @@ func TestParsePointsWithPrecisionNoTime(t *testing.T) {
 		},
 		{
 			name:      "nanosecond precision",
-			precision: "n",
+			precision: "ns",
 			exp:       "cpu,host=serverA,region=us-east value=1.0 946730096789012345",
 		},
 		{
 			name:      "microsecond precision",
-			precision: "u",
+			precision: "us",
 			exp:       "cpu,host=serverA,region=us-east value=1.0 946730096789012000",
 		},
 		{
@@ -1866,16 +1854,6 @@ func TestParsePointsWithPrecisionNoTime(t *testing.T) {
 			name:      "second precision",
 			precision: "s",
 			exp:       "cpu,host=serverA,region=us-east value=1.0 946730096000000000",
-		},
-		{
-			name:      "minute precision",
-			precision: "m",
-			exp:       "cpu,host=serverA,region=us-east value=1.0 946730040000000000",
-		},
-		{
-			name:      "hour precision",
-			precision: "h",
-			exp:       "cpu,host=serverA,region=us-east value=1.0 946728000000000000",
 		},
 	}
 
@@ -2041,7 +2019,7 @@ func TestPrecisionString(t *testing.T) {
 		},
 		{
 			name:      "microsecond precision",
-			precision: "u",
+			precision: "us",
 			exp:       "cpu value=1 946730096789012",
 		},
 		{
@@ -2053,16 +2031,6 @@ func TestPrecisionString(t *testing.T) {
 			name:      "second precision",
 			precision: "s",
 			exp:       "cpu value=1 946730096",
-		},
-		{
-			name:      "minute precision",
-			precision: "m",
-			exp:       "cpu value=1 15778834",
-		},
-		{
-			name:      "hour precision",
-			precision: "h",
-			exp:       "cpu value=1 262980",
 		},
 	}
 
@@ -2109,16 +2077,6 @@ func TestRoundedString(t *testing.T) {
 			name:      "second precision",
 			precision: time.Second,
 			exp:       "cpu value=1 946730097000000000",
-		},
-		{
-			name:      "minute precision",
-			precision: time.Minute,
-			exp:       "cpu value=1 946730100000000000",
-		},
-		{
-			name:      "hour precision",
-			precision: time.Hour,
-			exp:       "cpu value=1 946731600000000000",
 		},
 	}
 


### PR DESCRIPTION
Closes #1959 

_Briefly describe your proposed changes:_
1. Use SI symbols `us` and `ns` rather than `u` and `n` for timestamp precision.
2. Remove `h` (hours) and `m` (minutes) from timestamp precision.

I don't think we need hours and minutes since the Unix epoch.

_What was the problem?_
We didn't have a consistent unit system for precision.

_What was the solution?
Use only `ns`, `us`, `ms`, and `s` of precision since the Unix epoch for timestamps.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)