### PR TITLE
fix(inmem): user service now filters by id

### DIFF
--- a/bolt/kv_test.go
+++ b/bolt/kv_test.go
@@ -57,7 +57,7 @@ func initExampleService(f platformtesting.UserFields, t *testing.T) (platform.Us
 			t.Fatalf("failed to populate users")
 		}
 	}
-	return svc, "", func() {
+	return svc, "kv/", func() {
 		defer closeFn()
 		for _, u := range f.Users {
 			if err := svc.DeleteUser(ctx, u.ID); err != nil {

--- a/inmem/kv_test.go
+++ b/inmem/kv_test.go
@@ -23,7 +23,7 @@ func initExampleService(f platformtesting.UserFields, t *testing.T) (platform.Us
 			t.Fatalf("failed to populate users")
 		}
 	}
-	return svc, "", func() {
+	return svc, "kv/", func() {
 		for _, u := range f.Users {
 			if err := svc.DeleteUser(ctx, u.ID); err != nil {
 				t.Logf("failed to remove users: %v", err)

--- a/kv/example.go
+++ b/kv/example.go
@@ -57,7 +57,7 @@ func (c *ExampleService) FindUserByID(ctx context.Context, id platform.ID) (*pla
 
 	if err != nil {
 		return nil, &platform.Error{
-			Op:  platform.OpFindUserByID,
+			Op:  "kv/" + platform.OpFindUserByID,
 			Err: err,
 		}
 	}
@@ -121,7 +121,7 @@ func (c *ExampleService) findUserByName(ctx context.Context, tx Tx, n string) (*
 		return nil, &platform.Error{
 			Code: platform.ENotFound,
 			Msg:  "user not found",
-			Op:   platform.OpFindUser,
+			Op:   "kv/" + platform.OpFindUser,
 		}
 	}
 	if err != nil {
@@ -140,7 +140,14 @@ func (c *ExampleService) findUserByName(ctx context.Context, tx Tx, n string) (*
 // Other filters will do a linear scan across examples until it finds a match.
 func (c *ExampleService) FindUser(ctx context.Context, filter platform.UserFilter) (*platform.User, error) {
 	if filter.ID != nil {
-		return c.FindUserByID(ctx, *filter.ID)
+		u, err := c.FindUserByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, &platform.Error{
+				Op:  "kv/" + platform.OpFindUser,
+				Err: err,
+			}
+		}
+		return u, nil
 	}
 
 	if filter.Name != nil {
@@ -200,7 +207,7 @@ func (c *ExampleService) FindUsers(ctx context.Context, filter platform.UserFilt
 		if err != nil {
 			return nil, 0, &platform.Error{
 				Err: err,
-				Op:  op,
+				Op:  "kv/" + op,
 			}
 		}
 
@@ -212,7 +219,7 @@ func (c *ExampleService) FindUsers(ctx context.Context, filter platform.UserFilt
 		if err != nil {
 			return nil, 0, &platform.Error{
 				Err: err,
-				Op:  op,
+				Op:  "kv/" + op,
 			}
 		}
 
@@ -258,7 +265,7 @@ func (c *ExampleService) CreateUser(ctx context.Context, u *platform.User) error
 	if err != nil {
 		return &platform.Error{
 			Err: err,
-			Op:  platform.OpCreateUser,
+			Op:  "kv/" + platform.OpCreateUser,
 		}
 	}
 
@@ -355,7 +362,7 @@ func (c *ExampleService) UpdateUser(ctx context.Context, id platform.ID, upd pla
 	if err != nil {
 		return nil, &platform.Error{
 			Err: err,
-			Op:  platform.OpUpdateUser,
+			Op:  "kv/" + platform.OpUpdateUser,
 		}
 	}
 
@@ -397,7 +404,7 @@ func (c *ExampleService) DeleteUser(ctx context.Context, id platform.ID) error {
 
 	if err != nil {
 		return &platform.Error{
-			Op:  platform.OpDeleteUser,
+			Op:  "kv/" + platform.OpDeleteUser,
 			Err: err,
 		}
 	}

--- a/testing/util.go
+++ b/testing/util.go
@@ -16,19 +16,19 @@ func diffPlatformErrors(name string, actual, expected error, opPrefix string, t 
 	}
 
 	if expected != nil && actual == nil {
-		t.Fatalf("%s failed, expected error %s but received nil", name, expected.Error())
+		t.Errorf("%s failed, expected error %s but received nil", name, expected.Error())
 	}
 
 	if platform.ErrorCode(expected) != platform.ErrorCode(actual) {
-		t.Fatalf("%s failed, expected error code %q but received %q", name, platform.ErrorCode(expected), platform.ErrorCode(actual))
+		t.Errorf("%s failed, expected error code %q but received %q", name, platform.ErrorCode(expected), platform.ErrorCode(actual))
 	}
 
 	if opPrefix+platform.ErrorOp(expected) != platform.ErrorOp(actual) {
-		t.Fatalf("%s failed, expected error op %q but received %q", name, opPrefix+platform.ErrorOp(expected), platform.ErrorOp(actual))
+		t.Errorf("%s failed, expected error op %q but received %q", name, opPrefix+platform.ErrorOp(expected), platform.ErrorOp(actual))
 	}
 
 	if platform.ErrorMessage(expected) != platform.ErrorMessage(actual) {
-		t.Fatalf("%s failed, expected error message %q but received %q", name, platform.ErrorMessage(expected), platform.ErrorMessage(actual))
+		t.Errorf("%s failed, expected error message %q but received %q", name, platform.ErrorMessage(expected), platform.ErrorMessage(actual))
 	}
 }
 


### PR DESCRIPTION
Related #2072

_Briefly describe your proposed changes:_

inmem user service's FindUser would only check for name, but not ID.

I've added a few more tests filter permutations and then fixed the resulting bugs.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
