### PR TITLE
Change typo of procstats to procstat and make exe required

### DIFF
--- a/telegraf.go
+++ b/telegraf.go
@@ -344,7 +344,7 @@ var availableInputPlugins = map[string](func() plugins.Config){
 	"net":          func() plugins.Config { return &inputs.NetIOStats{} },
 	"ngnix":        func() plugins.Config { return &inputs.Nginx{} },
 	"processes":    func() plugins.Config { return &inputs.Processes{} },
-	"procstats":    func() plugins.Config { return &inputs.Procstat{} },
+	"procstat":     func() plugins.Config { return &inputs.Procstat{} },
 	"prometheus":   func() plugins.Config { return &inputs.Prometheus{} },
 	"redis":        func() plugins.Config { return &inputs.Redis{} },
 	"swap":         func() plugins.Config { return &inputs.SwapStats{} },

--- a/ui/src/onboarding/constants/pluginConfigs.ts
+++ b/ui/src/onboarding/constants/pluginConfigs.ts
@@ -170,7 +170,7 @@ export const telegrafPluginsInfo: TelegrafPluginInfo = {
     },
   },
   [TelegrafPluginInputProcstat.NameEnum.Procstat]: {
-    fields: {exe: {type: ConfigFieldType.String, isRequired: false}},
+    fields: {exe: {type: ConfigFieldType.String, isRequired: true}},
     defaults: {
       name: TelegrafPluginInputProcstat.NameEnum.Procstat,
       type: TelegrafPluginInputProcstat.TypeEnum.Input,


### PR DESCRIPTION
In the check for a valid plugin, procstat should be singular.
additionally, exe is required in the front end object.

  - [x] Rebased/mergeable
  - [x] Tests pass
