### PR TITLE
Add org admin and member specific permissions

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -30,7 +30,7 @@ func (a *Authorization) Allowed(p Permission) bool {
 		return false
 	}
 
-	return allowed(p, a.Permissions)
+	return PermissionAllowed(p, a.Permissions)
 }
 
 // IsActive is a stub for idpe.

--- a/authz.go
+++ b/authz.go
@@ -29,9 +29,25 @@ type Authorizer interface {
 	Kind() string
 }
 
-func allowed(p Permission, ps []Permission) bool {
+// PermissionAllowed
+func PermissionAllowed(p Permission, ps []Permission) bool {
+	pID := ID(0)
+	if p.ID != nil {
+		pID = *p.ID
+		if !pID.Valid() {
+			return false
+		}
+	}
+
 	for _, perm := range ps {
-		if perm.Action == p.Action && perm.Resource == p.Resource {
+		permID := ID(0)
+		if perm.ID != nil {
+			permID = *perm.ID
+			if !permID.Valid() {
+				return false
+			}
+		}
+		if perm.Action == p.Action && perm.Resource == p.Resource && permID == pID {
 			return true
 		}
 	}

--- a/authz.go
+++ b/authz.go
@@ -99,7 +99,17 @@ var AllResources = []Resource{
 	UsersResource,          // 7
 }
 
-// Valid checks if the resource is a member of the Resource enum
+// OrgResources is the list of all known resource types that belong to an organization.
+var OrgResources = []Resource{
+	BucketsResource,    // 1
+	DashboardsResource, // 2
+	SourcesResource,    // 4
+	TasksResource,      // 5
+	TelegrafsResource,  // 6
+	UsersResource,      // 7
+}
+
+// Valid checks if the resource is a member of the Resource enum.
 func (r Resource) Valid() (err error) {
 	switch r {
 	case AuthorizationsResource: // 0
@@ -133,7 +143,7 @@ func (p Permission) String() string {
 	return str
 }
 
-// Valid checks if there the resource and action provided is known
+// Valid checks if there the resource and action provided is known.
 func (p *Permission) Valid() error {
 	if err := p.Resource.Valid(); err != nil {
 		return &Error{
@@ -162,7 +172,7 @@ func (p *Permission) Valid() error {
 	return nil
 }
 
-// NewPermission returns a permission with provided arguments
+// NewPermission returns a permission with provided arguments.
 func NewPermission(a Action, r Resource) (*Permission, error) {
 	p := &Permission{
 		Action:   a,
@@ -172,7 +182,7 @@ func NewPermission(a Action, r Resource) (*Permission, error) {
 	return p, p.Valid()
 }
 
-// NewPermissionAtID creates a permission with the provided arguments
+// NewPermissionAtID creates a permission with the provided arguments.
 func NewPermissionAtID(id ID, a Action, r Resource) (*Permission, error) {
 	p := &Permission{
 		Action:   a,
@@ -183,13 +193,35 @@ func NewPermissionAtID(id ID, a Action, r Resource) (*Permission, error) {
 	return p, p.Valid()
 }
 
-// OperPermissions are the default permissions for those who setup the application
+// OperPermissions are the default permissions for those who setup the application.
 func OperPermissions() []Permission {
 	ps := []Permission{}
 	for _, r := range AllResources {
 		for _, a := range actions {
 			ps = append(ps, Permission{Action: a, Resource: r})
 		}
+	}
+
+	return ps
+}
+
+// OrgAdminPermissions are the default permissions for org admins.
+func OrgAdminPermissions(orgID ID) []Permission {
+	ps := []Permission{}
+	for _, r := range OrgResources {
+		for _, a := range actions {
+			ps = append(ps, Permission{ID: &orgID, Action: a, Resource: r})
+		}
+	}
+
+	return ps
+}
+
+// OrgMemberPermissions are the default permissions for org members.
+func OrgMemberPermissions(orgID ID) []Permission {
+	ps := []Permission{}
+	for _, r := range OrgResources {
+		ps = append(ps, Permission{ID: &orgID, Action: ReadAction, Resource: r})
 	}
 
 	return ps

--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -120,6 +120,15 @@ func (c *Client) Generate(ctx context.Context, req *platform.OnboardingRequest) 
 
 	perms := platform.OperPermissions()
 	perms = append(perms, platform.OrgAdminPermissions(o.ID)...)
+	writeBucketPerm, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResource)
+	if err != nil {
+		return nil, err
+	}
+	readBucketPerm, err := platform.NewPermissionAtID(bucket.ID, platform.ReadAction, platform.BucketsResource)
+	if err != nil {
+		return nil, err
+	}
+	perms = append(perms, *writeBucketPerm, *readBucketPerm)
 
 	auth := &platform.Authorization{
 		UserID:      u.ID,

--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -117,11 +117,15 @@ func (c *Client) Generate(ctx context.Context, req *platform.OnboardingRequest) 
 	if err = c.CreateBucket(ctx, bucket); err != nil {
 		return nil, err
 	}
+
+	perms := platform.OperPermissions()
+	perms = append(perms, platform.OrgAdminPermissions(o.ID)...)
+
 	auth := &platform.Authorization{
 		UserID:      u.ID,
 		Description: fmt.Sprintf("%s's Token", u.Name),
 		OrgID:       o.ID,
-		Permissions: platform.OperPermissions(),
+		Permissions: perms,
 	}
 	if err = c.CreateAuthorization(ctx, auth); err != nil {
 		return nil, err

--- a/bolt/onboarding_test.go
+++ b/bolt/onboarding_test.go
@@ -28,6 +28,6 @@ func initOnboardingService(f platformtesting.OnboardingFields, t *testing.T) (pl
 	}
 }
 
-func TestGenerate(t *testing.T) {
+func TestOnboardingService_Generate(t *testing.T) {
 	platformtesting.Generate(initOnboardingService, t)
 }

--- a/inmem/onboarding.go
+++ b/inmem/onboarding.go
@@ -92,11 +92,24 @@ func (s *Service) Generate(ctx context.Context, req *platform.OnboardingRequest)
 	if err = s.CreateBucket(ctx, bucket); err != nil {
 		return nil, err
 	}
+
+	perms := platform.OperPermissions()
+	perms = append(perms, platform.OrgAdminPermissions(o.ID)...)
+	writeBucketPerm, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResource)
+	if err != nil {
+		return nil, err
+	}
+	readBucketPerm, err := platform.NewPermissionAtID(bucket.ID, platform.ReadAction, platform.BucketsResource)
+	if err != nil {
+		return nil, err
+	}
+	perms = append(perms, *writeBucketPerm, *readBucketPerm)
+
 	auth := &platform.Authorization{
 		UserID:      u.ID,
 		Description: fmt.Sprintf("%s's Token", u.Name),
 		OrgID:       o.ID,
-		Permissions: platform.OperPermissions(),
+		Permissions: perms,
 	}
 	if err = s.CreateAuthorization(ctx, auth); err != nil {
 		return nil, err

--- a/session.go
+++ b/session.go
@@ -48,7 +48,7 @@ func (s *Session) Allowed(p Permission) bool {
 		return false
 	}
 
-	return allowed(p, s.Permissions)
+	return PermissionAllowed(p, s.Permissions)
 }
 
 // Kind returns session and is used for auditing.

--- a/task/validator.go
+++ b/task/validator.go
@@ -37,7 +37,7 @@ func NewValidator(ts platform.TaskService, bs platform.BucketService) platform.T
 }
 
 func (ts *taskServiceValidator) CreateTask(ctx context.Context, t *platform.Task) error {
-	p, err := platform.NewPermissionAtID(t.ID, platform.WriteAction, platform.TasksResource)
+	p, err := platform.NewPermissionAtID(t.Organization, platform.WriteAction, platform.TasksResource)
 	if err != nil {
 		return err
 	}

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -170,7 +170,7 @@ func Generate(
 						UserID:      MustIDBase16(oneID),
 						Description: "admin's Token",
 						OrgID:       MustIDBase16(twoID),
-						Permissions: platform.OperPermissions(),
+						Permissions: mustGeneratePermissions(MustIDBase16(twoID), MustIDBase16(threeID)),
 					},
 				},
 			},
@@ -201,6 +201,22 @@ func Generate(
 		})
 	}
 
+}
+
+func mustGeneratePermissions(orgID, bucketID platform.ID) []platform.Permission {
+	perms := platform.OperPermissions()
+	perms = append(perms, platform.OrgAdminPermissions(orgID)...)
+	writeBucketPerm, err := platform.NewPermissionAtID(bucketID, platform.WriteAction, platform.BucketsResource)
+	if err != nil {
+		panic(err)
+	}
+	readBucketPerm, err := platform.NewPermissionAtID(bucketID, platform.ReadAction, platform.BucketsResource)
+	if err != nil {
+		panic(err)
+	}
+	perms = append(perms, *writeBucketPerm, *readBucketPerm)
+
+	return perms
 }
 
 const (

--- a/user_resource_mapping.go
+++ b/user_resource_mapping.go
@@ -97,6 +97,11 @@ func (m *UserResourceMapping) ownerPerms() ([]Permission, error) {
 		}
 
 		ps = append(ps, *p)
+
+		if m.Resource == OrgsResource {
+			ps = append(ps, OrgAdminPermissions(m.ResourceID)...)
+		}
+
 	}
 
 	return ps, nil
@@ -111,6 +116,10 @@ func (m *UserResourceMapping) memberPerms() ([]Permission, error) {
 		}
 
 		ps = append(ps, *p)
+
+		if m.Resource == OrgsResource {
+			ps = append(ps, OrgMemberPermissions(m.ResourceID)...)
+		}
 	}
 
 	return ps, nil


### PR DESCRIPTION
Closes #2252 

_Briefly describe your proposed changes:_
As https://github.com/influxdata/platform/pull/2157 introduced a new structure for permissions, we now need to grant org level permissions for organization owned resources. Specifically, we introduces permissions for dashboards, tasks, sources, buckets, telegrafs, and users for organizations. The permission for these resources now contains an `ID` that links to the organization.

**Note:** We still need a way to describe the write/read actions for an individual task. This may imply the need to add an `OrganizationID *ID` to the permissions struct.
@mark-rushakoff @lyondhill thoughts on the note above.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
