### PR TITLE
Fix create authorization command

### DIFF
--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -165,7 +165,7 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newAuthResponse(auth, org, user, perms)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }

--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -139,10 +139,25 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 		return
 	}
 
-	user, err := getAuthorizedUser(r, h.UserService)
-	if err != nil {
-		EncodeError(ctx, platform.ErrUnableToCreateToken, w)
-		return
+	var user *platform.User
+	// allow the user id to be specified optionally, if it is not set
+	// we use the id from the authorizer
+	if req.UserID == nil {
+		u, err := getAuthorizedUser(r, h.UserService)
+		if err != nil {
+			EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+			return
+		}
+
+		user = u
+	} else {
+		u, err := h.UserService.FindUserByID(ctx, *req.UserID)
+		if err != nil {
+			EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+			return
+		}
+
+		user = u
 	}
 
 	auth := req.toPlatform(user.ID)
@@ -173,6 +188,7 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 type postAuthorizationRequest struct {
 	Status      platform.Status       `json:"status"`
 	OrgID       platform.ID           `json:"orgID"`
+	UserID      *platform.ID          `json:"userID,omitempty"`
 	Description string                `json:"description"`
 	Permissions []platform.Permission `json:"permissions"`
 }
@@ -193,6 +209,10 @@ func newPostAuthorizationRequest(a *platform.Authorization) (*postAuthorizationR
 		Description: a.Description,
 		Permissions: a.Permissions,
 		Status:      a.Status,
+	}
+
+	if a.UserID.Valid() {
+		res.UserID = &a.UserID
 	}
 
 	res.SetDefaults()

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -458,6 +458,88 @@ func TestService_handlePostAuthorization(t *testing.T) {
 `,
 			},
 		},
+		{
+			name: "create a new authorization with user id set explicitly",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					CreateAuthorizationFn: func(ctx context.Context, c *platform.Authorization) error {
+						c.ID = platformtesting.MustIDBase16("020f755c3c082000")
+						c.Token = "new-test-token"
+						return nil
+					},
+				},
+				UserService: &mock.UserService{
+					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
+						if !id.Valid() {
+							return nil, errors.New("invalid ID")
+						}
+						return &platform.User{
+							ID:   id,
+							Name: "u1",
+						}, nil
+					},
+				},
+				OrganizationService: &mock.OrganizationService{
+					FindOrganizationByIDF: func(ctx context.Context, id platform.ID) (*platform.Organization, error) {
+						if !id.Valid() {
+							return nil, errors.New("invalid ID")
+						}
+						return &platform.Organization{
+							ID:   id,
+							Name: "o1",
+						}, nil
+					},
+				},
+			},
+			args: args{
+				session: &platform.Authorization{
+					Token:       "session-token",
+					ID:          platformtesting.MustIDBase16("020f755c3c082000"),
+					UserID:      platformtesting.MustIDBase16("aaaaaaaaaaaaaaaa"),
+					OrgID:       platformtesting.MustIDBase16("020f755c3c083000"),
+					Description: "can write to authorization resource",
+					Permissions: []platform.Permission{
+						{
+							Action:   platform.WriteAction,
+							Resource: platform.AuthorizationsResource,
+						},
+					},
+				},
+				authorization: &platform.Authorization{
+					ID:          platformtesting.MustIDBase16("020f755c3c082000"),
+					UserID:      platformtesting.MustIDBase16("bbbbbbbbbbbbbbbb"),
+					OrgID:       platformtesting.MustIDBase16("020f755c3c083000"),
+					Description: "only read dashboards sucka",
+					Permissions: []platform.Permission{
+						{
+							Action:   platform.ReadAction,
+							Resource: platform.DashboardsResource,
+						},
+					},
+				},
+			},
+			wants: wants{
+				statusCode:  http.StatusCreated,
+				contentType: "application/json; charset=utf-8",
+				body: `
+{
+  "links": {
+    "user": "/api/v2/users/bbbbbbbbbbbbbbbb",
+    "self": "/api/v2/authorizations/020f755c3c082000"
+  },
+  "id": "020f755c3c082000",
+  "user": "u1",
+  "userID": "bbbbbbbbbbbbbbbb",
+  "orgID": "020f755c3c083000",
+  "org": "o1",
+  "token": "new-test-token",
+  "status": "active",
+  "description": "only read dashboards sucka",
+  "permissions": [{"action": "read", "resource": "dashboards"}]
+}
+`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #2169 

_Briefly describe your proposed changes:_
Previously, authorizations required the users id to be set explicitly on the authorization. As of https://github.com/influxdata/platform/pull/2157 the user id is retrieved off of the authorization or session used in the http request.

We now allow users to specify an explicit user when creating authorizations. If not id is provided, the user from the authorizer will be used.

Additionally, we now need to pass the organization id when creating an authorization.


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
