### PR TITLE
Set default time axis to vertical

### DIFF
--- a/ui/src/shared/utils/view.ts
+++ b/ui/src/shared/utils/view.ts
@@ -150,7 +150,7 @@ const NEW_VIEW_CREATORS = {
       queries: [defaultViewQuery()],
       colors: DEFAULT_THRESHOLDS_LIST_COLORS,
       tableOptions: {
-        verticalTimeAxis: false,
+        verticalTimeAxis: true,
         sortBy: DEFAULT_TIME_FIELD,
         fixFirstColumn: false,
       },


### PR DESCRIPTION
Tables currently crash when time axis is horizontal- also time axis should be vertical by default. 