### PR TITLE
fix(platform): check for (*platform.Error)(nil) in error functions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -85,21 +85,51 @@ func (e *Error) Error() string {
 func ErrorCode(err error) string {
 	if err == nil {
 		return ""
-	} else if e, ok := err.(*Error); ok && e.Code != "" {
+	}
+
+	e, ok := err.(*Error)
+	if !ok {
+		return EInternal
+	}
+
+	if e == nil {
+		return ""
+	}
+
+	if e.Code != "" {
 		return e.Code
-	} else if ok && e.Err != nil {
+	}
+
+	if e.Err != nil {
 		return ErrorCode(e.Err)
 	}
+
 	return EInternal
 }
 
 // ErrorOp returns the op of the error, if available; otherwise return empty string.
 func ErrorOp(err error) string {
-	if e, ok := err.(*Error); ok && e.Op != "" {
+	if err == nil {
+		return ""
+	}
+
+	e, ok := err.(*Error)
+	if !ok {
+		return ""
+	}
+
+	if e == nil {
+		return ""
+	}
+
+	if e.Op != "" {
 		return e.Op
-	} else if ok && e.Err != nil {
+	}
+
+	if e.Err != nil {
 		return ErrorOp(e.Err)
 	}
+
 	return ""
 }
 
@@ -108,11 +138,25 @@ func ErrorOp(err error) string {
 func ErrorMessage(err error) string {
 	if err == nil {
 		return ""
-	} else if e, ok := err.(*Error); ok && e.Msg != "" {
+	}
+
+	e, ok := err.(*Error)
+	if !ok {
+		return "An internal error has occurred."
+	}
+
+	if e == nil {
+		return ""
+	}
+
+	if e.Msg != "" {
 		return e.Msg
-	} else if ok && e.Err != nil {
+	}
+
+	if e.Err != nil {
 		return ErrorMessage(e.Err)
 	}
+
 	return "An internal error has occurred."
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -60,7 +60,7 @@ func TestErrorMsg(t *testing.T) {
 	}
 	for _, c := range cases {
 		if c.msg != c.err.Error() {
-			t.Fatalf("%s failed, want %s, got %s", c.name, c.msg, c.err.Error())
+			t.Errorf("%s failed, want %s, got %s", c.name, c.msg, c.err.Error())
 		}
 	}
 }
@@ -73,6 +73,10 @@ func TestErrorMessage(t *testing.T) {
 	}{
 		{
 			name: "nil error",
+		},
+		{
+			name: "nil error of type *platform.Error",
+			err:  (*platform.Error)(nil),
 		},
 		{
 			name: "simple error",
@@ -92,7 +96,7 @@ func TestErrorMessage(t *testing.T) {
 	}
 	for _, c := range cases {
 		if result := platform.ErrorMessage(c.err); c.want != result {
-			t.Fatalf("%s failed, want %s, got %s", c.name, c.want, result)
+			t.Errorf("%s failed, want %s, got %s", c.name, c.want, result)
 		}
 	}
 }
@@ -105,6 +109,10 @@ func TestErrorOp(t *testing.T) {
 	}{
 		{
 			name: "nil error",
+		},
+		{
+			name: "nil error of type *platform.Error",
+			err:  (*platform.Error)(nil),
 		},
 		{
 			name: "simple error",
@@ -129,7 +137,7 @@ func TestErrorOp(t *testing.T) {
 	}
 	for _, c := range cases {
 		if result := platform.ErrorOp(c.err); c.want != result {
-			t.Fatalf("%s failed, want %s, got %s", c.name, c.want, result)
+			t.Errorf("%s failed, want %s, got %s", c.name, c.want, result)
 		}
 	}
 }
@@ -141,6 +149,10 @@ func TestErrorCode(t *testing.T) {
 	}{
 		{
 			name: "nil error",
+		},
+		{
+			name: "nil error of type *platform.Error",
+			err:  (*platform.Error)(nil),
 		},
 		{
 			name: "simple error",
@@ -165,7 +177,7 @@ func TestErrorCode(t *testing.T) {
 	}
 	for _, c := range cases {
 		if result := platform.ErrorCode(c.err); c.want != result {
-			t.Fatalf("%s failed, want %s, got %s", c.name, c.want, result)
+			t.Errorf("%s failed, want %s, got %s", c.name, c.want, result)
 		}
 	}
 }
@@ -237,17 +249,17 @@ func TestJSON(t *testing.T) {
 		result, err := json.Marshal(c.err)
 		// encode testing
 		if err != nil {
-			t.Fatalf("%s encode failed, want err: %v, should be nil", c.name, err)
+			t.Errorf("%s encode failed, want err: %v, should be nil", c.name, err)
 		}
 
 		if string(result) != c.encoded {
-			t.Fatalf("%s encode failed, want result: %s, got %s", c.name, c.encoded, string(result))
+			t.Errorf("%s encode failed, want result: %s, got %s", c.name, c.encoded, string(result))
 		}
 		// decode testing
 		got := new(platform.Error)
 		err = json.Unmarshal(result, got)
 		if err != nil {
-			t.Fatalf("%s decode failed, want err: %v, should be nil", c.name, err)
+			t.Errorf("%s decode failed, want err: %v, should be nil", c.name, err)
 		}
 		decodeEqual(t, c.err, got, "decode: "+c.name)
 	}
@@ -255,20 +267,20 @@ func TestJSON(t *testing.T) {
 
 func decodeEqual(t *testing.T, want, result *platform.Error, caseName string) {
 	if want.Code != result.Code {
-		t.Fatalf("%s code failed, want %s, got %s", caseName, want.Code, result.Code)
+		t.Errorf("%s code failed, want %s, got %s", caseName, want.Code, result.Code)
 	}
 	if want.Op != result.Op {
-		t.Fatalf("%s op failed, want %s, got %s", caseName, want.Op, result.Op)
+		t.Errorf("%s op failed, want %s, got %s", caseName, want.Op, result.Op)
 	}
 	if want.Msg != result.Msg {
-		t.Fatalf("%s msg failed, want %s, got %s", caseName, want.Msg, result.Msg)
+		t.Errorf("%s msg failed, want %s, got %s", caseName, want.Msg, result.Msg)
 	}
 	if want.Err != nil {
 		if _, ok := want.Err.(*platform.Error); ok {
 			decodeEqual(t, want.Err.(*platform.Error), result.Err.(*platform.Error), caseName)
 		} else {
 			if want.Err.Error() != result.Err.Error() {
-				t.Fatalf("%s Err failed, want %s, got %s", caseName, want.Err.Error(), result.Err.Error())
+				t.Errorf("%s Err failed, want %s, got %s", caseName, want.Err.Error(), result.Err.Error())
 			}
 		}
 	}


### PR DESCRIPTION
As of https://github.com/influxdata/platform/pull/2192 a panic was
introduced in the startup of platform. It is the result of
`Error{Code,Op,Message}` being passed a `(*platform.Error)(nil)`
instead of an `(error)(nil)`.

Specifically
```
   if err == nil {
        return ""
    } else if e, ok := err.(*Error); ok && e.Code != "" {
        return e.Code
    }
```
will panic when err is `(*platform.Error)(nil)` as the `err == nil`
check will fail and the `e, ok := err.(*Error); ok && e.Code != ""` will
succeed and panic on `e.Code`, as `e` is nil.

This panic could have been avoided if all methods returned `error`
instead of `*platform.Error`.

```
env GO111MODULE=on go build -tags '' -o bin/darwin/influxd ./cmd/influxd
             ._ o o
             \_`-)|_
          ,""      _\_
        ,"  ## |   0 0.
      ," ##   ,-\__    `.
    ,"       /     `--._;) - "HAI, I'm Chronogiraffe. Let's be friends!"
  ,"     ## /
,"   ##    /
./bin/darwin/influxd --developer-mode=true
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1510ae6]

goroutine 1 [running]:
github.com/influxdata/platform.ErrorCode(0x22a3d00, 0x0, 0xc000346700, 0xc0002040e0)
    /Users/del/go/src/github.com/influxdata/platform/errors.go:88 +0x46
github.com/influxdata/platform/bolt.(*Client).initializeSources(0xc0002e8190, 0x22b8ac0, 0xc000346700, 0xc0002040e0, 0x0, 0x0)
    /Users/del/go/src/github.com/influxdata/platform/bolt/source.go:50 +0xc1
github.com/influxdata/platform/bolt.(*Client).initialize.func1(0xc0002040e0, 0x212dd80, 0xc0002040e0)
    /Users/del/go/src/github.com/influxdata/platform/bolt/bbolt.go:127 +0x212
github.com/coreos/bbolt.(*DB).Update(0xc0005f2000, 0xc0005d81c0, 0x0, 0x0)
    /Users/del/go/pkg/mod/github.com/coreos/bbolt@v1.3.1-coreos.6/db.go:667 +0x90
github.com/influxdata/platform/bolt.(*Client).initialize(0xc0002e8190, 0x22b8ac0, 0xc000346700, 0xc0005d8230, 0xc0005f2000)
    /Users/del/go/src/github.com/influxdata/platform/bolt/bbolt.go:90 +0x6f
github.com/influxdata/platform/bolt.(*Client).Open(0xc0002e8190, 0x22b8ac0, 0xc000346700, 0x1, 0xc000156660)
    /Users/del/go/src/github.com/influxdata/platform/bolt/bbolt.go:80 +0x2be
github.com/influxdata/platform/cmd/influxd/launcher.(*Launcher).run(0xc000142700, 0x22b8ac0, 0xc000346700, 0xc00027a000, 0x1b433b0)
    /Users/del/go/src/github.com/influxdata/platform/cmd/influxd/launcher/launcher.go:228 +0x4ac
github.com/influxdata/platform/cmd/influxd/launcher.(*Launcher).Run.func1(0x0, 0x0)
    /Users/del/go/src/github.com/influxdata/platform/cmd/influxd/launcher/launcher.go:143 +0x3c
github.com/influxdata/platform/kit/cli.NewCommand.func1(0xc00027a000, 0xc0002a4200, 0x0, 0x1, 0x0, 0x0)
    /Users/del/go/src/github.com/influxdata/platform/kit/cli/viper.go:51 +0x29
github.com/spf13/cobra.(*Command).execute(0xc00027a000, 0xc0000d8010, 0x1, 0x1, 0xc00027a000, 0xc0000d8010)
    /Users/del/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762 +0x473
github.com/spf13/cobra.(*Command).ExecuteC(0xc00027a000, 0x229e030, 0x20fbc0f, 0x26)
    /Users/del/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852 +0x2fd
github.com/spf13/cobra.(*Command).Execute(0xc00027a000, 0xc00027a000, 0x1e60080)
    /Users/del/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800 +0x2b
github.com/influxdata/platform/cmd/influxd/launcher.(*Launcher).Run(0xc000142700, 0x22b8ac0, 0xc000346100, 0xc0000d8010, 0x1, 0x1, 0x0, 0xc0005d9f68)
    /Users/del/go/src/github.com/influxdata/platform/cmd/influxd/launcher/launcher.go:192 +0x64d
main.main()
    /Users/del/go/src/github.com/influxdata/platform/cmd/influxd/main.go:24 +0x142
make: *** [run] Error 2
```

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
