### PR TITLE
Wire up Storage Engine to API-layer BucketService

### DIFF
--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/influxdata/platform/cmd/influxd/launcher"
-
 	"github.com/influxdata/platform/kit/signals"
 	_ "github.com/influxdata/platform/query/builtin"
 	_ "github.com/influxdata/platform/tsdb/tsi1"

--- a/storage/bucket_service.go
+++ b/storage/bucket_service.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"github.com/influxdata/platform"
+)
+
+// BucketDeleter defines the behaviour of deleting a bucket.
+type BucketDeleter interface {
+	DeleteBucket(platform.ID, platform.ID) error
+}
+
+// BucketService wraps an existing platform.BucketService implementation.
+//
+// BucketService ensures that when a bucket is deleted, all stored data
+// associated with the bucket is either removed, or marked to be removed via a
+// future compaction.
+type BucketService struct {
+	inner  platform.BucketService
+	engine BucketDeleter
+}
+
+// NewBucketService returns a new BucketService for the provided BucketDeleter,
+// which typically will be an Engine.
+func NewBucketService(s platform.BucketService, engine BucketDeleter) *BucketService {
+	return &BucketService{
+		inner:  s,
+		engine: engine,
+	}
+}
+
+// FindBucketByID returns a single bucket by ID.
+func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*platform.Bucket, error) {
+	if s.inner == nil || s.engine == nil {
+		return nil, errors.New("nil inner BucketService or Engine")
+	}
+	return s.inner.FindBucketByID(ctx, id)
+}
+
+// FindBucket returns the first bucket that matches filter.
+func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFilter) (*platform.Bucket, error) {
+	if s.inner == nil || s.engine == nil {
+		return nil, errors.New("nil inner BucketService or Engine")
+	}
+	return s.inner.FindBucket(ctx, filter)
+}
+
+// FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
+// Additional options provide pagination & sorting.
+func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketFilter, opt ...platform.FindOptions) ([]*platform.Bucket, int, error) {
+	if s.inner == nil || s.engine == nil {
+		return nil, 0, errors.New("nil inner BucketService or Engine")
+	}
+	return s.inner.FindBuckets(ctx, filter, opt...)
+}
+
+// CreateBucket creates a new bucket and sets b.ID with the new identifier.
+func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) error {
+	if s.inner == nil || s.engine == nil {
+		return errors.New("nil inner BucketService or Engine")
+	}
+	return s.inner.CreateBucket(ctx, b)
+}
+
+// UpdateBucket updates a single bucket with changeset.
+// Returns the new bucket state after update.
+func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd platform.BucketUpdate) (*platform.Bucket, error) {
+	if s.inner == nil || s.engine == nil {
+		return nil, errors.New("nil inner BucketService or Engine")
+	}
+	return s.inner.UpdateBucket(ctx, id, upd)
+}
+
+// DeleteBucket removes a bucket by ID.
+func (s *BucketService) DeleteBucket(ctx context.Context, bucketID platform.ID) error {
+	bucket, err := s.FindBucketByID(ctx, bucketID)
+	if err != nil {
+		return err
+	}
+
+	// The data is dropped first from the storage engine. If this fails for any
+	// reason, then the bucket will still be available in the future to retrieve
+	// the orgID, which is needed for the engine.
+	if err := s.engine.DeleteBucket(bucket.OrganizationID, bucketID); err != nil {
+		return err
+	}
+	return s.inner.DeleteBucket(ctx, bucketID)
+}

