### PR TITLE
Add data to rows from get api instead of dummy data

### DIFF
--- a/ui/src/organizations/components/Tasks.tsx
+++ b/ui/src/organizations/components/Tasks.tsx
@@ -9,7 +9,6 @@ import FilterList from 'src/shared/components/Filter'
 
 // Types
 import {Task} from 'src/api'
-import {dummyTasks} from 'src/tasks/dummyData'
 
 interface Props {
   tasks: Task[]
@@ -45,17 +44,12 @@ export default class Tasks extends PureComponent<Props, State> {
         <FilterList<Task>
           searchTerm={searchTerm}
           searchKeys={['name', 'owner.name']}
-          list={this.tempTasks}
+          list={this.props.tasks}
         >
           {ts => <TaskList tasks={ts} emptyState={this.emptyState} />}
         </FilterList>
       </>
     )
-  }
-
-  // TODO: use real tasks
-  private get tempTasks(): Task[] {
-    return dummyTasks
   }
 
   private handleFilterBlur = (e: ChangeEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
Closes #4919

Updated Tasks rows to display task data from api instead of using dummy data which was causing name to be null.