### PR TITLE
Remove pipe operator when 'from' is clicked on explorer

### DIFF
--- a/ui/src/shared/components/flux_functions_toolbar/FluxFunctionsToolbar.tsx
+++ b/ui/src/shared/components/flux_functions_toolbar/FluxFunctionsToolbar.tsx
@@ -71,10 +71,14 @@ class FluxFunctionsToolbar extends PureComponent<Props, State> {
     this.setState({searchTerm})
   }
 
-  private handleUpdateScript = (funcExample: string) => {
+  private handleUpdateScript = (funcName: string, funcExample: string) => {
     const {activeQueryText, onSetActiveQueryText} = this.props
 
-    onSetActiveQueryText(`${activeQueryText}\n  |> ${funcExample}`)
+    if (funcName === 'from') {
+      onSetActiveQueryText(`${activeQueryText}\n${funcExample}`)
+    } else {
+      onSetActiveQueryText(`${activeQueryText}\n  |> ${funcExample}`)
+    }
   }
 }
 

--- a/ui/src/shared/components/flux_functions_toolbar/FunctionCategory.tsx
+++ b/ui/src/shared/components/flux_functions_toolbar/FunctionCategory.tsx
@@ -10,7 +10,7 @@ import {FluxToolbarFunction} from 'src/types/shared'
 interface Props {
   category: string
   funcs: FluxToolbarFunction[]
-  onClickFunction: (s: string) => void
+  onClickFunction: (name: string, example: string) => void
 }
 
 const FunctionCategory: SFC<Props> = props => {

--- a/ui/src/shared/components/flux_functions_toolbar/ToolbarFunction.tsx
+++ b/ui/src/shared/components/flux_functions_toolbar/ToolbarFunction.tsx
@@ -9,7 +9,7 @@ import {FluxToolbarFunction} from 'src/types/shared'
 
 interface Props {
   func: FluxToolbarFunction
-  onClickFunction: (s: string) => void
+  onClickFunction: (name: string, example: string) => void
 }
 
 interface State {
@@ -77,7 +77,7 @@ class ToolbarFunction extends PureComponent<Props, State> {
   private handleClickFunction = () => {
     const {func, onClickFunction} = this.props
 
-    onClickFunction(func.example)
+    onClickFunction(func.name, func.example)
   }
 }
 


### PR DESCRIPTION
Closes #2116 

Add parameter to the onclick for toolbar functions that conditions on the function name