### PR TITLE
store label properties in a separate bucket

### DIFF
--- a/bolt/label.go
+++ b/bolt/label.go
@@ -218,7 +218,11 @@ func (c *Client) updateLabel(ctx context.Context, tx *bolt.Tx, l *platform.Label
 
 	label := ls[0]
 
-	if label.Properties != nil {
+	if label.Properties == nil {
+		label.Properties = make(map[string]string)
+	}
+
+	if upd.Properties != nil {
 		for k, v := range upd.Properties {
 			if v == "" {
 				delete(label.Properties, k)

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -24,7 +24,7 @@ func (s *Service) loadLabel(ctx context.Context, resourceID platform.ID, name st
 
 	l, ok := i.(platform.Label)
 	if !ok {
-		return nil, fmt.Errorf("type %T is not a label~", i)
+		return nil, fmt.Errorf("type %T is not a label", i)
 	}
 
 	i, ok = s.labelPropKV.Load(encodeLabelPropKey(name))
@@ -50,7 +50,7 @@ func (s *Service) forEachLabel(ctx context.Context, fn func(m *platform.Label) b
 	s.labelKV.Range(func(k, v interface{}) bool {
 		l, ok := v.(platform.Label)
 		if !ok {
-			err = fmt.Errorf("type %T is not a label!!", v)
+			err = fmt.Errorf("type %T is not a label", v)
 			return false
 		}
 		return fn(&l)

--- a/inmem/service.go
+++ b/inmem/service.go
@@ -24,6 +24,7 @@ type Service struct {
 	dbrpMappingKV         sync.Map
 	userResourceMappingKV sync.Map
 	labelKV               sync.Map
+	labelPropKV           sync.Map
 	scraperTargetKV       sync.Map
 	telegrafConfigKV      sync.Map
 	onboardingKV          sync.Map

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -399,44 +399,56 @@ func UpdateLabel(
 				},
 			},
 		},
-		// {
-		// 	name: "label update proliferation",
-		// 	fields: LabelFields{
-		// 		Labels: []*platform.Label{
-		// 			{
-		// 				ResourceID: MustIDBase16(bucketOneID),
-		// 				Name:       "Tag1",
-		// 			},
-		// 			{
-		// 				ResourceID: MustIDBase16(bucketTwoID),
-		// 				Name:       "Tag1",
-		// 			},
-		// 		},
-		// 	},
-		// 	args: args{
-		// 		label: platform.Label{
-		// 			ResourceID: MustIDBase16(bucketOneID),
-		// 			Name:       "Tag1",
-		// 		},
-		// 		update: platform.LabelUpdate{
-		// 			Color: &validColor,
-		// 		},
-		// 	},
-		// 	wants: wants{
-		// 		labels: []*platform.Label{
-		// 			{
-		// 				ResourceID: MustIDBase16(bucketOneID),
-		// 				Name:       "Tag1",
-		// 				Color:      "fff000",
-		// 			},
-		// 			{
-		// 				ResourceID: MustIDBase16(bucketTwoID),
-		// 				Name:       "Tag1",
-		// 				Color:      "fff000",
-		// 			},
-		// 		},
-		// 	},
-		// },
+		{
+			name: "label update proliferation",
+			fields: LabelFields{
+				Labels: []*platform.Label{
+					{
+						ResourceID: MustIDBase16(bucketOneID),
+						Name:       "Tag1",
+						Properties: map[string]string{
+							"color": "aaabbb",
+						},
+					},
+					{
+						ResourceID: MustIDBase16(bucketTwoID),
+						Name:       "Tag1",
+						Properties: map[string]string{
+							"color": "aaabbb",
+						},
+					},
+				},
+			},
+			args: args{
+				label: platform.Label{
+					ResourceID: MustIDBase16(bucketOneID),
+					Name:       "Tag1",
+				},
+				update: platform.LabelUpdate{
+					Properties: map[string]string{
+						"color": "fff000",
+					},
+				},
+			},
+			wants: wants{
+				labels: []*platform.Label{
+					{
+						ResourceID: MustIDBase16(bucketOneID),
+						Name:       "Tag1",
+						Properties: map[string]string{
+							"color": "fff000",
+						},
+					},
+					{
+						ResourceID: MustIDBase16(bucketTwoID),
+						Name:       "Tag1",
+						Properties: map[string]string{
+							"color": "fff000",
+						},
+					},
+				},
+			},
+		},
 		{
 			name: "updating a non-existent label",
 			fields: LabelFields{


### PR DESCRIPTION
Each label that is created has separate properties, but all label mappings with the same name should actually share the same properties.

This PR implements shared label properties by adding another boltDB bucket for them.
