### PR TITLE
fix(http): remove fmt.Println from scraper service tests

### DIFF
--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -585,8 +585,6 @@ func TestService_handlePatchScraperTarget(t *testing.T) {
 				}
 			}
 
-			fmt.Println(string(st))
-
 			r := httptest.NewRequest("GET", "http://any.tld", bytes.NewReader(st))
 
 			r = r.WithContext(context.WithValue(


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Removes a debug `fmt.Println` that was missed in code review. 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
