### PR TITLE
Add support for get /api/v2/query

### DIFF
--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -47,7 +47,8 @@ func NewFluxHandler() *FluxHandler {
 		Logger: zap.NewNop(),
 	}
 
-	h.HandlerFunc("POST", fluxPath, h.handlePostQuery)
+	h.HandlerFunc("POST", fluxPath, h.handleQuery)
+	h.HandlerFunc("GET", fluxPath, h.handleQuery)
 	h.HandlerFunc("POST", "/api/v2/query/ast", h.postFluxAST)
 	h.HandlerFunc("POST", "/api/v2/query/analyze", h.postQueryAnalyze)
 	h.HandlerFunc("POST", "/api/v2/query/spec", h.postFluxSpec)
@@ -56,7 +57,7 @@ func NewFluxHandler() *FluxHandler {
 	return h
 }
 
-func (h *FluxHandler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
+func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	a, err := pcontext.GetAuthorizer(ctx)


### PR DESCRIPTION
Closes #1918 

_Briefly describe your proposed changes:_
This PR allows users to submit `GET /api/v2/query` requests where the flux query is provided via query param called `query`. 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
