### PR TITLE
fix(http): update task test to use :id

### DIFF
--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -307,7 +307,7 @@ func TestTaskHandler_handleGetRun(t *testing.T) {
 				httprouter.ParamsKey,
 				httprouter.Params{
 					{
-						Key:   "tid",
+						Key:   "id",
 						Value: tt.args.taskID.String(),
 					},
 					{
@@ -419,7 +419,7 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 				httprouter.ParamsKey,
 				httprouter.Params{
 					{
-						Key:   "tid",
+						Key:   "id",
 						Value: tt.args.taskID.String(),
 					},
 				}))


### PR DESCRIPTION
Fixes merge issue from #1562 

_Briefly describe your proposed changes:_
Update tests to sync with the router parameters.

_What was the problem?_
Tests used :tid while the routes used :id

_What was the solution?_
Update the tests to use 🆔 


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)