### PR TITLE
Add protos (templates of dasboards)

### DIFF
--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -139,6 +139,7 @@ func RunLauncherOrFail(tb testing.TB, ctx context.Context, args ...string) *Laun
 // Run executes the program with additional arguments to set paths and ports.
 func (l *Launcher) Run(ctx context.Context, args ...string) error {
 	args = append(args, "--bolt-path", filepath.Join(l.Path, "influxd.bolt"))
+	args = append(args, "--protos-path", filepath.Join(l.Path, "protos"))
 	args = append(args, "--engine-path", filepath.Join(l.Path, "engine"))
 	args = append(args, "--nats-path", filepath.Join(l.Path, "nats"))
 	args = append(args, "--http-bind-address", "127.0.0.1:0")

--- a/dashboard.go
+++ b/dashboard.go
@@ -157,9 +157,7 @@ func (u DashboardUpdate) Valid() *Error {
 
 // AddDashboardCellOptions are options for adding a dashboard.
 type AddDashboardCellOptions struct {
-	// UsingView specifies the view that should be used as a template
-	// for the new cells view.
-	UsingView ID
+	View *View
 }
 
 // CellUpdate is the patch structure for a cell.

--- a/fs/proto.go
+++ b/fs/proto.go
@@ -1,0 +1,161 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/influxdata/platform"
+	"go.uber.org/zap"
+)
+
+const protoFileExt = ".json"
+
+// ProtoService implements platform.ProtoService on the file system.
+type ProtoService struct {
+	Dir              string
+	DashboardService platform.DashboardService
+	Logger           *zap.Logger
+
+	protos []*platform.Proto
+}
+
+// NewProtoService creates an instance of a ProtoService.
+func NewProtoService(dir string, logger *zap.Logger, s platform.DashboardService) *ProtoService {
+	return &ProtoService{
+		Dir:              dir,
+		Logger:           logger.With(zap.String("service", "proto")),
+		DashboardService: s,
+	}
+}
+
+// WithProtos is used for testing the ProtoService. It will overwrite the protos on the service.
+func (s *ProtoService) WithProtos(ps []*platform.Proto) {
+	s.protos = ps
+}
+
+// Open loads the protos from the file system and sets them on the service.
+func (s *ProtoService) Open(ctx context.Context) error {
+	if _, err := os.Stat(s.Dir); os.IsNotExist(err) {
+		if err := os.Mkdir(s.Dir, 0600); err != nil {
+			return err
+		}
+	}
+
+	files, err := ioutil.ReadDir(s.Dir)
+	if err != nil {
+		return err
+	}
+
+	protos := []*platform.Proto{}
+	for _, file := range files {
+		filename := file.Name()
+		if path.Ext(filename) != protoFileExt {
+			s.Logger.Info("file extention did not match proto file extension", zap.String("file", filename))
+			continue
+		}
+
+		octets, err := ioutil.ReadFile(filepath.Join(s.Dir, filename))
+		if err != nil {
+			s.Logger.Info("error openeing file", zap.String("file", filename), zap.Error(err))
+			continue
+		}
+
+		proto := &platform.Proto{}
+		if err := json.Unmarshal(octets, proto); err != nil {
+			s.Logger.Info("error unmarshalling file into proto", zap.String("file", filename), zap.Error(err))
+			continue
+		}
+
+		// TODO(desa): ensure that the proto provided is a valid proto (e.g. that all viewID exists for all cells in a dashboard).
+
+		protos = append(protos, proto)
+	}
+
+	s.protos = protos
+
+	return nil
+}
+
+// FindProtos returns a list of protos from the file system.
+func (s *ProtoService) FindProtos(ctx context.Context) ([]*platform.Proto, error) {
+	protos := []*platform.Proto{}
+	for _, proto := range s.protos {
+		// easy way to make a deep copy
+		octets, err := json.Marshal(proto)
+		if err != nil {
+			return nil, err
+		}
+
+		p := &platform.Proto{}
+		if err := json.Unmarshal(octets, p); err != nil {
+			return nil, err
+		}
+
+		protos = append(protos, p)
+	}
+
+	return protos, nil
+}
+
+func (s *ProtoService) findProto(ctx context.Context, id platform.ID) (*platform.Proto, error) {
+	for _, proto := range s.protos {
+		if proto.ID == id {
+			return proto, nil
+		}
+	}
+
+	return nil, &platform.Error{Msg: "proto not found"}
+}
+
+// CreateDashboardsFromProtos creates instances of each dashboard in a proto.
+func (s *ProtoService) CreateDashboardsFromProto(ctx context.Context, protoID platform.ID, orgID platform.ID) ([]*platform.Dashboard, error) {
+	// TODO(desa): this should be done transactionally.
+	proto, err := s.findProto(ctx, protoID)
+	if err != nil {
+		return nil, err
+	}
+
+	dashes := []*platform.Dashboard{}
+
+	for _, protodash := range proto.Dashboards {
+		dash := &platform.Dashboard{}
+		*dash = protodash.Dashboard
+		// TODO(desa): add organization id here
+		dash.Cells = nil
+
+		if err := s.DashboardService.CreateDashboard(ctx, dash); err != nil {
+			return nil, err
+		}
+
+		cells := []*platform.Cell{}
+		for _, protocell := range protodash.Dashboard.Cells {
+			cell := &platform.Cell{}
+			*cell = *protocell
+
+			protoview, ok := protodash.Views[cell.ID]
+			if !ok {
+				return nil, &platform.Error{Msg: fmt.Sprintf("view for ID %q does not exist", cell.ID)}
+			}
+
+			view := &platform.View{}
+			*view = protoview
+			opts := platform.AddDashboardCellOptions{View: view}
+			if err := s.DashboardService.AddDashboardCell(ctx, dash.ID, cell, opts); err != nil {
+				return nil, err
+			}
+
+			cells = append(cells, cell)
+		}
+
+		dash.Cells = cells
+
+		dashes = append(dashes, dash)
+	}
+
+	return dashes, nil
+}

--- a/fs/proto_test.go
+++ b/fs/proto_test.go
@@ -1,0 +1,138 @@
+package fs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/fs"
+	platformtesting "github.com/influxdata/platform/testing"
+	"go.uber.org/zap"
+)
+
+var protoCmpOptions = cmp.Options{
+	cmpopts.EquateEmpty(),
+}
+
+func TestProtoService_FindProtos(t *testing.T) {
+	type fields struct {
+		protos []*platform.Proto
+	}
+	type wants struct {
+		protos []*platform.Proto
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		wants  wants
+	}{
+		{
+			name: "get protos",
+			fields: fields{
+				protos: []*platform.Proto{
+					{
+						ID:   1,
+						Name: "system",
+						Dashboards: []platform.ProtoDashboard{
+							{
+								Dashboard: platform.Dashboard{
+									Name:        "hello",
+									Description: "oh hello there!",
+									Meta: platform.DashboardMeta{
+										CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+										UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
+									},
+									Cells: []*platform.Cell{
+										{
+											ID: platformtesting.MustIDBase16("da7aba5e5d81e550"),
+											X:  1,
+											Y:  2,
+											W:  3,
+											H:  4,
+										},
+									},
+								},
+								Views: map[platform.ID]platform.View{
+									platformtesting.MustIDBase16("da7aba5e5d81e550"): platform.View{
+										ViewContents: platform.ViewContents{
+											Name: "hello",
+										},
+										Properties: platform.XYViewProperties{
+											Type: "xy",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wants: wants{
+				protos: []*platform.Proto{
+					{
+						ID:   1,
+						Name: "system",
+						Dashboards: []platform.ProtoDashboard{
+							{
+								Dashboard: platform.Dashboard{
+									Name:        "hello",
+									Description: "oh hello there!",
+									Meta: platform.DashboardMeta{
+										CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+										UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
+									},
+									Cells: []*platform.Cell{
+										{
+											ID: platformtesting.MustIDBase16("da7aba5e5d81e550"),
+											X:  1,
+											Y:  2,
+											W:  3,
+											H:  4,
+										},
+									},
+								},
+								Views: map[platform.ID]platform.View{
+									platformtesting.MustIDBase16("da7aba5e5d81e550"): platform.View{
+										ViewContents: platform.ViewContents{
+											Name: "hello",
+										},
+										Properties: platform.XYViewProperties{
+											Type: "xy",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// dir is not actually required for this test
+			dir := ""
+			logger := zap.NewNop()
+			s := fs.NewProtoService(dir, logger, nil)
+			s.WithProtos(tt.fields.protos)
+
+			ctx := context.Background()
+			protos, err := s.FindProtos(ctx)
+			if err != nil {
+				// TODO(desa): fill is sad path eventually
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(protos, tt.wants.protos, protoCmpOptions...); diff != "" {
+				t.Errorf("protos are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// TODO(desa): Add tests for CreateDashboardsFromProto.

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -25,6 +25,7 @@ type APIHandler struct {
 	TaskHandler          *TaskHandler
 	TelegrafHandler      *TelegrafHandler
 	QueryHandler         *FluxHandler
+	ProtoHandler         *ProtoHandler
 	WriteHandler         *WriteHandler
 	SetupHandler         *SetupHandler
 	SessionHandler       *SessionHandler
@@ -63,6 +64,7 @@ type APIBackend struct {
 	SecretService                   platform.SecretService
 	LookupService                   platform.LookupService
 	ChronografService               *server.Service
+	ProtoService                    platform.ProtoService
 }
 
 // NewAPIHandler constructs all api handlers beneath it and returns an APIHandler
@@ -132,6 +134,8 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.QueryHandler.Logger = b.Logger.With(zap.String("handler", "query"))
 	h.QueryHandler.ProxyQueryService = b.ProxyQueryService
 
+	h.ProtoHandler = NewProtoHandler(NewProtoBackend(b))
+
 	h.ChronografHandler = NewChronografHandler(b.ChronografService)
 
 	return h
@@ -149,6 +153,7 @@ var apiLinks = map[string]interface{}{
 	"macros": "/api/v2/macros",
 	"me":     "/api/v2/me",
 	"orgs":   "/api/v2/orgs",
+	"protos": "/api/v2/protos",
 	"query": map[string]string{
 		"self":        "/api/v2/query",
 		"ast":         "/api/v2/query/ast",
@@ -259,6 +264,11 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if strings.HasPrefix(r.URL.Path, "/api/v2/macros") {
 		h.MacroHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/protos") {
+		h.ProtoHandler.ServeHTTP(w, r)
 		return
 	}
 

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -727,7 +727,7 @@ func decodeGetDashboardCellViewRequest(ctx context.Context, r *http.Request) (*g
 	params := httprouter.ParamsFromContext(ctx)
 	id := params.ByName("id")
 	if id == "" {
-		return nil, errors.InvalidDataf("url missing id")
+		return nil, platform.NewError(platform.WithErrorMsg("url missing id"), platform.WithErrorCode(platform.EInvalid))
 	}
 	if err := req.dashboardID.DecodeFromString(id); err != nil {
 		return nil, err
@@ -735,7 +735,7 @@ func decodeGetDashboardCellViewRequest(ctx context.Context, r *http.Request) (*g
 
 	cellID := params.ByName("cellID")
 	if cellID == "" {
-		return nil, errors.InvalidDataf("url missing cellID")
+		return nil, platform.NewError(platform.WithErrorMsg("url missing cellID"), platform.WithErrorCode(platform.EInvalid))
 	}
 	if err := req.cellID.DecodeFromString(cellID); err != nil {
 		return nil, err
@@ -777,7 +777,7 @@ func decodePatchDashboardCellViewRequest(ctx context.Context, r *http.Request) (
 	params := httprouter.ParamsFromContext(ctx)
 	id := params.ByName("id")
 	if id == "" {
-		return nil, errors.InvalidDataf("url missing id")
+		return nil, platform.NewError(platform.WithErrorMsg("url missing id"), platform.WithErrorCode(platform.EInvalid))
 	}
 	if err := req.dashboardID.DecodeFromString(id); err != nil {
 		return nil, err
@@ -785,7 +785,7 @@ func decodePatchDashboardCellViewRequest(ctx context.Context, r *http.Request) (
 
 	cellID := params.ByName("cellID")
 	if cellID == "" {
-		return nil, errors.InvalidDataf("url missing cellID")
+		return nil, platform.NewError(platform.WithErrorMsg("url missing cellID"), platform.WithErrorCode(platform.EInvalid))
 	}
 	if err := req.cellID.DecodeFromString(cellID); err != nil {
 		return nil, err

--- a/http/proto.go
+++ b/http/proto.go
@@ -1,0 +1,164 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/influxdata/platform"
+	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
+)
+
+// ProtoHandler is the handler for creating instances of
+// prebuilt resources (dashboards, tasks, etcd).
+type ProtoHandler struct {
+	*httprouter.Router
+	Logger       *zap.Logger
+	ProtoService platform.ProtoService
+	LabelService platform.LabelService
+}
+
+const (
+	protosPath           = "/api/v2/protos"
+	protosDashboardsPath = "/api/v2/protos/:protoID/dashboards"
+)
+
+func extractID(ctx context.Context, s string) (platform.ID, error) {
+	params := httprouter.ParamsFromContext(ctx)
+	idStr := params.ByName(s)
+	if idStr == "" {
+		return 0, platform.NewError(platform.WithErrorMsg("url missing protoID"), platform.WithErrorCode(platform.EInvalid))
+	}
+
+	var id platform.ID
+	if err := id.DecodeFromString(idStr); err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func extractProtoID(ctx context.Context) (platform.ID, error) {
+	return extractID(ctx, "protoID")
+}
+
+// ProtoBackend is the backend for the proto handler.
+type ProtoBackend struct {
+	Logger       *zap.Logger
+	ProtoService platform.ProtoService
+	LabelService platform.LabelService
+}
+
+// NewProtoBackend creates an instance of the Protobackend from the APIBackend.
+func NewProtoBackend(b *APIBackend) *ProtoBackend {
+	return &ProtoBackend{
+		Logger:       b.Logger.With(zap.String("handler", "proto")),
+		ProtoService: b.ProtoService,
+		LabelService: b.LabelService,
+	}
+}
+
+// NewProtoHandler creates an instance of a proto handler.
+func NewProtoHandler(b *ProtoBackend) *ProtoHandler {
+	h := &ProtoHandler{
+		Router:       NewRouter(),
+		Logger:       b.Logger,
+		ProtoService: b.ProtoService,
+		LabelService: b.LabelService,
+	}
+
+	h.HandlerFunc("GET", protosPath, h.handleGetProtos)
+	h.HandlerFunc("POST", protosDashboardsPath, h.handlePostProtosDashboards)
+
+	return h
+}
+
+type protosResponse struct {
+	Protos []*protoResponse `json:"protos"`
+}
+
+func newProtosResponse(ps []*platform.Proto) *protosResponse {
+	rs := []*protoResponse{}
+	for _, p := range ps {
+		rs = append(rs, newProtoResponse(p))
+	}
+
+	return &protosResponse{
+		Protos: rs,
+	}
+}
+
+type protoResponse struct {
+	Links map[string]string `json:"links"`
+	*platform.Proto
+}
+
+func newProtoResponse(p *platform.Proto) *protoResponse {
+	return &protoResponse{
+		Links: map[string]string{
+			"dashboards": fmt.Sprintf("/api/v2/protos/%s/dashboards", p.ID),
+		},
+		Proto: p,
+	}
+}
+
+func (h *ProtoHandler) handleGetProtos(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	ps, err := h.ProtoService.FindProtos(ctx)
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	if err := encodeResponse(ctx, w, http.StatusOK, newProtosResponse(ps)); err != nil {
+		logEncodingError(h.Logger, r, err)
+		return
+	}
+}
+
+type createProtoResourcesRequest struct {
+	ProtoID        platform.ID `json:"-"`
+	OrganizationID platform.ID `json:"organizationID"`
+}
+
+// Decode turns an http request into a createProtoResourceRequest.
+func (r *createProtoResourcesRequest) Decode(req *http.Request) error {
+	ctx := req.Context()
+	id, err := extractProtoID(ctx)
+	if err != nil {
+		return err
+	}
+
+	r.ProtoID = id
+
+	if err := json.NewDecoder(req.Body).Decode(r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *ProtoHandler) handlePostProtosDashboards(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req := &createProtoResourcesRequest{}
+	if err := req.Decode(r); err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	ds, err := h.ProtoService.CreateDashboardsFromProto(ctx, req.ProtoID, req.OrganizationID)
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	if err := encodeResponse(ctx, w, http.StatusCreated, newGetDashboardsResponse(ctx, ds, h.LabelService)); err != nil {
+		logEncodingError(h.Logger, r, err)
+		return
+	}
+
+}

--- a/http/proto_test.go
+++ b/http/proto_test.go
@@ -1,0 +1,238 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/mock"
+	platformtesting "github.com/influxdata/platform/testing"
+	"go.uber.org/zap"
+)
+
+// TestProtoHandler tests the ProtoHandler.
+func TestProtoHandler(t *testing.T) {
+	type fields struct {
+		ProtoService platform.ProtoService
+	}
+	type args struct {
+		method   string
+		endpoint string
+		body     interface{}
+	}
+	type wants struct {
+		body        string
+		contentType string
+		statusCode  int
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "get all protos",
+			fields: fields{
+				ProtoService: &mock.ProtoService{
+					FindProtosFn: func(context.Context) ([]*platform.Proto, error) {
+						return []*platform.Proto{
+							{
+								ID:   1,
+								Name: "system",
+							},
+							{
+								ID:   2,
+								Name: "k8s",
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				method:   "GET",
+				endpoint: "/api/v2/protos",
+				body:     nil,
+			},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json; charset=utf-8",
+				body: `
+{
+  "protos": [
+    {
+      "id": "0000000000000001",
+      "links": {
+        "dashboards": "/api/v2/protos/0000000000000001/dashboards"
+      },
+      "name": "system"
+    },
+    {
+      "id": "0000000000000002",
+      "links": {
+        "dashboards": "/api/v2/protos/0000000000000002/dashboards"
+      },
+      "name": "k8s"
+    }
+  ]
+}
+`,
+			},
+		},
+		{
+			name: "create dashboard from proto",
+			fields: fields{
+				ProtoService: &mock.ProtoService{
+					CreateDashboardsFromProtoFn: func(ctx context.Context, protoID, orgID platform.ID) ([]*platform.Dashboard, error) {
+						return []*platform.Dashboard{
+							{
+								ID:          platformtesting.MustIDBase16("da7aba5e5d81e550"),
+								Name:        "hello",
+								Description: "oh hello there!",
+								Meta: platform.DashboardMeta{
+									CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+									UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
+								},
+								Cells: []*platform.Cell{
+									{
+										ID: platformtesting.MustIDBase16("da7aba5e5d81e550"),
+										X:  1,
+										Y:  2,
+										W:  3,
+										H:  4,
+									},
+								},
+							},
+							{
+								ID: platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								Meta: platform.DashboardMeta{
+									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
+									UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
+								},
+								Name: "example",
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				method:   "POST",
+				endpoint: "/api/v2/protos/0000000000000001/dashboards",
+				body: &createProtoResourcesRequest{
+					OrganizationID: 100,
+				},
+			},
+			wants: wants{
+				statusCode:  http.StatusCreated,
+				contentType: "application/json; charset=utf-8",
+				body: `
+		{
+		  "dashboards": [
+		    {
+		      "cells": [
+		        {
+		          "h": 4,
+		          "id": "da7aba5e5d81e550",
+		          "links": {
+		            "self": "/api/v2/dashboards/da7aba5e5d81e550/cells/da7aba5e5d81e550",
+		            "view": "/api/v2/dashboards/da7aba5e5d81e550/cells/da7aba5e5d81e550/view"
+		          },
+		          "w": 3,
+		          "x": 1,
+		          "y": 2
+		        }
+		      ],
+		      "description": "oh hello there!",
+		      "id": "da7aba5e5d81e550",
+		      "labels": [
+		      ],
+		      "links": {
+		        "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
+		        "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels",
+		        "log": "/api/v2/dashboards/da7aba5e5d81e550/log",
+		        "self": "/api/v2/dashboards/da7aba5e5d81e550"
+		      },
+		      "meta": {
+		        "createdAt": "2009-11-10T23:00:00Z",
+		        "updatedAt": "2009-11-11T00:00:00Z"
+		      },
+		      "name": "hello"
+		    },
+		    {
+		      "cells": [
+		      ],
+		      "description": "",
+		      "id": "0ca2204eca2204e0",
+		      "labels": [
+		      ],
+		      "links": {
+		        "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells",
+		        "labels": "/api/v2/dashboards/0ca2204eca2204e0/labels",
+		        "log": "/api/v2/dashboards/0ca2204eca2204e0/log",
+		        "self": "/api/v2/dashboards/0ca2204eca2204e0"
+		      },
+		      "meta": {
+		        "createdAt": "2012-11-10T23:00:00Z",
+		        "updatedAt": "2012-11-11T00:00:00Z"
+		      },
+		      "name": "example"
+		    }
+		  ],
+		  "links": {
+		    "self": "/api/v2/dashboards"
+		  }
+		}
+		`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &ProtoBackend{
+				Logger:       zap.NewNop(),
+				LabelService: mock.NewLabelService(),
+				ProtoService: tt.fields.ProtoService,
+			}
+
+			h := NewProtoHandler(b)
+
+			var bdy io.Reader
+			if tt.args.body != nil {
+				bs, err := json.Marshal(tt.args.body)
+				if err != nil {
+					t.Fatalf("unexpected errror marshalling body: %v", err)
+				}
+
+				bdy = bytes.NewReader(bs)
+			}
+
+			r := httptest.NewRequest(tt.args.method, "http://localhost:9999"+tt.args.endpoint, bdy)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("got %v, want %v", res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("got %v, want %v", content, tt.wants.contentType)
+			}
+			if eq, diff, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("diff\n-got/+want\n%s", diff)
+			}
+
+		})
+	}
+}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -47,6 +47,59 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Routes"
+  /protos:
+    get:
+      tags:
+        - Protos
+      summary: List of available protos (templates of tasks/dashboards/etc)
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+      responses:
+        '200':
+          description: List of protos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Protos"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /protos/{protoID}/dashboards:
+    post:
+      tags:
+        - Protos
+      summary: Create instance of a proto dashboard
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: protoID
+          schema:
+            type: string
+          required: true
+          description: ID of proto
+      requestBody:
+          description: organization that the dashboard will be created as
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateProtoResourcesRequest"
+      responses:
+        '201':
+          description: List of dashboards that was created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dashboards"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /setup:
     get:
       tags:
@@ -5245,6 +5298,9 @@ components:
         orgs:
           type: string
           format: uri
+        protos:
+          type: string
+          format: uri
         query:
           type: object
           properties:
@@ -6034,6 +6090,40 @@ components:
           type: array
           items:
             type: string
+    CreateProtoResourcesRequest:
+      properties:
+        organizationID:
+          type: string
+    Proto:
+      properties:
+        links:
+          readOnly: true
+          type: object
+          properties:
+            dashboard:
+              type: string
+              format: uri
+        id:
+          readOnly: true
+          type: string
+        name:
+          readOnly: true
+          type: string
+          description: user-facing name of the proto
+        dashboards:
+          type: array
+          items:
+            $ref: "#/components/schemas/Dashboard"
+        views:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/View"
+    Protos:
+      properties:
+        protos:
+          type: array
+          items:
+            $ref: "#/components/schemas/Proto"
     Dashboard:
       properties:
         links:

--- a/mock/proto.go
+++ b/mock/proto.go
@@ -1,0 +1,31 @@
+package mock
+
+import (
+	"context"
+	"errors"
+
+	"github.com/influxdata/platform"
+)
+
+// ProtoService is a mock implementation of a retention.ProtoService, which
+// also makes it a suitable mock to use wherever an platform.ProtoService is required.
+type ProtoService struct {
+	FindProtosFn                func(context.Context) ([]*platform.Proto, error)
+	CreateDashboardsFromProtoFn func(context.Context, platform.ID, platform.ID) ([]*platform.Dashboard, error)
+}
+
+// FindProtos returns a list of protos.
+func (s *ProtoService) FindProtos(ctx context.Context) ([]*platform.Proto, error) {
+	if s.FindProtosFn == nil {
+		return nil, errors.New("not implemented")
+	}
+	return s.FindProtosFn(ctx)
+}
+
+// CreateDashboardsFromProto creates a new set of dashboards for a proto
+func (s *ProtoService) CreateDashboardsFromProto(ctx context.Context, protoID, orgID platform.ID) ([]*platform.Dashboard, error) {
+	if s.CreateDashboardsFromProtoFn == nil {
+		return nil, errors.New("not implemented")
+	}
+	return s.CreateDashboardsFromProtoFn(ctx, protoID, orgID)
+}

--- a/proto.go
+++ b/proto.go
@@ -1,0 +1,25 @@
+package platform
+
+import (
+	"context"
+)
+
+// Proto is templated resource.
+type Proto struct {
+	ID         ID               `json:"id"`
+	Name       string           `json:"name"`
+	Dashboards []ProtoDashboard `json:"dashboards,omitempty"`
+}
+
+// ProtoDashboard is a templated dashboard.
+type ProtoDashboard struct {
+	Dashboard Dashboard   `json:"dashboard"`
+	Views     map[ID]View `json:"views"`
+}
+
+// ProtoService is what dashboard.land will be.
+type ProtoService interface {
+	// TODO(desa): add pagination here eventually.
+	FindProtos(ctx context.Context) ([]*Proto, error)
+	CreateDashboardsFromProto(ctx context.Context, protoID ID, orgID ID) ([]*Dashboard, error)
+}


### PR DESCRIPTION
Closes #1877 

_Briefly describe your proposed changes:_
This PR introduces `protos` (the extension of the idea of protoboards, templated dashboards, from chronograf).

Specifically the following were introduced

* Proto API endpoints
  - `GET  /api/v2/protos`
  - `POST /api/v2/protos/:protoID/dashboards`
* a `protos-path` was added to the `influxd` command
  - it is expected that all required protos should be added to this directory in the structure described below

```json
{
  "id": "0000000000000001",
  "name": "system",
  "dashboards": [
    {
      "dashboard": {
        "name": "hello",
        "description": "oh hello there!",
        "cells": [
          {
            "id": "da7aba5e5d81e550",
            "x": 1,
            "y": 2,
            "w": 3,
            "h": 4
          }
        ]
      },
      "views": {
        "15743100361885476176": {
          "name": "hello",
          "properties": {
            "shape": "chronograf-v2",
            "queries": null,
            "axes": null,
            "type": "xy",
            "legend": {},
            "geom": "",
            "colors": null,
            "note": "",
            "showNoteWhenEmpty": false
          }
        }
      }
    }
  ]
}
```

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
