### PR TITLE
fix(ui/dataLoaders): Ensure type is streaming if the substep is streaming

### DIFF
--- a/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
+++ b/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
@@ -61,6 +61,12 @@ export class SelectDataSourceStep extends PureComponent<Props, State> {
     this.state = {showStreamingSources: false}
   }
 
+  public componentDidMount() {
+    if (this.isStreaming && this.props.type !== DataLoaderType.Streaming) {
+      this.props.onSetDataLoadersType(DataLoaderType.Streaming)
+    }
+  }
+
   public render() {
     return (
       <Form onSubmit={this.handleClickNext}>


### PR DESCRIPTION

_Briefly describe your proposed changes:_
Previously, if you refreshed on the streaming onboarding step, the url would still be that of the streaming step but would show the data loaders type selection rather than the streaming selection. this changed made it so that if the url has the substep of streaming, then the type should be set to streaming.

  - [x] Rebased/mergeable
  - [x] Tests pass
