### PR TITLE
WIP - Macros filtering and pagination

### DIFF
--- a/bolt/macro.go
+++ b/bolt/macro.go
@@ -20,7 +20,8 @@ func (c *Client) initializeMacros(ctx context.Context, tx *bolt.Tx) error {
 }
 
 // FindMacros returns all macros in the store
-func (c *Client) FindMacros(ctx context.Context) ([]*platform.Macro, error) {
+func (c *Client) FindMacros(ctx context.Context, filter platform.MacroFilter, opt ...platform.FindOptions) ([]*platform.Macro, error) {
+	// todo(leodido) > actually filter macros
 	op := getOp(platform.OpFindMacros)
 	macros := []*platform.Macro{}
 	err := c.db.View(func(tx *bolt.Tx) error {

--- a/http/macro_service.go
+++ b/http/macro_service.go
@@ -34,23 +34,22 @@ func NewMacroHandler() *MacroHandler {
 		Logger: zap.NewNop(),
 	}
 
-	h.HandlerFunc("GET", "/api/v2/macros", h.handleGetMacros)
-	h.HandlerFunc("POST", "/api/v2/macros", h.handlePostMacro)
-	h.HandlerFunc("GET", "/api/v2/macros/:id", h.handleGetMacro)
-	h.HandlerFunc("PATCH", "/api/v2/macros/:id", h.handlePatchMacro)
-	h.HandlerFunc("PUT", "/api/v2/macros/:id", h.handlePutMacro)
-	h.HandlerFunc("DELETE", "/api/v2/macros/:id", h.handleDeleteMacro)
+	path := fmt.Sprintf("%s", macroPath)
+	entityPath := fmt.Sprintf("%s/:id", macroPath)
+
+	h.HandlerFunc("GET", path, h.handleGetMacros)
+	h.HandlerFunc("POST", path, h.handlePostMacro)
+	h.HandlerFunc("GET", entityPath, h.handleGetMacro)
+	h.HandlerFunc("PATCH", entityPath, h.handlePatchMacro)
+	h.HandlerFunc("PUT", entityPath, h.handlePutMacro)
+	h.HandlerFunc("DELETE", entityPath, h.handleDeleteMacro)
 
 	return h
 }
 
-type macrosLinks struct {
-	Self string `json:"self"`
-}
-
 type getMacrosResponse struct {
-	Macros []macroResponse `json:"macros"`
-	Links  macrosLinks     `json:"links"`
+	Macros []macroResponse       `json:"macros"`
+	Links  *platform.PagingLinks `json:"links"`
 }
 
 func (r getMacrosResponse) ToPlatform() []*platform.Macro {
@@ -61,12 +60,11 @@ func (r getMacrosResponse) ToPlatform() []*platform.Macro {
 	return macros
 }
 
-func newGetMacrosResponse(macros []*platform.Macro) getMacrosResponse {
+func newGetMacrosResponse(macros []*platform.Macro, f platform.MacroFilter, opts platform.FindOptions) getMacrosResponse {
+	num := len(macros)
 	resp := getMacrosResponse{
-		Macros: make([]macroResponse, 0, len(macros)),
-		Links: macrosLinks{
-			Self: "/api/v2/macros",
-		},
+		Macros: make([]macroResponse, 0, num),
+		Links:  newPagingLinks(macroPath, opts, f, num),
 	}
 
 	for _, macro := range macros {
@@ -76,16 +74,53 @@ func newGetMacrosResponse(macros []*platform.Macro) getMacrosResponse {
 	return resp
 }
 
+type getMacrosRequest struct {
+	filter platform.MacroFilter
+	opts   platform.FindOptions
+}
+
+func decodeGetMacrosRequest(ctx context.Context, r *http.Request) (*getMacrosRequest, error) {
+	qp := r.URL.Query()
+	req := &getMacrosRequest{}
+
+	opts, err := decodeFindOptions(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.opts = *opts
+
+	if orgID := qp.Get("orgID"); orgID != "" {
+		id, err := platform.IDFromString(orgID)
+		if err != nil {
+			return nil, err
+		}
+		req.filter.OrganizationID = id
+	}
+
+	if org := qp.Get("org"); org != "" {
+		req.filter.Organization = &org
+	}
+
+	return req, nil
+}
+
 func (h *MacroHandler) handleGetMacros(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	macros, err := h.MacroService.FindMacros(ctx)
+	req, err := decodeGetMacrosRequest(ctx, r)
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	macros, err := h.MacroService.FindMacros(ctx, req.filter, req.opts)
 	if err != nil {
 		EncodeError(ctx, kerrors.InternalErrorf("could not read macros: %v", err), w)
 		return
 	}
 
-	err = encodeResponse(ctx, w, http.StatusOK, newGetMacrosResponse(macros))
+	err = encodeResponse(ctx, w, http.StatusOK, newGetMacrosResponse(macros, req.filter, req.opts))
 	if err != nil {
 		logEncodingError(h.Logger, r, err)
 		return
@@ -363,19 +398,33 @@ func (s *MacroService) FindMacroByID(ctx context.Context, id platform.ID) (*plat
 	return macro, nil
 }
 
-// FindMacros returns all macros in the store
-func (s *MacroService) FindMacros(ctx context.Context) ([]*platform.Macro, error) {
+// FindMacros returns a list of macros that match filter.
+//
+// Additional options provide pagination & sorting.
+func (s *MacroService) FindMacros(ctx context.Context, filter platform.MacroFilter, opts ...platform.FindOptions) ([]*platform.Macro, error) {
 	url, err := newURL(s.Addr, macroPath)
 	if err != nil {
 		return nil, err
+	}
+
+	query := url.Query()
+	if filter.OrganizationID != nil {
+		query.Add("orgID", filter.OrganizationID.String())
+	}
+	if filter.Organization != nil {
+		query.Add("org", *filter.Organization)
+	}
+	if filter.ID != nil {
+		query.Add("id", filter.ID.String())
 	}
 
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-
+	req.URL.RawQuery = query.Encode()
 	SetToken(s.Token, req)
+
 	hc := newClient(url.Scheme, s.InsecureSkipVerify)
 
 	resp, err := hc.Do(req)

--- a/inmem/macro.go
+++ b/inmem/macro.go
@@ -9,6 +9,7 @@ import (
 
 // FindMacroByID implements the platform.MacroService interface
 func (s *Service) FindMacroByID(ctx context.Context, id platform.ID) (*platform.Macro, error) {
+	// todo(leodido) > use macro filter with id
 	op := OpPrefix + platform.OpFindMacroByID
 	i, ok := s.macroKV.Load(id.String())
 	if !ok {
@@ -31,7 +32,8 @@ func (s *Service) FindMacroByID(ctx context.Context, id platform.ID) (*platform.
 }
 
 // FindMacros implements the platform.MacroService interface
-func (s *Service) FindMacros(ctx context.Context) ([]*platform.Macro, error) {
+func (s *Service) FindMacros(ctx context.Context, filter platform.MacroFilter, opt ...platform.FindOptions) ([]*platform.Macro, error) {
+	// todo(leodido) > macro filtering (by id or org)
 	op := OpPrefix + platform.OpFindMacros
 	var err error
 	var macros []*platform.Macro

--- a/inmem/macro_test.go
+++ b/inmem/macro_test.go
@@ -37,6 +37,11 @@ func TestMacroService_FindMacroByID(t *testing.T) {
 	platformtesting.FindMacroByID(initMacroService, t)
 }
 
+// todo(leodido)
+func TestMacroService_FindMacros(t *testing.T) {
+	platformtesting.FindMacros(initMacroService, t)
+}
+
 func TestMacroService_UpdateMacro(t *testing.T) {
 	platformtesting.UpdateMacro(initMacroService, t)
 }

--- a/macro.go
+++ b/macro.go
@@ -22,7 +22,7 @@ type MacroService interface {
 	FindMacroByID(ctx context.Context, id ID) (*Macro, error)
 
 	// FindMacros returns all macros in the store
-	FindMacros(ctx context.Context) ([]*Macro, error)
+	FindMacros(ctx context.Context, filter MacroFilter, opt ...FindOptions) ([]*Macro, error)
 
 	// CreateMacro creates a new macro and assigns it an ID
 	CreateMacro(ctx context.Context, m *Macro) error
@@ -40,10 +40,38 @@ type MacroService interface {
 // A Macro describes a keyword that can be expanded into several possible
 // values when used in an InfluxQL or Flux query
 type Macro struct {
-	ID        ID              `json:"id,omitempty"`
-	Name      string          `json:"name"`
-	Selected  []string        `json:"selected"`
-	Arguments *MacroArguments `json:"arguments"`
+	ID             ID              `json:"id,omitempty"`
+	OrganizationID ID              `json:"org_id,omitempty"` // todo(leodido) > remove omitempty
+	Name           string          `json:"name"`
+	Selected       []string        `json:"selected"`
+	Arguments      *MacroArguments `json:"arguments"`
+}
+
+// MacroFilter represents a set of filter that restrict the returned results.
+type MacroFilter struct {
+	ID             *ID
+	OrganizationID *ID
+	Organization   *string
+}
+
+// QueryParams implements PagingFilter.
+//
+// It converts MacroFilter fields to url query params.
+func (f MacroFilter) QueryParams() map[string][]string {
+	qp := map[string][]string{}
+	if f.ID != nil {
+		qp["id"] = []string{f.ID.String()}
+	}
+
+	if f.OrganizationID != nil {
+		qp["orgID"] = []string{f.OrganizationID.String()}
+	}
+
+	if f.Organization != nil {
+		qp["org"] = []string{*f.Organization}
+	}
+
+	return qp
 }
 
 // A MacroUpdate describes a set of changes that can be applied to a Macro
@@ -73,8 +101,10 @@ type MacroMapValues map[string]string
 
 // Valid returns an error if a Macro contains invalid data
 func (m *Macro) Valid() error {
+	// todo(leodido) > is organization mandatory? ie., every macro belongs to an organization? if yes, check it
+
 	if m.Name == "" {
-		return fmt.Errorf("name empty")
+		return fmt.Errorf("missing macro name")
 	}
 
 	validTypes := map[string]bool{

--- a/macro_test.go
+++ b/macro_test.go
@@ -9,7 +9,10 @@ import (
 	platformtesting "github.com/influxdata/platform/testing"
 )
 
-var macroTestID = "debac1e0deadbeef"
+var (
+	macroTestID    = "debac1e0deadbeef"
+	macroTestOrgID = "deadbeefdeadbeef"
+)
 
 func TestMacro_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
@@ -17,6 +20,31 @@ func TestMacro_UnmarshalJSON(t *testing.T) {
 		json string
 		want platform.Macro
 	}{
+		{
+			name: "with organization",
+			json: `
+{ 
+  "id": "debac1e0deadbeef",
+  "org_id": "deadbeefdeadbeef",
+  "name": "howdy",
+  "selected": [],
+  "arguments": {
+    "type": "constant",
+    "values": ["a", "b", "c", "d"]
+  }
+}
+`,
+			want: platform.Macro{
+				ID:             platformtesting.MustIDBase16(macroTestID),
+				OrganizationID: platformtesting.MustIDBase16(macroTestOrgID),
+				Name:           "howdy",
+				Selected:       make([]string, 0),
+				Arguments: &platform.MacroArguments{
+					Type:   "constant",
+					Values: platform.MacroConstantValues{"a", "b", "c", "d"},
+				},
+			},
+		},
 		{
 			name: "with constant arguments",
 			json: `

--- a/mock/macro_service.go
+++ b/mock/macro_service.go
@@ -9,7 +9,7 @@ import (
 var _ platform.MacroService = &MacroService{}
 
 type MacroService struct {
-	FindMacrosF    func(context.Context) ([]*platform.Macro, error)
+	FindMacrosF    func(context.Context, platform.MacroFilter, ...platform.FindOptions) ([]*platform.Macro, error)
 	FindMacroByIDF func(context.Context, platform.ID) (*platform.Macro, error)
 	CreateMacroF   func(context.Context, *platform.Macro) error
 	UpdateMacroF   func(ctx context.Context, id platform.ID, update *platform.MacroUpdate) (*platform.Macro, error)
@@ -25,8 +25,8 @@ func (s *MacroService) ReplaceMacro(ctx context.Context, macro *platform.Macro) 
 	return s.ReplaceMacroF(ctx, macro)
 }
 
-func (s *MacroService) FindMacros(ctx context.Context) ([]*platform.Macro, error) {
-	return s.FindMacrosF(ctx)
+func (s *MacroService) FindMacros(ctx context.Context, filter platform.MacroFilter, opts ...platform.FindOptions) ([]*platform.Macro, error) {
+	return s.FindMacrosF(ctx, filter, opts...)
 }
 
 func (s *MacroService) FindMacroByID(ctx context.Context, id platform.ID) (*platform.Macro, error) {

--- a/testing/macro.go
+++ b/testing/macro.go
@@ -53,6 +53,10 @@ func MacroService(
 			fn:   FindMacroByID,
 		},
 		{
+			name: "FindMacros",
+			fn:   FindMacros,
+		},
+		{
 			name: "UpdateMacro",
 			fn:   UpdateMacro,
 		},
@@ -149,7 +153,7 @@ func CreateMacro(init func(MacroFields, *testing.T) (platform.MacroService, stri
 		err := s.CreateMacro(ctx, tt.args.macro)
 		diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
-		macros, err := s.FindMacros(ctx)
+		macros, err := s.FindMacros(ctx, platform.MacroFilter{})
 		if err != nil {
 			t.Fatalf("failed to retrieve macros: %v", err)
 		}
@@ -243,6 +247,11 @@ func FindMacroByID(init func(MacroFields, *testing.T) (platform.MacroService, st
 			t.Fatalf("found unexpected macro -got/+want\ndiff %s", diff)
 		}
 	}
+}
+
+// FindMacros tests platform.macroService FindMacros interface method
+func FindMacros(init func(MacroFields, *testing.T) (platform.MacroService, string, func()), t *testing.T) {
+	// todo(leodido)
 }
 
 // UpdateMacro tests platform.MacroService UpdateMacro interface method
@@ -349,7 +358,7 @@ func UpdateMacro(init func(MacroFields, *testing.T) (platform.MacroService, stri
 				}
 			}
 
-			macros, err := s.FindMacros(ctx)
+			macros, err := s.FindMacros(ctx, platform.MacroFilter{})
 			if err != nil {
 				t.Fatalf("failed to retrieve macros: %v", err)
 			}
@@ -446,7 +455,7 @@ func DeleteMacro(init func(MacroFields, *testing.T) (platform.MacroService, stri
 		})
 		diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
-		macros, err := s.FindMacros(ctx)
+		macros, err := s.FindMacros(ctx, platform.MacroFilter{})
 		if err != nil {
 			t.Fatalf("failed to retrieve macros: %v", err)
 		}

--- a/testing/util.go
+++ b/testing/util.go
@@ -3,6 +3,10 @@ package testing
 import (
 	"testing"
 
+	"fmt"
+
+	"encoding/json"
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/platform"
 )
 
@@ -39,4 +43,27 @@ func MustIDBase16(s string) platform.ID {
 		panic(err)
 	}
 	return *id
+}
+
+// CompareJSON tests two JSON strings.
+func CompareJSON(got, want, name, header string) error {
+	var errorFn = func() error {
+		return fmt.Errorf("%q.%s \ngot\n%v\n\nwant\n%v", name, header, got, want)
+	}
+
+	var gotO interface{}
+	if gotErr := json.Unmarshal([]byte(got), &gotO); gotErr != nil {
+		return errorFn()
+	}
+
+	var wantO interface{}
+	if wantErr := json.Unmarshal([]byte(want), &wantO); wantErr != nil {
+		return errorFn()
+	}
+
+	if eq := cmp.Equal(gotO, wantO); !eq {
+		return errorFn()
+	}
+
+	return nil
 }

--- a/testing/util_test.go
+++ b/testing/util_test.go
@@ -1,0 +1,59 @@
+package testing
+
+import (
+	"testing"
+)
+
+func TestJSONComparation(t *testing.T) {
+	type testCase struct {
+		name   string
+		got    string
+		want   string
+		errors bool
+	}
+
+	tests := []testCase{
+		{
+			"valid empty json string",
+			"{}",
+			"{}",
+			false,
+		},
+		{
+			"malformed got",
+			"{...}",
+			"{}",
+			true,
+		},
+		{
+			"empty want",
+			"{}",
+			"",
+			true,
+		},
+		{
+			"empty got",
+			"",
+			"{}",
+			true,
+		},
+		{
+			"order insensitive",
+			`{"hello":"world","ciao":"mondo"}`,
+			`{"ciao":"mondo","hello":"world"}`,
+			false,
+		},
+		{
+			"case sensitive",
+			`{"lower":"case"}`,
+			`{"UPPER":"CASE"}`,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		if err := CompareJSON(tt.got, tt.want, tt.name, "CompareJSON"); tt.errors != (err != nil) {
+			t.Errorf("%q.%s", "testing", tt.name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1908, closes #837 

_Briefly describe your proposed changes:_

Bind macros to organizations.

_What was the problem?_

Macro not bound to organizations.
Cannot get macros by organization as swagger definition mandates.

_What was the solution?_

Introducing organization into `platform.Macro`.
Modify accordingly various layers: inmem, bolt, http, mock.
Introduce tests for macro by org.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)