### PR TITLE
fix(write): fix close logic to avoid race from read error

### DIFF
--- a/write/batcher_test.go
+++ b/write/batcher_test.go
@@ -90,7 +90,7 @@ func TestBatcher_read(t *testing.T) {
 			args: args{
 				r:     strings.NewReader("m1,t1=v1 f1=1\nm2,t2=v2 f2=2"),
 				lines: make(chan []byte),
-				errC:  make(chan error),
+				errC:  make(chan error, 1),
 			},
 			want: []string{"m1,t1=v1 f1=1\n", "m2,t2=v2 f2=2"},
 		},
@@ -100,7 +100,7 @@ func TestBatcher_read(t *testing.T) {
 				cancel: true,
 				r:      strings.NewReader("m1,t1=v1 f1=1"),
 				lines:  make(chan []byte),
-				errC:   make(chan error),
+				errC:   make(chan error, 1),
 			},
 			want:    []string{},
 			wantErr: true,
@@ -110,7 +110,7 @@ func TestBatcher_read(t *testing.T) {
 			args: args{
 				r:     &errorReader{},
 				lines: make(chan []byte),
-				errC:  make(chan error),
+				errC:  make(chan error, 1),
 			},
 			want:    []string{},
 			wantErr: true,


### PR DESCRIPTION
In the case that there is a read error, we would close the lines
channel before sending the error into the read error channel. closing
lines then allows the write goroutine to possibly send in a nil error
before read is able to, causing the main function driving both to
return a nil error. Additionally, it is possible for both reads and
writes to race sending errors into their channels, and the main
goroutine will only read from one, causing the other goroutine to leak.

To fix this, we close lines only after we have sent an error into
the channel, we ensure we read from both errors to make sure that
both have exited, and we unify the channels and add a buffer of size
two to the channel. It is possible for write to exit leaving read blocked
forever, but write only exits with a nil error when read has exited, so
this only happens during an actual write error, just like before.

Channels are hard.