### PR TITLE
Hook up DeleteBucket to the tsm1 engine

### DIFF
--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -89,8 +89,6 @@ func TestLauncher_WriteAndQuery(t *testing.T) {
 }
 
 func TestLauncher_BucketDelete(t *testing.T) {
-	t.Skip("Awaiting storage.Engine.DeleteBucket implementation to be completed.")
-
 	l := RunLauncherOrFail(t, ctx)
 	l.SetupOrFail(t)
 	defer l.ShutdownOrFail(t, ctx)

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -375,11 +376,10 @@ func (e *Engine) DeleteBucket(orgID, bucketID platform.ID) error {
 
 	// TODO(edd): we need to clean up how we're encoding the prefix so that we
 	// don't have to remember to get it right everywhere we need to touch TSM data.
-	prefix := tsdb.EncodeName(orgID, bucketID)
-	_ = prefix
+	encoded := tsdb.EncodeName(orgID, bucketID)
+	prefix := models.EscapeMeasurement(encoded[:])
 
-	// TODO(edd): Call into tsm1.Engine to delete bucket
-	return nil
+	return e.engine.DeletePrefix(prefix, math.MinInt64, math.MaxInt64)
 }
 
 // DeleteSeriesRangeWithPredicate deletes all series data iterated over if fn returns


### PR DESCRIPTION
Closes #1837

_Briefly describe your proposed changes:_

Hooks up the engine's DeleteBucket call to delete a prefix out of the tsm1 engine, fixes a couple of bugs found during the integration, and enables the test that it works.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
