### PR TITLE
feat(ui): add field options to view

### DIFF
--- a/ui/src/shared/utils/filterTables.ts
+++ b/ui/src/shared/utils/filterTables.ts
@@ -1,0 +1,21 @@
+import {FluxTable} from 'src/types'
+
+const IGNORED_COLUMNS = ['', 'result', 'table', '_start', '_stop']
+
+export const filterTables = (tables: FluxTable[]): FluxTable[] => {
+  return tables.map(table => {
+    const header = table.data[0]
+    const indices = IGNORED_COLUMNS.map(name => header.indexOf(name))
+
+    const tableData = table.data
+
+    const data = tableData.map(row => {
+      return row.filter((__, i) => !indices.includes(i))
+    })
+
+    return {
+      ...table,
+      data,
+    }
+  })
+}

--- a/ui/src/shared/utils/view.ts
+++ b/ui/src/shared/utils/view.ts
@@ -150,7 +150,7 @@ const NEW_VIEW_CREATORS = {
       queries: [defaultViewQuery()],
       colors: DEFAULT_THRESHOLDS_LIST_COLORS,
       tableOptions: {
-        verticalTimeAxis: false,
+        verticalTimeAxis: true,
         sortBy: DEFAULT_TIME_FIELD,
         fixFirstColumn: false,
       },


### PR DESCRIPTION
Closes #2097 

_Briefly describe your proposed changes:_
Extracts and updates field options for a table graph view. Currently, only the default `_time` field option was being displayed.  

  - [x] Rebased/mergeable
  - [x] Tests pass

![kapture 2019-01-02 at 11 15 04](https://user-images.githubusercontent.com/4994741/50600666-d04f3c80-0e7f-11e9-91af-3bc16e1c8387.gif)
