### PR TITLE
Remove 32bit architectures from builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,17 +5,7 @@ builds:
     - darwin
     goarch:
     - amd64
-    - 386
-    - arm
     - arm64
-    goarm:
-    - 6
-    - 7
-    ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: windows
-        goarch: 386
     main: ./cmd/influx/
     env:
       - GO111MODULE=on
@@ -26,17 +16,7 @@ builds:
     - darwin
     goarch:
     - amd64
-    - 386
-    - arm
     - arm64
-    goarm:
-    - 6
-    - 7
-    ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: windows
-        goarch: 386
     main: ./cmd/influxd/
     flags:
       - -tags=assets


### PR DESCRIPTION
We don't currently plan to provide 32 bit support in Platform. As such, we don't want to attempt to build binaries targetting 32 bit architectures. 

This PR removes support for building 32bit architectures, including i386, arm6 and arm7.

Closes #2233.