### PR TITLE
fix(ui/onboarding): Prevent unskippable steps from being skipped with progress bar

### DIFF
--- a/ui/src/clockface/components/wizard/ProgressBar.scss
+++ b/ui/src/clockface/components/wizard/ProgressBar.scss
@@ -84,6 +84,10 @@
   }
 }
 
+.unclickable {
+  cursor: default;
+}
+
 .wizard--progress-connector {
   min-width: 20px;
   width: 100%;

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -105,7 +105,7 @@ class OnboardingWizard extends PureComponent<Props> {
     'Complete',
   ]
 
-  public stepSkippable = [false, false, false, false, false, false]
+  public stepSkippable = [true, false, true, true, true, true]
 
   constructor(props: Props) {
     super(props)
@@ -190,6 +190,7 @@ class OnboardingWizard extends PureComponent<Props> {
           handleSetCurrentStep={onSetCurrentStepIndex}
           stepStatuses={stepStatuses}
           stepTitles={this.stepTitles}
+          stepSkippable={this.stepSkippable}
         />
       </WizardProgressHeader>
     )


### PR DESCRIPTION
Closes #1939

_Briefly describe your proposed changes:_
The admin step of the onboarding wizard should not be able to be skipped. However, it is skippable by clicking on the steps in the progress bar. this pr adds a check in the progress bar that prevent non skippable steps from being skipped via the progress bar

  - [x] Rebased/mergeable
  - [x] Tests pass