### PR TITLE
Remove plugin bundles that don't match the protoboards

### DIFF
--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -17,12 +17,13 @@ import {
   TelegrafPluginInputCpu,
   TelegrafPluginInputRedis,
   TelegrafPluginInputDisk,
-  TelegrafPluginInputKernel,
   TelegrafPluginInputDiskio,
   TelegrafPluginInputMem,
-  TelegrafPluginInputSwap,
   TelegrafPluginInputSystem,
   TelegrafPluginInputProcesses,
+  TelegrafPluginInputNet,
+  TelegrafPluginInputProcstat,
+  TelegrafPluginInputDocker,
 } from 'src/api'
 
 export const links: Links = {
@@ -328,9 +329,9 @@ export const diskioTelegrafPlugin = {
   configured: ConfigurationState.Configured,
 }
 
-export const kernelTelegrafPlugin = {
+export const netTelegrafPlugin = {
   ...telegrafPlugin,
-  name: TelegrafPluginInputKernel.NameEnum.Kernel,
+  name: TelegrafPluginInputNet.NameEnum.Net,
   configured: ConfigurationState.Configured,
 }
 
@@ -346,10 +347,10 @@ export const processesTelegrafPlugin = {
   configured: ConfigurationState.Configured,
 }
 
-export const swapTelegrafPlugin = {
+export const procstatTelegrafPlugin = {
   ...telegrafPlugin,
-  name: TelegrafPluginInputSwap.NameEnum.Swap,
-  configured: ConfigurationState.Configured,
+  name: TelegrafPluginInputProcstat.NameEnum.Procstat,
+  configured: ConfigurationState.Unconfigured,
 }
 
 export const systemTelegrafPlugin = {
@@ -370,6 +371,12 @@ export const redisPlugin = {
     servers: [],
     password: '',
   },
+}
+
+export const dockerTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: TelegrafPluginInputDocker.NameEnum.Docker,
+  configured: ConfigurationState.Configured,
 }
 
 export const influxDB2Plugin = {

--- a/ui/src/onboarding/constants/pluginConfigs.ts
+++ b/ui/src/onboarding/constants/pluginConfigs.ts
@@ -37,30 +37,16 @@ export const pluginsByBundle: PluginBundles = {
     TelegrafPluginInputCpu.NameEnum.Cpu,
     TelegrafPluginInputDisk.NameEnum.Disk,
     TelegrafPluginInputDiskio.NameEnum.Diskio,
-    TelegrafPluginInputKernel.NameEnum.Kernel,
-    TelegrafPluginInputMem.NameEnum.Mem,
-    TelegrafPluginInputProcesses.NameEnum.Processes,
-    TelegrafPluginInputSwap.NameEnum.Swap,
     TelegrafPluginInputSystem.NameEnum.System,
-  ],
-  [BundleName.Disk]: [
-    TelegrafPluginInputDisk.NameEnum.Disk,
-    TelegrafPluginInputDiskio.NameEnum.Diskio,
+    TelegrafPluginInputMem.NameEnum.Mem,
+    TelegrafPluginInputNet.NameEnum.Net,
+    TelegrafPluginInputProcesses.NameEnum.Processes,
+    TelegrafPluginInputProcstat.NameEnum.Procstat,
   ],
   [BundleName.Docker]: [TelegrafPluginInputDocker.NameEnum.Docker],
-  [BundleName.File]: [TelegrafPluginInputFile.NameEnum.File],
   [BundleName.Kubernetes]: [TelegrafPluginInputKubernetes.NameEnum.Kubernetes],
-  [BundleName.Logparser]: [TelegrafPluginInputLogParser.NameEnum.Logparser],
-  [BundleName.Net]: [TelegrafPluginInputNet.NameEnum.Net],
-  [BundleName.NetResponse]: [
-    TelegrafPluginInputNetResponse.NameEnum.NetResponse,
-  ],
   [BundleName.Ngnix]: [TelegrafPluginInputNgnix.NameEnum.Ngnix],
-  [BundleName.Procstat]: [TelegrafPluginInputProcstat.NameEnum.Procstat],
-  [BundleName.Prometheus]: [TelegrafPluginInputPrometheus.NameEnum.Prometheus],
   [BundleName.Redis]: [TelegrafPluginInputRedis.NameEnum.Redis],
-  [BundleName.Syslog]: [TelegrafPluginInputSyslog.NameEnum.Syslog],
-  [BundleName.Tail]: [TelegrafPluginInputTail.NameEnum.Tail],
 }
 
 export const telegrafPluginsInfo: TelegrafPluginInfo = {
@@ -272,7 +258,6 @@ import {
   LogoDocker,
   LogoKubernetes,
   LogoNginx,
-  LogoPrometheus,
   LogoRedis,
 } from 'src/onboarding/graphics'
 
@@ -281,23 +266,13 @@ export const BUNDLE_LOGOS = {
   [BundleName.Docker]: LogoDocker,
   [BundleName.Kubernetes]: LogoKubernetes,
   [BundleName.Ngnix]: LogoNginx,
-  [BundleName.Prometheus]: LogoPrometheus,
   [BundleName.Redis]: LogoRedis,
 }
 
 export const PLUGIN_BUNDLE_OPTIONS: BundleName[] = [
   BundleName.System,
-  BundleName.Disk,
   BundleName.Docker,
-  BundleName.File,
   BundleName.Kubernetes,
-  BundleName.Logparser,
-  BundleName.Net,
-  BundleName.NetResponse,
   BundleName.Ngnix,
-  BundleName.Procstat,
-  BundleName.Prometheus,
   BundleName.Redis,
-  BundleName.Syslog,
-  BundleName.Tail,
 ]

--- a/ui/src/onboarding/reducers/dataLoaders.test.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.test.ts
@@ -28,14 +28,15 @@ import {
   cpuTelegrafPlugin,
   diskTelegrafPlugin,
   diskioTelegrafPlugin,
-  kernelTelegrafPlugin,
+  netTelegrafPlugin,
   memTelegrafPlugin,
   processesTelegrafPlugin,
-  swapTelegrafPlugin,
+  procstatTelegrafPlugin,
   systemTelegrafPlugin,
   redisTelegrafPlugin,
   token,
   telegrafConfig,
+  dockerTelegrafPlugin,
 } from 'mocks/dummyData'
 
 // Types
@@ -374,16 +375,17 @@ describe('dataLoader reducer', () => {
     const actual = dataLoadersReducer(
       {
         ...INITIAL_STATE,
-        pluginBundles: [BundleName.Disk, BundleName.System],
+        pluginBundles: [BundleName.Docker, BundleName.System],
         telegrafPlugins: [
           cpuTelegrafPlugin,
           diskTelegrafPlugin,
           diskioTelegrafPlugin,
-          kernelTelegrafPlugin,
+          netTelegrafPlugin,
           memTelegrafPlugin,
           processesTelegrafPlugin,
-          swapTelegrafPlugin,
+          procstatTelegrafPlugin,
           systemTelegrafPlugin,
+          dockerTelegrafPlugin,
         ],
       },
       removeBundlePlugins(BundleName.System)
@@ -391,8 +393,8 @@ describe('dataLoader reducer', () => {
 
     const expected = {
       ...INITIAL_STATE,
-      pluginBundles: [BundleName.Disk, BundleName.System],
-      telegrafPlugins: [diskTelegrafPlugin, diskioTelegrafPlugin],
+      pluginBundles: [BundleName.Docker, BundleName.System],
+      telegrafPlugins: [dockerTelegrafPlugin],
     }
 
     expect(actual).toEqual(expected)
@@ -430,11 +432,11 @@ describe('dataLoader reducer', () => {
         cpuTelegrafPlugin,
         diskTelegrafPlugin,
         diskioTelegrafPlugin,
-        kernelTelegrafPlugin,
-        memTelegrafPlugin,
-        processesTelegrafPlugin,
-        swapTelegrafPlugin,
         systemTelegrafPlugin,
+        memTelegrafPlugin,
+        netTelegrafPlugin,
+        processesTelegrafPlugin,
+        procstatTelegrafPlugin,
       ])
     )
   })

--- a/ui/src/onboarding/utils/__snapshots__/pluginConfigs.test.ts.snap
+++ b/ui/src/onboarding/utils/__snapshots__/pluginConfigs.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Onboarding.Utils.PluginConfig if plugin is found in only one bundle isPluginUniqueToBundle returns true 1`] = `true`;

--- a/ui/src/onboarding/utils/pluginConfigs.test.ts
+++ b/ui/src/onboarding/utils/pluginConfigs.test.ts
@@ -6,39 +6,25 @@ import {
 
 // Types
 import {BundleName} from 'src/types/v2/dataLoaders'
-import {
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputDisk,
-  TelegrafPluginInputSystem,
-} from 'src/api'
+import {TelegrafPluginInputCpu, TelegrafPluginInputSystem} from 'src/api'
 
 describe('Onboarding.Utils.PluginConfig', () => {
   describe('if plugin is found in only one bundle', () => {
     it('isPluginUniqueToBundle returns true', () => {
       const telegrafPlugin = TelegrafPluginInputCpu.NameEnum.Cpu
       const bundle = BundleName.System
-      const bundles = [BundleName.System, BundleName.Disk]
+      const bundles = [BundleName.System, BundleName.Docker]
 
       const actual = isPluginUniqueToBundle(telegrafPlugin, bundle, bundles)
 
       expect(actual).toBe(true)
-    })
-  })
-  describe('if plugin is found in multiple bundles', () => {
-    it('isPluginUniqueToBundle returns false', () => {
-      const telegrafPlugin = TelegrafPluginInputDisk.NameEnum.Disk
-      const bundle = BundleName.System
-      const bundles = [BundleName.System, BundleName.Disk]
-
-      const actual = isPluginUniqueToBundle(telegrafPlugin, bundle, bundles)
-
-      expect(actual).toBe(false)
+      expect(actual).toMatchSnapshot()
     })
   })
   describe('if plugin is not in bundle', () => {
     it('isPluginInBundle returns false', () => {
       const telegrafPlugin = TelegrafPluginInputSystem.NameEnum.System
-      const bundle = BundleName.Disk
+      const bundle = BundleName.Docker
 
       const actual = isPluginInBundle(telegrafPlugin, bundle)
 

--- a/ui/src/types/v2/dataLoaders.ts
+++ b/ui/src/types/v2/dataLoaders.ts
@@ -107,19 +107,10 @@ export interface TelegrafPlugin {
 
 export enum BundleName {
   System = 'System',
-  Disk = 'Disk',
   Docker = 'Docker',
-  File = 'File',
   Kubernetes = 'Kubernetes',
-  Logparser = 'LogParser',
-  Net = 'Net',
-  NetResponse = 'NetResponse',
   Ngnix = 'NGNIX',
-  Procstat = 'Procstat',
-  Prometheus = 'Prometheus',
   Redis = 'Redis',
-  Syslog = 'Syslog',
-  Tail = 'Tail',
 }
 
 export type TelegrafPluginName =


### PR DESCRIPTION
Closes #1894

Removed the plugin bundles from plugin configs and updated the tests to match correct bundles and names.