--- a/storage/bucket_service_test.go
+++ b/storage/bucket_service_test.go
@@ -1,0 +1,63 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/platform"
+	"github.com/influxdata/platform/inmem"
+	"github.com/influxdata/platform/storage"
+)
+
+func TestBucketService(t *testing.T) {
+	service := storage.NewBucketService(nil, nil)
+
+	i, err := platform.IDFromString("2222222222222222")
+	if err != nil {
+		panic(err)
+	}
+
+	if err := service.DeleteBucket(context.TODO(), *i); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	inmemService := inmem.NewService()
+	service = storage.NewBucketService(inmemService, nil)
+
+	if err := service.DeleteBucket(context.TODO(), *i); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	org := &platform.Organization{}
+	if err := inmemService.CreateOrganization(context.TODO(), org); err != nil {
+		panic(err)
+	}
+
+	bucket := &platform.Bucket{OrganizationID: org.ID}
+	if err := inmemService.CreateBucket(context.TODO(), bucket); err != nil {
+		panic(err)
+	}
+
+	// Test deleting a bucket calls into the deleter.
+	deleter := &MockDeleter{}
+	service = storage.NewBucketService(inmemService, deleter)
+
+	if err := service.DeleteBucket(context.TODO(), bucket.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if deleter.orgID != org.ID {
+		t.Errorf("got org ID: %s, expected %s", deleter.orgID, org.ID)
+	} else if deleter.bucketID != bucket.ID {
+		t.Errorf("got bucket ID: %s, expected %s", deleter.bucketID, bucket.ID)
+	}
+}
+
+type MockDeleter struct {
+	orgID, bucketID platform.ID
+}
+
+func (m *MockDeleter) DeleteBucket(orgID, bucketID platform.ID) error {
+	m.orgID, m.bucketID = orgID, bucketID
+	return nil
+}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -377,7 +377,9 @@ func (e *Engine) DeleteBucket(orgID, bucketID platform.ID) error {
 	// don't have to remember to get it right everywhere we need to touch TSM data.
 	prefix := tsdb.EncodeName(orgID, bucketID)
 	_ = prefix
-	panic("TODO")
+
+	// TODO(edd): Call into tsm1.Engine to delete bucket
+	return nil
 }
 
 // DeleteSeriesRangeWithPredicate deletes all series data iterated over if fn returns

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxql"
+	"github.com/influxdata/platform"
 	"github.com/influxdata/platform/logger"
 	"github.com/influxdata/platform/models"
 	"github.com/influxdata/platform/tsdb"
@@ -362,6 +363,21 @@ func (e *Engine) WritePoints(points []models.Point) error {
 		return err
 	}
 	return collection.PartialWriteError()
+}
+
+// DeleteBucket deletes an entire bucket from the storage engine.
+func (e *Engine) DeleteBucket(orgID, bucketID platform.ID) error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return ErrEngineClosed
+	}
+
+	// TODO(edd): we need to clean up how we're encoding the prefix so that we
+	// don't have to remember to get it right everywhere we need to touch TSM data.
+	prefix := tsdb.EncodeName(orgID, bucketID)
+	_ = prefix
+	panic("TODO")
 }
 
 // DeleteSeriesRangeWithPredicate deletes all series data iterated over if fn returns

--- a/storage/retention.go
+++ b/storage/retention.go
@@ -192,15 +192,6 @@ func (s *retentionEnforcer) PrometheusCollectors() []prometheus.Collector {
 	return s.metrics.PrometheusCollectors()
 }
 
-// A BucketService is an platform.BucketService that the retentionEnforcer can open,
-// close and log.
-type BucketService interface {
-	platform.BucketService
-	Open() error
-	Close() error
-	WithLogger(l *zap.Logger)
-}
-
 type seriesIteratorAdapter struct {
 	itr  SeriesCursor
 	ea   seriesElemAdapter

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -842,6 +842,7 @@ func KVConcurrentUpdate(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Skip("https://github.com/influxdata/platform/issues/2371")
 			s, closeFn := init(tt.fields, t)
 			defer closeFn()
 


### PR DESCRIPTION
Partially completes #1837.

_Briefly describe your proposed changes:_

This PR connects the API-level bucket service with the storage engine, by wrapping the bucket service implementation with a storage-backed one.

When deleting a bucket via the API, the storage engine will now attempt to delete all the data associated with that bucket.

In order for this to work fully #1836 will need to be completed.

However, it's safe to merge this now, the storage engine portion of deleting a bucket will simply be a no-op for the moment. An new end-to-end test is currently skipped, and this should be unskipped when #1836 lands. /cc @zeebo 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
