### PR TITLE
chore(ci): Update trigger schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 7 * * *"
+          cron: "0 7,22 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
Update CircleCI trigger time to allow for a new nightly to be built at 10:00 pm UTC.